### PR TITLE
RenderBucketType use internal map

### DIFF
--- a/trunk/ardor3d-core/src/main/java/com/ardor3d/renderer/queue/RenderBucketType.java
+++ b/trunk/ardor3d-core/src/main/java/com/ardor3d/renderer/queue/RenderBucketType.java
@@ -11,10 +11,11 @@
 package com.ardor3d.renderer.queue;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public final class RenderBucketType {
 
-    public static final RenderBucketType getRenderBucketType(final String name) {
+    public static RenderBucketType getRenderBucketType(final String name) {
         if (name == null) {
             throw new IllegalArgumentException("name must not be null!");
         }
@@ -22,11 +23,12 @@ public final class RenderBucketType {
         RenderBucketType bucketType = bucketTypeMap.get(name);
         if (bucketType == null) {
             bucketType = new RenderBucketType(name);
+			  bucketTypeMap.put(name, bucketType);
         }
         return bucketType;
     }
 
-    private static final HashMap<String, RenderBucketType> bucketTypeMap = new HashMap<String, RenderBucketType>();
+    private static final Map<String, RenderBucketType> bucketTypeMap = new HashMap<String, RenderBucketType>();
 
     private final String name;
 
@@ -41,16 +43,6 @@ public final class RenderBucketType {
     @Override
     public String toString() {
         return name();
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return this == obj;
-    }
-
-    @Override
-    public int hashCode() {
-        return name.hashCode();
     }
 
     /**

--- a/trunk/ardor3d-core/src/test/java/com/ardor3d/renderer/queue/RenderBucketTypeTest.java
+++ b/trunk/ardor3d-core/src/test/java/com/ardor3d/renderer/queue/RenderBucketTypeTest.java
@@ -1,0 +1,38 @@
+package com.ardor3d.renderer.queue;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public class RenderBucketTypeTest {
+
+	@Test
+	public void getPrebucket() throws Exception {
+		RenderBucketType preBucket = RenderBucketType.getRenderBucketType("PreBucket");
+		assertNotNull(preBucket);
+
+		RenderBucketType preBucket2 = RenderBucketType.getRenderBucketType("PreBucket");
+		assertSame(preBucket, preBucket2);
+		assertSame(RenderBucketType.PreBucket, preBucket);
+	}
+
+	@Test
+	public void getUserDefined() throws Exception {
+		RenderBucketType myBucket = RenderBucketType.getRenderBucketType("MyBucket");
+		assertNotNull(myBucket);
+
+		RenderBucketType myBucket2 = RenderBucketType.getRenderBucketType("MyBucket");
+		assertSame(myBucket, myBucket2);
+	}
+
+	@Test
+	public void getWithNull() throws Exception {
+		try {
+			RenderBucketType nullBucket = RenderBucketType.getRenderBucketType(null);
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+	}
+}


### PR DESCRIPTION
The map inside RenderBucketType is never updated, only queried.
