### PR TITLE
Adds  AnimationClipInstance parameter to AnimationListener, to know what clipInstance finished

### DIFF
--- a/trunk/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/AnimationListener.java
+++ b/trunk/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/AnimationListener.java
@@ -10,6 +10,8 @@
 
 package com.ardor3d.extension.animation.skeletal;
 
+import com.ardor3d.extension.animation.skeletal.clip.AnimationClipInstance;
+
 /**
  * Describes a class interested in receiving notice when an animation has changed state.
  */
@@ -17,7 +19,10 @@ public interface AnimationListener {
 
     /**
      * Called when an animation reaches the end of its complete play time (maxTime * loops)
+     * 
+     * @param source
+     *            The animation clip instance that finished.
      */
-    void animationFinished();
+    void animationFinished(AnimationClipInstance source);
 
 }

--- a/trunk/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/AnimationManager.java
+++ b/trunk/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/AnimationManager.java
@@ -590,4 +590,11 @@ public class AnimationManager {
     public LoggingMap<String, Double> getValuesStore() {
         return _valuesStore;
     }
+
+    /**
+     * @return the Map containing the AnimationClips and their respective AnimationClipInstances.
+     */
+    public Map<AnimationClip, AnimationClipInstance> getClipInstancesStore() {
+        return _clipInstances;
+    }
 }

--- a/trunk/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/AnimationClipInstance.java
+++ b/trunk/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/AnimationClipInstance.java
@@ -141,7 +141,7 @@ public class AnimationClipInstance {
         }
 
         for (final AnimationListener animationListener : animationListeners) {
-            animationListener.animationFinished();
+            animationListener.animationFinished(this);
         }
     }
 }

--- a/trunk/ardor3d-examples/src/main/java/com/ardor3d/example/pipeline/AnimationCopyExample.java
+++ b/trunk/ardor3d-examples/src/main/java/com/ardor3d/example/pipeline/AnimationCopyExample.java
@@ -25,6 +25,7 @@ import com.ardor3d.extension.animation.skeletal.SkinnedMeshCombineLogic;
 import com.ardor3d.extension.animation.skeletal.blendtree.ManagedTransformSource;
 import com.ardor3d.extension.animation.skeletal.blendtree.SimpleAnimationApplier;
 import com.ardor3d.extension.animation.skeletal.clip.AnimationClip;
+import com.ardor3d.extension.animation.skeletal.clip.AnimationClipInstance;
 import com.ardor3d.extension.animation.skeletal.state.loader.InputStore;
 import com.ardor3d.extension.animation.skeletal.state.loader.JSLayerImporter;
 import com.ardor3d.extension.animation.skeletal.util.MissingCallback;
@@ -424,7 +425,7 @@ public class AnimationCopyExample extends ExampleBase {
 
         // add callback for our UI
         manager.findClipInstance("skeleton.punch").addAnimationListener(new AnimationListener() {
-            public void animationFinished() {
+            public void animationFinished(final AnimationClipInstance source) {
                 punchButton.setEnabled(true);
             }
         });

--- a/trunk/ardor3d-examples/src/main/java/com/ardor3d/example/pipeline/AnimationStateExample.java
+++ b/trunk/ardor3d-examples/src/main/java/com/ardor3d/example/pipeline/AnimationStateExample.java
@@ -25,6 +25,7 @@ import com.ardor3d.extension.animation.skeletal.SkinnedMesh;
 import com.ardor3d.extension.animation.skeletal.SkinnedMeshCombineLogic;
 import com.ardor3d.extension.animation.skeletal.blendtree.SimpleAnimationApplier;
 import com.ardor3d.extension.animation.skeletal.clip.AnimationClip;
+import com.ardor3d.extension.animation.skeletal.clip.AnimationClipInstance;
 import com.ardor3d.extension.animation.skeletal.state.loader.InputStore;
 import com.ardor3d.extension.animation.skeletal.state.loader.JSLayerImporter;
 import com.ardor3d.extension.animation.skeletal.util.MissingCallback;
@@ -421,7 +422,7 @@ public class AnimationStateExample extends ExampleBase {
 
         // add callback for our UI
         manager.findClipInstance("skeleton.punch").addAnimationListener(new AnimationListener() {
-            public void animationFinished() {
+            public void animationFinished(final AnimationClipInstance source) {
                 punchButton.setEnabled(true);
             }
         });


### PR DESCRIPTION
While it seems that on your design you wanted to keep access to _clipInstances just in the AnimationManager. There seems to be no way to know when all animationClipInstances have been completed.
(This is particularly useful because of the AnimationUpdateStates (to update UI or whatever).

So i decided that adding an AnimationClipInstance as parameter in the AnimationListener Interface would allow to who wants to create a Common AnimationListener to all AnimationClips (to know when there is no more animation to be done).

I updated the the examples affected accordingly.

If you have though about this already and you have seen a better way cancel the pull request and let me know, so I can update my code accordingly.
