### PR TITLE
Allow to specify display to render on for JoglNewtWindow

### DIFF
--- a/ardor3d-jogl/src/main/java/com/ardor3d/framework/jogl/JoglNewtWindow.java
+++ b/ardor3d-jogl/src/main/java/com/ardor3d/framework/jogl/JoglNewtWindow.java
@@ -22,6 +22,8 @@ import com.ardor3d.annotation.MainThread;
 import com.ardor3d.framework.DisplaySettings;
 import com.ardor3d.framework.NativeCanvas;
 import com.ardor3d.image.Image;
+import com.jogamp.newt.Display;
+import com.jogamp.newt.NewtFactory;
 import com.jogamp.newt.Screen;
 import com.jogamp.newt.ScreenMode;
 import com.jogamp.newt.event.KeyListener;
@@ -51,8 +53,18 @@ public class JoglNewtWindow implements NativeCanvas, NewtWindowContainer {
     public JoglNewtWindow(final JoglCanvasRenderer canvasRenderer, final DisplaySettings settings,
             final boolean onscreen, final boolean bitmapRequested, final boolean pbufferRequested,
             final boolean fboRequested) {
-        _newtWindow = GLWindow.create(CapsUtil.getCapsForSettings(settings, onscreen, bitmapRequested,
-                pbufferRequested, fboRequested));
+        this(canvasRenderer, settings, onscreen, bitmapRequested, pbufferRequested, fboRequested, null);
+    }
+
+    public JoglNewtWindow(final JoglCanvasRenderer canvasRenderer, final DisplaySettings settings,
+            final boolean onscreen, final boolean bitmapRequested, final boolean pbufferRequested,
+            final boolean fboRequested, final String displayConnection) {
+
+        final Display display = NewtFactory.createDisplay(displayConnection);
+        final Screen screen = NewtFactory.createScreen(display, 0);
+
+        _newtWindow = GLWindow.create(screen,
+                CapsUtil.getCapsForSettings(settings, onscreen, bitmapRequested, pbufferRequested, fboRequested));
         _drawerGLRunnable = new JoglDrawerRunnable(canvasRenderer);
         _settings = settings;
         _canvasRenderer = canvasRenderer;


### PR DESCRIPTION
See the [forum post](http://ardor3d.com/forums/viewtopic.php?f=11&t=274&p=25178#p25176).

This change is fully backwards-compatible. When the connection is not specified (using the existing constructors or passing `null` to the new one) the behavior is exactly the same as before.

Although the code should be fine, I had trouble to use it when a connection string was specified, (e.g. `:99.0`) but I'm quite sure that this is actually a bug in jogl itself:

```
javax.media.opengl.GLException: X11GLXDrawableFactory - Could not initialize shared resources for :99.0
    at jogamp.opengl.x11.glx.X11GLXDrawableFactory$SharedResourceImplementation.createSharedResource(X11GLXDrawableFactory.java:299)
    at jogamp.opengl.SharedResourceRunner.run(SharedResourceRunner.java:269)
    at java.lang.Thread.run(Thread.java:662)
Caused by: java.lang.IllegalArgumentException: Passed thread is original owner: Thread[Thread-1-SharedResourceRunner,5,main]
    at jogamp.common.util.locks.RecursiveThreadGroupLockImpl01Unfairish.addOwner(RecursiveThreadGroupLockImpl01Unfairish.java:163)
    at javax.media.opengl.GLProfile.initProfilesForDeviceCritical(GLProfile.java:1593)
    at javax.media.opengl.GLProfile.initProfilesForDevice(GLProfile.java:1556)
    at javax.media.opengl.GLProfile.getProfileMap(GLProfile.java:1907)
    at javax.media.opengl.GLProfile.get(GLProfile.java:836)
    at jogamp.opengl.x11.glx.X11GLXDrawableFactory$SharedResourceImplementation.createSharedResource(X11GLXDrawableFactory.java:260)
    ... 2 more
```

I'm sure that it's a jogl bug because it works if I specify the environment variable `DISPLAY=:99.0` and set `null` as connection string in jogl.

@gouessej If you agree that the code is ok, I would like to merge it anyway to have something to play with.
