### PR TITLE
POM changes for 0.9 release

### DIFF
--- a/ardor3d-animation/pom.xml
+++ b/ardor3d-animation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-awt/pom.xml
+++ b/ardor3d-awt/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-collada/pom.xml
+++ b/ardor3d-collada/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-core/pom.xml
+++ b/ardor3d-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-distribution/pom.xml
+++ b/ardor3d-distribution/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-effects/pom.xml
+++ b/ardor3d-effects/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-examples/pom.xml
+++ b/ardor3d-examples/pom.xml
@@ -4,7 +4,7 @@
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ardor3d-examples</artifactId>

--- a/ardor3d-extras/pom.xml
+++ b/ardor3d-extras/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-jogl/pom.xml
+++ b/ardor3d-jogl/pom.xml
@@ -4,7 +4,7 @@
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ardor3d-jogl</artifactId>

--- a/ardor3d-lwjgl/pom.xml
+++ b/ardor3d-lwjgl/pom.xml
@@ -4,7 +4,7 @@
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ardor3d-lwjgl</artifactId>

--- a/ardor3d-math/pom.xml
+++ b/ardor3d-math/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-savable/pom.xml
+++ b/ardor3d-savable/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-swt/pom.xml
+++ b/ardor3d-swt/pom.xml
@@ -5,7 +5,7 @@
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ardor3d-swt</artifactId>

--- a/ardor3d-terrain/pom.xml
+++ b/ardor3d-terrain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ardor3d-ui/pom.xml
+++ b/ardor3d-ui/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ardor3d</groupId>
         <artifactId>ardor3d</artifactId>
-        <version>0.9</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.ardor3d</groupId>
     <artifactId>ardor3d</artifactId>
     <packaging>pom</packaging>
-    <version>0.9</version>
+    <version>1.0-SNAPSHOT</version>
     
     <name>Ardor 3D</name>
     <description>A free, open source 3D graphics engine written in Java</description>
@@ -22,8 +22,7 @@
         <connection>scm:git:git://github.com/Renanse/Ardor3D.git</connection>
         <developerConnection>scm:git:git@github.com:Renanse/Ardor3D.git</developerConnection>
         <url>https://github.com/Renanse/Ardor3D</url>
-      <tag>v0.9</tag>
-  </scm>
+    </scm>
     
     <developers>
         <developer>


### PR DESCRIPTION
This contains the changes and the version bumps related to the first Maven Central (Sonatype) release 0.9.

Some notable changes:
- The building of the zip assemblies now only happens when the "hudson" profile is used.
- The default Maven repositories are now the Sonatype ones which are then overriden in the "hudson" profile to the ones of ardor3d.

As it's impossible to put git tags into a pull request, please create the `v0.9` tag for the commit 27979b9. (You can use GitHub's new "releases" functionality for that)
