### PR TITLE
Skip pom deployment for distribution module by default

### DIFF
--- a/ardor3d-distribution/pom.xml
+++ b/ardor3d-distribution/pom.xml
@@ -21,6 +21,18 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>
@@ -61,6 +73,14 @@
 			                </executions>
 			            </plugin>
 			      
+			            <plugin>
+			                <groupId>org.apache.maven.plugins</groupId>
+			                <artifactId>maven-deploy-plugin</artifactId>
+			                <configuration>
+			                    <skip>false</skip>
+			                </configuration>
+			            </plugin>
+			            
 			            <plugin>
 			                <groupId>org.apache.maven.plugins</groupId>
 			                <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
Just a missing bit from my last pull request... now the sonatype deployment completely skips the distribution module (before that it skipped the assemblies but still deployed the pom file of that module)
