### PR TITLE
Fix problem with billboard stretching when rotating around z axis

### DIFF
--- a/ardor3d-core/src/main/java/com/ardor3d/scenegraph/extension/BillboardNode.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/scenegraph/extension/BillboardNode.java
@@ -220,13 +220,14 @@ public class BillboardNode extends Node {
             _left.setX(_left.getX() * invLength);
             _left.setY(_left.getY() * invLength);
             _left.setZ(0.0);
+            _left.normalizeLocal();
 
             // compute the local orientation matrix for the billboard
             _orient.setValue(0, 0, _left.getY());
             _orient.setValue(0, 1, _left.getX());
             _orient.setValue(0, 2, 0);
-            _orient.setValue(1, 0, -_left.getY());
-            _orient.setValue(1, 1, _left.getX());
+            _orient.setValue(1, 0, -_left.getX());
+            _orient.setValue(1, 1, _left.getY());
             _orient.setValue(1, 2, 0);
             _orient.setValue(2, 0, 0);
             _orient.setValue(2, 1, 0);


### PR DESCRIPTION
I originally submitted this fix in Ardor3D forum (before it was taken down) over a year ago. I was promised that it would be tested and added to Ardor3D but I noticed that it is still not added. I figured I make the job easier by pull requesting this time. It's a simple but crucial fix.