### PR TITLE
Added check for empty child list

### DIFF
--- a/ardor3d-core/src/main/java/com/ardor3d/scenegraph/Node.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/scenegraph/Node.java
@@ -261,6 +261,9 @@ public class Node extends Spatial {
    * @return the child at a specified index.
    */
   public Spatial getChild(final int i) {
+    if(_children.isEmpty()) {
+      return null;
+    }
     return _children.get(i);
   }
 


### PR DESCRIPTION
Endurance testing of VERVE (i.e., leaving it running overnight) uncovered a strange problem in which index-out-of-bounds errors were being thrown in the Node.getChild(int) method that caused Ardor and VERVE to crash. Somehow child lists that shouldn't be empty had become empty, so no matter what the integer argument was, an error would be thrown. The proposed change simply checks if the list is empty and if so, the return value will be null. There haven't been any crashes since making this change.