### PR TITLE
Add HiDPI scaling support for AWT-embedded canvases

### DIFF
--- a/ardor3d-awt/src/main/java/com/ardor3d/framework/awt/AwtDpiScaler.java
+++ b/ardor3d-awt/src/main/java/com/ardor3d/framework/awt/AwtDpiScaler.java
@@ -78,7 +78,12 @@ public enum AwtDpiScaler {
       return 1.0;
     }
     // Use X scale - typically X and Y scale are the same
-    return transform.getScaleX();
+    final double scale = transform.getScaleX();
+    // Guard against degenerate values
+    if (!Double.isFinite(scale) || scale <= 0) {
+      return 1.0;
+    }
+    return scale;
   }
 
   public int scaleToScreenDpiInt(final Component component, final double size) {

--- a/ardor3d-awt/src/main/java/com/ardor3d/framework/awt/AwtDpiScaler.java
+++ b/ardor3d-awt/src/main/java/com/ardor3d/framework/awt/AwtDpiScaler.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.framework.awt;
+
+import java.awt.Component;
+import java.awt.GraphicsConfiguration;
+import java.awt.geom.AffineTransform;
+
+/**
+ * Utility for handling DPI scaling in AWT-based canvases.
+ * Uses the component's GraphicsConfiguration to determine the display scale factor.
+ */
+public enum AwtDpiScaler {
+
+  INSTANCE;
+
+  /**
+   * Scale a size value from logical pixels to physical screen pixels based on the
+   * component's display DPI.
+   *
+   * @param component
+   *          the component to get the scale factor from
+   * @param size
+   *          the logical pixel size
+   * @return the scaled physical pixel size
+   */
+  public double scaleToScreenDpi(final Component component, final double size) {
+    if (!ApplyScale) {
+      return size;
+    }
+    final double scale = getScaleFactor(component);
+    return size * scale;
+  }
+
+  /**
+   * Scale a size value from physical screen pixels to logical pixels based on the
+   * component's display DPI.
+   *
+   * @param component
+   *          the component to get the scale factor from
+   * @param size
+   *          the physical pixel size
+   * @return the unscaled logical pixel size
+   */
+  public double scaleFromScreenDpi(final Component component, final double size) {
+    if (!ApplyScale) {
+      return size;
+    }
+    final double scale = getScaleFactor(component);
+    return size / scale;
+  }
+
+  /**
+   * Get the display scale factor for a component.
+   *
+   * @param component
+   *          the component to query
+   * @return the scale factor (1.0 for standard DPI, 2.0 for 200% scaling, etc.)
+   */
+  public double getScaleFactor(final Component component) {
+    if (component == null) {
+      return 1.0;
+    }
+    final GraphicsConfiguration gc = component.getGraphicsConfiguration();
+    if (gc == null) {
+      return 1.0;
+    }
+    final AffineTransform transform = gc.getDefaultTransform();
+    if (transform == null) {
+      return 1.0;
+    }
+    // Use X scale - typically X and Y scale are the same
+    return transform.getScaleX();
+  }
+
+  public int scaleToScreenDpiInt(final Component component, final double size) {
+    return (int) Math.round(scaleToScreenDpi(component, size));
+  }
+
+  public int scaleFromScreenDpiInt(final Component component, final double size) {
+    return (int) Math.round(scaleFromScreenDpi(component, size));
+  }
+
+  /**
+   * Whether to apply DPI scaling. Defaults to true, but disabled on macOS
+   * where AWT typically handles scaling automatically.
+   */
+  public static boolean ApplyScale = true;
+
+  static {
+    final String os = System.getProperty("os.name").toLowerCase();
+    if (os.startsWith("mac os x")) {
+      ApplyScale = false;
+    }
+  }
+}

--- a/ardor3d-lwjgl3-awt/src/main/java/com/ardor3d/framework/lwjgl3/awt/Lwjgl3AwtCanvas.java
+++ b/ardor3d-lwjgl3-awt/src/main/java/com/ardor3d/framework/lwjgl3/awt/Lwjgl3AwtCanvas.java
@@ -26,6 +26,7 @@ import com.ardor3d.framework.Canvas;
 import com.ardor3d.framework.CanvasRenderer;
 import com.ardor3d.framework.DisplaySettings;
 import com.ardor3d.framework.ICanvasListener;
+import com.ardor3d.framework.awt.AwtDpiScaler;
 import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer;
 import com.ardor3d.input.mouse.MouseManager;
 
@@ -151,4 +152,14 @@ public class Lwjgl3AwtCanvas extends AWTGLCanvas implements Canvas {
   }
 
   public boolean isInited() { return _inited; }
+
+  @Override
+  public double scaleToScreenDpi(final double size) {
+    return AwtDpiScaler.INSTANCE.scaleToScreenDpi(this, size);
+  }
+
+  @Override
+  public double scaleFromScreenDpi(final double size) {
+    return AwtDpiScaler.INSTANCE.scaleFromScreenDpi(this, size);
+  }
 }

--- a/ardor3d-swt/src/main/java/com/ardor3d/framework/swt/SwtDpiScaler.java
+++ b/ardor3d-swt/src/main/java/com/ardor3d/framework/swt/SwtDpiScaler.java
@@ -18,12 +18,22 @@ public enum SwtDpiScaler implements IDpiScaleProvider {
 
   @Override
   public double scaleToScreenDpi(final double size) {
-    return ApplyScale ? org.eclipse.swt.internal.DPIUtil.autoScaleUp((int) Math.round(size)) : size;
+    if (!ApplyScale) {
+      return size;
+    }
+    final double scaled = org.eclipse.swt.internal.DPIUtil.autoScaleUp((int) Math.round(size));
+    // Guard against degenerate values
+    return Double.isFinite(scaled) ? scaled : size;
   }
 
   @Override
   public double scaleFromScreenDpi(final double size) {
-    return ApplyScale ? org.eclipse.swt.internal.DPIUtil.autoScaleDown((int) Math.round(size)) : size;
+    if (!ApplyScale) {
+      return size;
+    }
+    final double scaled = org.eclipse.swt.internal.DPIUtil.autoScaleDown((int) Math.round(size));
+    // Guard against degenerate values
+    return Double.isFinite(scaled) ? scaled : size;
   }
 
   public int scaleToScreenDpiInt(final double size) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DPI scaling across AWT and LWJGL3 AWT canvases so UI and content scale correctly on high‑DPI displays.
  * Exposed conversions between logical and physical pixels (including integer-rounded variants) for consistent sizing.

* **Bug Fixes / Reliability**
  * Safer scaling with fallbacks for missing display info and non‑finite results.
  * Automatic disabling of scaling on macOS to avoid platform issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->