### PR TITLE
Fix ten latent correctness findings

### DIFF
--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/GuaranteedTriggerChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/GuaranteedTriggerChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -72,7 +72,7 @@ public class GuaranteedTriggerChannel extends TriggerChannel {
     final float[] times = new float[samples];
     final String[] keys = new String[samples];
 
-    for (int i = 0; i <= samples; i++) {
+    for (int i = 0; i < samples; i++) {
       times[i] = _times[i + startSample];
       keys[i] = _keys[i + startSample];
     }

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/InterpolatedDoubleChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/InterpolatedDoubleChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -76,7 +76,7 @@ public class InterpolatedDoubleChannel extends AbstractAnimationChannel {
     final float[] times = new float[samples];
     final double[] values = new double[samples];
 
-    for (int i = 0; i <= samples; i++) {
+    for (int i = 0; i < samples; i++) {
       times[i] = _times[i + startSample];
       values[i] = _values[i + startSample];
     }

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/InterpolatedFloatChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/InterpolatedFloatChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -75,7 +75,7 @@ public class InterpolatedFloatChannel extends AbstractAnimationChannel {
     final float[] times = new float[samples];
     final float[] values = new float[samples];
 
-    for (int i = 0; i <= samples; i++) {
+    for (int i = 0; i < samples; i++) {
       times[i] = _times[i + startSample];
       values[i] = _values[i + startSample];
     }

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/TransformData.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/TransformData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -180,6 +180,6 @@ public class TransformData implements Savable {
   public void read(final InputCapsule capsule) throws IOException {
     setRotation(capsule.readSavable("rotation", (Quaternion) Quaternion.IDENTITY));
     setScale(capsule.readSavable("scale", (Vector3) Vector3.ONE));
-    setTranslation(capsule.readSavable("rotation", (Vector3) Vector3.ZERO));
+    setTranslation(capsule.readSavable("translation", (Vector3) Vector3.ZERO));
   }
 }

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/TriggerChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/TriggerChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -79,7 +79,7 @@ public class TriggerChannel extends AbstractAnimationChannel {
     final float[] times = new float[samples];
     final String[] keys = new String[samples];
 
-    for (int i = 0; i <= samples; i++) {
+    for (int i = 0; i < samples; i++) {
       times[i] = _times[i + startSample];
       keys[i] = _keys[i + startSample];
     }

--- a/ardor3d-animation/src/test/java/com/ardor3d/extension/animation/skeletal/clip/TestAnimationChannelSubchannel.java
+++ b/ardor3d-animation/src/test/java/com/ardor3d/extension/animation/skeletal/clip/TestAnimationChannelSubchannel.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.animation.skeletal.clip;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Exercises {@link AbstractAnimationChannel#getSubchannelBySample} for each concrete channel type.
+ * The sub-channel of samples [1,3] of a five-sample channel must contain exactly the three middle
+ * samples; an off-by-one in the copy loop throws ArrayIndexOutOfBoundsException instead.
+ */
+public class TestAnimationChannelSubchannel {
+
+  private static final float[] TIMES = {0f, 1f, 2f, 3f, 4f};
+  private static final float[] EXPECTED_TIMES = {1f, 2f, 3f};
+
+  @Test
+  public void testTriggerChannelSubchannel() {
+    final String[] keys = {"a", "b", "c", "d", "e"};
+    final TriggerChannel sub =
+        (TriggerChannel) new TriggerChannel("c", TIMES, keys).getSubchannelBySample("sub", 1, 3);
+
+    assertEquals(3, sub.getSampleCount());
+    assertArrayEquals(EXPECTED_TIMES, sub.getTimes(), 0f);
+    assertArrayEquals(new String[] {"b", "c", "d"}, sub.getKeys());
+  }
+
+  @Test
+  public void testGuaranteedTriggerChannelSubchannel() {
+    final String[] keys = {"a", "b", "c", "d", "e"};
+    final GuaranteedTriggerChannel sub = (GuaranteedTriggerChannel) new GuaranteedTriggerChannel("c", TIMES, keys)
+        .getSubchannelBySample("sub", 1, 3);
+
+    assertEquals(3, sub.getSampleCount());
+    assertArrayEquals(EXPECTED_TIMES, sub.getTimes(), 0f);
+    assertArrayEquals(new String[] {"b", "c", "d"}, sub.getKeys());
+  }
+
+  @Test
+  public void testInterpolatedFloatChannelSubchannel() {
+    final float[] values = {10f, 11f, 12f, 13f, 14f};
+    final InterpolatedFloatChannel sub =
+        new InterpolatedFloatChannel("c", TIMES, values).getSubchannelBySample("sub", 1, 3);
+
+    assertEquals(3, sub.getSampleCount());
+    assertArrayEquals(EXPECTED_TIMES, sub.getTimes(), 0f);
+    assertArrayEquals(new float[] {11f, 12f, 13f}, sub.getValues(), 0f);
+  }
+
+  @Test
+  public void testInterpolatedDoubleChannelSubchannel() {
+    final double[] values = {10d, 11d, 12d, 13d, 14d};
+    final InterpolatedDoubleChannel sub =
+        new InterpolatedDoubleChannel("c", TIMES, values).getSubchannelBySample("sub", 1, 3);
+
+    assertEquals(3, sub.getSampleCount());
+    assertArrayEquals(EXPECTED_TIMES, sub.getTimes(), 0f);
+    assertArrayEquals(new double[] {11d, 12d, 13d}, sub.getValues(), 0d);
+  }
+}

--- a/ardor3d-animation/src/test/java/com/ardor3d/extension/animation/skeletal/clip/TestTransformData.java
+++ b/ardor3d-animation/src/test/java/com/ardor3d/extension/animation/skeletal/clip/TestTransformData.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.animation.skeletal.clip;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Test;
+
+import com.ardor3d.math.Quaternion;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.util.export.binary.BinaryExporter;
+import com.ardor3d.util.export.binary.BinaryImporter;
+
+public class TestTransformData {
+
+  /**
+   * Round-trips a TransformData through the binary Savable format. Translation, rotation and scale
+   * are all distinct and non-default so a mixed-up capsule key cannot be masked by coincidental
+   * equality with another field or with a default value.
+   */
+  @Test
+  public void testBinaryRoundTrip() throws Exception {
+    final TransformData source = new TransformData();
+    source.setTranslation(new Vector3(1, 2, 3));
+    source.setScale(new Vector3(4, 5, 6));
+    source.setRotation(new Quaternion(0.5, 0.5, 0.5, 0.5)); // already unit-length
+
+    final TransformData restored = (TransformData) roundTrip(source);
+
+    assertEquals("translation must survive serialization", new Vector3(1, 2, 3), restored.getTranslation());
+    assertEquals("rotation must survive serialization", new Quaternion(0.5, 0.5, 0.5, 0.5), restored.getRotation());
+    assertEquals("scale must survive serialization", new Vector3(4, 5, 6), restored.getScale());
+  }
+
+  /**
+   * JointData extends TransformData and delegates to super.read()/super.write(), so it must
+   * round-trip the inherited transform fields as well as its own joint index.
+   */
+  @Test
+  public void testJointDataBinaryRoundTrip() throws Exception {
+    final JointData source = new JointData(7);
+    source.setTranslation(new Vector3(1, 2, 3));
+    source.setScale(new Vector3(4, 5, 6));
+    source.setRotation(new Quaternion(0.5, 0.5, 0.5, 0.5));
+
+    final JointData restored = (JointData) roundTrip(source);
+
+    assertEquals("joint index must survive serialization", 7, restored.getJointIndex());
+    assertEquals("translation must survive serialization", new Vector3(1, 2, 3), restored.getTranslation());
+    assertEquals("rotation must survive serialization", new Quaternion(0.5, 0.5, 0.5, 0.5), restored.getRotation());
+    assertEquals("scale must survive serialization", new Vector3(4, 5, 6), restored.getScale());
+  }
+
+  private static TransformData roundTrip(final TransformData source) throws Exception {
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    new BinaryExporter().save(source, bytes);
+    return (TransformData) new BinaryImporter().load(new ByteArrayInputStream(bytes.toByteArray()));
+  }
+}

--- a/ardor3d-core/src/main/java/com/ardor3d/bounding/CollisionTree.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/bounding/CollisionTree.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -230,7 +230,7 @@ public class CollisionTree implements Serializable {
     // check to see if we are a leaf, if the number of primitives we reference is less than or equal to
     // the maximum
     // defined by the CollisionTreeManager we are done.
-    if (_end - _start + 1 <= CollisionTreeManager.getInstance().getMaxPrimitivesPerLeaf()) {
+    if (_end - _start <= CollisionTreeManager.getInstance().getMaxPrimitivesPerLeaf()) {
       return;
     }
 

--- a/ardor3d-core/src/main/java/com/ardor3d/buffer/BufferUtils.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/buffer/BufferUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -77,7 +77,7 @@ public final class BufferUtils {
       return null;
     }
     final FloatBuffer buff = createFloatBuffer(4 * length);
-    for (int x = offset; x < length; x++) {
+    for (int x = offset; x < offset + length; x++) {
       if (data[x] != null) {
         buff.put(data[x].getRed()).put(data[x].getGreen()).put(data[x].getBlue()).put(data[x].getAlpha());
       } else {
@@ -252,11 +252,11 @@ public final class BufferUtils {
       return null;
     }
     final FloatBuffer buff = createFloatBuffer(4 * length);
-    for (int x = offset; x < length; x++) {
+    for (int x = offset; x < offset + length; x++) {
       if (data[x] != null) {
         buff.put(data[x].getXf()).put(data[x].getYf()).put(data[x].getZf()).put(data[x].getWf());
       } else {
-        buff.put(0).put(0).put(0);
+        buff.put(0).put(0).put(0).put(0);
       }
     }
     buff.flip();
@@ -513,7 +513,7 @@ public final class BufferUtils {
       return null;
     }
     final FloatBuffer buff = createFloatBuffer(3 * length);
-    for (int x = offset; x < length; x++) {
+    for (int x = offset; x < offset + length; x++) {
       if (data[x] != null) {
         buff.put(data[x].getXf()).put(data[x].getYf()).put(data[x].getZf());
       } else {
@@ -766,7 +766,7 @@ public final class BufferUtils {
       return null;
     }
     final FloatBuffer buff = createFloatBuffer(2 * length);
-    for (int x = offset; x < length; x++) {
+    for (int x = offset; x < offset + length; x++) {
       if (data[x] != null) {
         buff.put(data[x].getXf()).put(data[x].getYf());
       } else {

--- a/ardor3d-core/src/main/java/com/ardor3d/intersection/PickResults.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/intersection/PickResults.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -131,11 +131,10 @@ public abstract class PickResults {
 
     @Override
     public int compare(final PickData o1, final PickData o2) {
-      if (o1.getIntersectionRecord().getClosestDistance() <= o2.getIntersectionRecord().getClosestDistance()) {
-        return -1;
-      }
-
-      return 1;
+      // Ascending by closest distance. Must be a true total order (equal distances -> 0), otherwise
+      // sorting throws "Comparison method violates its general contract!".
+      return Double.compare(o1.getIntersectionRecord().getClosestDistance(),
+          o2.getIntersectionRecord().getClosestDistance());
     }
   }
 

--- a/ardor3d-core/src/main/java/com/ardor3d/light/LightManager.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/light/LightManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -159,13 +159,9 @@ public class LightManager implements IUniformSupplier {
     public int compare(final WeakReference<Light> l1, final WeakReference<Light> l2) {
       final double v1 = getValueFor(l1, _bv);
       final double v2 = getValueFor(l2, _bv);
-      final double cmp = v1 - v2;
-      if (0 > cmp) {
-        return 1;
-      } else if (0 < cmp) {
-        return -1;
-      }
-      return 0;
+      // Descending by value. Double.compare gives a total order even for the -Infinity values
+      // getValueFor returns for disabled/collected lights, where v1 - v2 could yield NaN.
+      return Double.compare(v2, v1);
     }
   }
 

--- a/ardor3d-core/src/main/java/com/ardor3d/scenegraph/Mesh.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/scenegraph/Mesh.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -586,7 +586,7 @@ public class Mesh extends Spatial implements Renderable, Pickable {
     // must be non-null
     final FloatBufferData verts = meshData.getVertexCoords().makeCopy();
 
-    final FloatBufferData norms = meshData.getNormalBuffer() != null ? meshData.getVertexCoords().makeCopy() : null;
+    final FloatBufferData norms = meshData.getNormalBuffer() != null ? meshData.getNormalCoords().makeCopy() : null;
     final FloatBufferData colors = meshData.getColorBuffer() != null ? meshData.getColorCoords().makeCopy() : null;
     final FloatBufferData tangents =
         meshData.getTangentBuffer() != null ? meshData.getTangentCoords().makeCopy() : null;

--- a/ardor3d-core/src/main/java/com/ardor3d/scenegraph/Spatial.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/scenegraph/Spatial.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -1158,7 +1158,7 @@ public abstract class Spatial implements Savable, Hintable {
     }
 
     if (mode == PropertyMode.UseOursLast) {
-      if (parent.hasProperty(key)) {
+      if (parent != null && parent.hasProperty(key)) {
         return parent.getProperty(key, defaultValue);
       }
 

--- a/ardor3d-core/src/main/java/com/ardor3d/util/GameTask.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/util/GameTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,6 +11,7 @@
 package com.ardor3d.util;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -81,14 +82,18 @@ public class GameTask<V> implements Future<V> {
       throws InterruptedException, ExecutionException, TimeoutException {
     _stateLock.lock();
     try {
+      long remainingNanos = unit.toNanos(timeout);
+      while (!isDone() && remainingNanos > 0) {
+        remainingNanos = _finishedCondition.awaitNanos(remainingNanos);
+      }
       if (!isDone()) {
-        _finishedCondition.await(timeout, unit);
+        throw new TimeoutException("Object not returned in time allocated.");
       }
       if (_exception != null) {
         throw _exception;
       }
-      if (_result == null) {
-        throw new TimeoutException("Object not returned in time allocated.");
+      if (_cancelled) {
+        throw new CancellationException();
       }
       return _result;
     } finally {

--- a/ardor3d-core/src/main/java/com/ardor3d/util/GameTask.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/util/GameTask.java
@@ -68,11 +68,11 @@ public class GameTask<V> implements Future<V> {
       while (!isDone()) {
         _finishedCondition.await();
       }
-      if (_exception != null) {
-        throw _exception;
-      }
       if (_cancelled) {
         throw new CancellationException();
+      }
+      if (_exception != null) {
+        throw _exception;
       }
       return _result;
     } finally {
@@ -92,11 +92,11 @@ public class GameTask<V> implements Future<V> {
       if (!isDone()) {
         throw new TimeoutException("Object not returned in time allocated.");
       }
-      if (_exception != null) {
-        throw _exception;
-      }
       if (_cancelled) {
         throw new CancellationException();
+      }
+      if (_exception != null) {
+        throw _exception;
       }
       return _result;
     } finally {

--- a/ardor3d-core/src/main/java/com/ardor3d/util/GameTask.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/util/GameTask.java
@@ -71,6 +71,9 @@ public class GameTask<V> implements Future<V> {
       if (_exception != null) {
         throw _exception;
       }
+      if (_cancelled) {
+        throw new CancellationException();
+      }
       return _result;
     } finally {
       _stateLock.unlock();

--- a/ardor3d-core/src/main/java/com/ardor3d/util/SortUtil.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/util/SortUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -163,7 +163,7 @@ public abstract class SortUtil {
       for (int i = left + h; i <= right; i++) {
         int j = i;
         final T val = array[i];
-        while (j >= left + h && val.compareTo(array[j - 1]) < 0) {
+        while (j >= left + h && val.compareTo(array[j - h]) < 0) {
           array[j] = array[j - h];
           j -= h;
         }

--- a/ardor3d-core/src/main/java/com/ardor3d/util/export/binary/BinaryOutputCapsule.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/util/export/binary/BinaryOutputCapsule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -1231,8 +1231,10 @@ public class BinaryOutputCapsule implements OutputCapsule {
     write(_forceDirectNioBuffers || source.isDirect());
 
     final byte[] array;
+    final int offset;
     if (source.hasArray()) {
       array = source.array();
+      offset = source.arrayOffset();
     } else {
       // duplicate buffer to allow modification of limit/position without changing original.
       final ByteBuffer value = source.duplicate();
@@ -1241,10 +1243,11 @@ public class BinaryOutputCapsule implements OutputCapsule {
       array = new byte[length];
       value.rewind();
       value.get(array);
+      offset = 0;
     }
 
-    // write to stream
-    _baos.write(array);
+    // write to stream - exactly `length` bytes, not the whole backing array
+    _baos.write(array, offset, length);
   }
 
   @Override

--- a/ardor3d-core/src/test/java/com/ardor3d/bounding/TestCollisionTreeLeaf.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/bounding/TestCollisionTreeLeaf.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.bounding;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.scenegraph.Mesh;
+import com.ardor3d.scenegraph.MeshData;
+
+public class TestCollisionTreeLeaf {
+
+  private final int originalMax = CollisionTreeManager.getInstance().getMaxPrimitivesPerLeaf();
+
+  @After
+  public void restoreMax() {
+    CollisionTreeManager.getInstance().setMaxPrimitivesPerLeaf(originalMax);
+  }
+
+  /**
+   * A node holding exactly maxPrimitivesPerLeaf primitives must be a leaf. The leaf test used
+   * _end - _start + 1 on a half-open [_start,_end) range, overcounting by one, so a full (== max)
+   * node split needlessly (one level too deep; at max == 1 it recursed into itself forever).
+   */
+  @Test
+  public void testNodeWithMaxPrimitivesIsLeaf() {
+    CollisionTreeManager.getInstance().setMaxPrimitivesPerLeaf(2);
+
+    final Mesh mesh = new Mesh("m");
+    final MeshData md = new MeshData();
+    // two triangles (6 vertices) -> getPrimitiveCount(0) == 2 == maxPrimitivesPerLeaf
+    md.setVertexBuffer(BufferUtils.createFloatBuffer(new float[] { //
+        0, 0, 0, 1, 0, 0, 0, 1, 0, // triangle 0
+        0, 0, 1, 1, 0, 1, 0, 1, 1})); // triangle 1
+    mesh.setMeshData(md);
+
+    final CollisionTree tree = new CollisionTree(CollisionTree.Type.AABB);
+    tree.construct(mesh, false);
+
+    assertNotNull(tree._bounds);
+    assertNull("a node with exactly maxPrimitivesPerLeaf primitives should be a leaf", tree._left);
+    assertNull(tree._right);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/buffer/TestBufferUtilsOffset.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/buffer/TestBufferUtilsOffset.java
@@ -17,6 +17,8 @@ import java.nio.FloatBuffer;
 
 import org.junit.Test;
 
+import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Vector2;
 import com.ardor3d.math.Vector3;
 import com.ardor3d.math.Vector4;
 
@@ -55,5 +57,33 @@ public class TestBufferUtilsOffset {
     final float[] out = new float[buf.remaining()];
     buf.get(out);
     assertArrayEquals(new float[] {1, 2, 3, 4, 0, 0, 0, 0}, out, 0f);
+  }
+
+  @Test
+  public void testCreateFloatBufferColorRGBAWithOffset() {
+    final ColorRGBA c0 = new ColorRGBA(0, 0, 0, 0);
+    final ColorRGBA c1 = new ColorRGBA(1, 2, 3, 4);
+    final ColorRGBA c2 = new ColorRGBA(5, 6, 7, 8);
+
+    final FloatBuffer buf = BufferUtils.createFloatBuffer(1, 2, c0, c1, c2);
+
+    assertEquals(8, buf.remaining());
+    final float[] out = new float[buf.remaining()];
+    buf.get(out);
+    assertArrayEquals(new float[] {1, 2, 3, 4, 5, 6, 7, 8}, out, 0f);
+  }
+
+  @Test
+  public void testCreateFloatBufferVector2WithOffset() {
+    final Vector2 v0 = new Vector2(0, 0);
+    final Vector2 v1 = new Vector2(1, 2);
+    final Vector2 v2 = new Vector2(3, 4);
+
+    final FloatBuffer buf = BufferUtils.createFloatBuffer(1, 2, v0, v1, v2);
+
+    assertEquals(4, buf.remaining());
+    final float[] out = new float[buf.remaining()];
+    buf.get(out);
+    assertArrayEquals(new float[] {1, 2, 3, 4}, out, 0f);
   }
 }

--- a/ardor3d-core/src/test/java/com/ardor3d/buffer/TestBufferUtilsOffset.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/buffer/TestBufferUtilsOffset.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.buffer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.nio.FloatBuffer;
+
+import org.junit.Test;
+
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.Vector4;
+
+public class TestBufferUtilsOffset {
+
+  /**
+   * The offset variant must emit {@code length} tuples starting at {@code offset}. The buggy loop
+   * bound ({@code x < length} instead of {@code x < offset + length}) emitted too few when offset
+   * was non-zero.
+   */
+  @Test
+  public void testCreateFloatBufferVector3WithOffset() {
+    final Vector3 v0 = new Vector3(0, 0, 0);
+    final Vector3 v1 = new Vector3(1, 1, 1);
+    final Vector3 v2 = new Vector3(2, 2, 2);
+
+    final FloatBuffer buf = BufferUtils.createFloatBuffer(1, 2, v0, v1, v2);
+
+    assertEquals(6, buf.remaining());
+    final float[] out = new float[buf.remaining()];
+    buf.get(out);
+    assertArrayEquals(new float[] {1, 1, 1, 2, 2, 2}, out, 0f);
+  }
+
+  /**
+   * A null Vector4 entry must contribute four zero floats (not three), otherwise the buffer is
+   * desynchronised for every following entry.
+   */
+  @Test
+  public void testCreateFloatBufferVector4NullEntryWritesFourFloats() {
+    final Vector4 v = new Vector4(1, 2, 3, 4);
+
+    final FloatBuffer buf = BufferUtils.createFloatBuffer(0, 2, v, null);
+
+    assertEquals(8, buf.remaining());
+    final float[] out = new float[buf.remaining()];
+    buf.get(out);
+    assertArrayEquals(new float[] {1, 2, 3, 4, 0, 0, 0, 0}, out, 0f);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/intersection/TestPickResultsOrdering.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/intersection/TestPickResultsOrdering.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.intersection;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ardor3d.math.Ray3;
+import com.ardor3d.math.Vector3;
+
+/**
+ * Guards the live pick-sort path (used by scene mouse-picking): PickResults must order picks
+ * nearest-first, including when two picks share a distance. The tie case is what previously made the
+ * distance comparator violate the Comparator contract.
+ */
+public class TestPickResultsOrdering {
+
+  /** A Pickable whose world-bounds intersection sits at a single, fixed distance. */
+  private static PickData pickAtDistance(final double distance) {
+    final Pickable target = new Pickable() {
+      @Override
+      public boolean supportsBoundsIntersectionRecord() { return true; }
+
+      @Override
+      public boolean supportsPrimitivesIntersectionRecord() { return false; }
+
+      @Override
+      public boolean intersectsWorldBound(final Ray3 ray) { return true; }
+
+      @Override
+      public IntersectionRecord intersectsWorldBoundsWhere(final Ray3 ray) {
+        return new IntersectionRecord(new double[] {distance}, new Vector3[] {new Vector3()});
+      }
+
+      @Override
+      public IntersectionRecord intersectsPrimitivesWhere(final Ray3 ray) { return null; }
+    };
+    return new PickData(new Ray3(), target, true);
+  }
+
+  @Test
+  public void testOrdersPicksNearestFirstWithTies() {
+    final PickResults results = new PickResults() {
+      @Override
+      public void addPick(final Ray3 ray, final Pickable p) { /* unused: data added directly */ }
+    };
+    results.setCheckDistance(true);
+
+    results.addPickData(pickAtDistance(5.0));
+    results.addPickData(pickAtDistance(1.0));
+    results.addPickData(pickAtDistance(3.0));
+    results.addPickData(pickAtDistance(1.0)); // ties with the nearest
+
+    // First getPickData triggers the sort; the rest read the sorted list.
+    assertEquals(1.0, results.getPickData(0).getIntersectionRecord().getClosestDistance(), 0.0);
+    assertEquals(1.0, results.getPickData(1).getIntersectionRecord().getClosestDistance(), 0.0);
+    assertEquals(3.0, results.getPickData(2).getIntersectionRecord().getClosestDistance(), 0.0);
+    assertEquals(5.0, results.getPickData(3).getIntersectionRecord().getClosestDistance(), 0.0);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/scenegraph/TestMeshReorder.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/scenegraph/TestMeshReorder.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.scenegraph;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+import com.ardor3d.buffer.BufferUtils;
+
+public class TestMeshReorder {
+
+  /**
+   * reorderVertexData must rebuild the normal working buffer from the normals, not from the vertex
+   * coordinates. The reorder {1,1} never writes target slot 0, so that slot keeps its seeded value -
+   * which exposes what the buffer was seeded from: the original normal (correct) vs. the vertex
+   * coordinate (the bug).
+   */
+  @Test
+  public void testReorderRebuildsNormalsFromNormals() {
+    final Mesh mesh = new Mesh("m");
+    final MeshData md = new MeshData();
+    md.setVertexBuffer(BufferUtils.createFloatBuffer(new float[] {10, 10, 10, 20, 20, 20}));
+    md.setNormalBuffer(BufferUtils.createFloatBuffer(new float[] {0, 0, 1, 0, 1, 0}));
+    mesh.setMeshData(md);
+
+    mesh.reorderVertexData(new int[] {1, 1}); // both source verts map to slot 1; slot 0 never written
+
+    final float[] firstNormal = new float[3];
+    mesh.getMeshData().getNormalBuffer().rewind();
+    mesh.getMeshData().getNormalBuffer().get(firstNormal, 0, 3);
+
+    // slot 0 keeps its seed: must be the original normal (0,0,1), not the vertex coord (10,10,10)
+    assertArrayEquals(new float[] {0, 0, 1}, firstNormal, 0f);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/scenegraph/TestSpatialProperty.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/scenegraph/TestSpatialProperty.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.scenegraph;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ardor3d.scenegraph.hint.PropertyMode;
+
+public class TestSpatialProperty {
+
+  /**
+   * In {@link PropertyMode#UseOursLast} a root spatial (no parent) must still resolve properties.
+   * The buggy implementation called {@code parent.hasProperty(...)} without a null guard, throwing
+   * a NullPointerException on any parentless spatial.
+   */
+  @Test
+  public void testGetPropertyUseOursLastOnRoot() {
+    final Node root = new Node("root");
+    root.getSceneHints().setPropertyMode(PropertyMode.UseOursLast);
+    root.setProperty("color", "red");
+
+    assertEquals("red", root.getProperty("color", "default"));
+    assertEquals("default", root.getProperty("missing", "default"));
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/TestGameTask.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/TestGameTask.java
@@ -47,4 +47,12 @@ public class TestGameTask {
     task.cancel(false);
     task.get(2, TimeUnit.SECONDS);
   }
+
+  /** The untimed get() must also report cancellation (Future contract), not return a null result. */
+  @Test(expected = CancellationException.class)
+  public void testUntimedGetReportsCancellation() throws Exception {
+    final GameTask<String> task = new GameTask<>(() -> "done");
+    task.cancel(false);
+    task.get();
+  }
 }

--- a/ardor3d-core/src/test/java/com/ardor3d/util/TestGameTask.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/TestGameTask.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util;
+
+import static org.junit.Assert.assertNull;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+public class TestGameTask {
+
+  /**
+   * A task that completes with a null result (e.g. a {@code Callable<Void>}) must return null, not
+   * report a spurious timeout. The buggy implementation treated {@code _result == null} as a
+   * timeout even when the task had finished.
+   */
+  @Test
+  public void testGetReturnsNullResultWithoutTimingOut() throws Exception {
+    final GameTask<Void> task = new GameTask<>(() -> null);
+    task.invoke();
+
+    assertNull(task.get(2, TimeUnit.SECONDS));
+  }
+
+  /** A task that is never invoked must still genuinely time out. */
+  @Test(expected = TimeoutException.class)
+  public void testGetTimesOutWhenNeverInvoked() throws Exception {
+    final GameTask<String> task = new GameTask<>(() -> "done");
+    task.get(50, TimeUnit.MILLISECONDS);
+  }
+
+  /** A cancelled task must report cancellation, not a timeout. */
+  @Test(expected = CancellationException.class)
+  public void testGetReportsCancellation() throws Exception {
+    final GameTask<String> task = new GameTask<>(() -> "done");
+    task.cancel(false);
+    task.get(2, TimeUnit.SECONDS);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/TestGameTask.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/TestGameTask.java
@@ -55,4 +55,19 @@ public class TestGameTask {
     task.cancel(false);
     task.get();
   }
+
+  /**
+   * Cancellation takes precedence over a stored exception. The queue normally skips cancelled tasks,
+   * but if one is cancelled and still runs and throws, get() must honor the Future contract and throw
+   * CancellationException, not the incidental ExecutionException.
+   */
+  @Test(expected = CancellationException.class)
+  public void testCancellationTakesPrecedenceOverException() throws Exception {
+    final GameTask<String> task = new GameTask<>(() -> {
+      throw new RuntimeException("boom");
+    });
+    task.cancel(false); // mark cancelled first
+    task.invoke();      // the queue would skip this; invoked directly to force the cancelled+threw state
+    task.get();
+  }
 }

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/SavableByteBufferHolder.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/SavableByteBufferHolder.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import com.ardor3d.util.export.InputCapsule;
+import com.ardor3d.util.export.OutputCapsule;
+import com.ardor3d.util.export.Savable;
+
+/**
+ * Minimal test Savable that writes a ByteBuffer field followed by a plain int field, used to verify
+ * that serializing a ByteBuffer does not desynchronise the fields written after it.
+ */
+public class SavableByteBufferHolder implements Savable {
+
+  public ByteBuffer buffer;
+  public int marker;
+
+  public SavableByteBufferHolder() {}
+
+  @Override
+  public Class<? extends SavableByteBufferHolder> getClassTag() { return this.getClass(); }
+
+  @Override
+  public void write(final OutputCapsule capsule) throws IOException {
+    capsule.write(buffer, "buffer", null);
+    capsule.write(marker, "marker", 0);
+  }
+
+  @Override
+  public void read(final InputCapsule capsule) throws IOException {
+    buffer = capsule.readByteBuffer("buffer", null);
+    marker = capsule.readInt("marker", 0);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryByteBufferRoundTrip.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryByteBufferRoundTrip.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+public class TestBinaryByteBufferRoundTrip {
+
+  /**
+   * A heap ByteBuffer whose limit is below its capacity must serialize exactly limit() bytes. The
+   * buggy code wrote the whole backing array while recording length=limit(), leaving stray bytes
+   * that desynchronised every following field - here, the int written after the buffer.
+   */
+  @Test
+  public void testHeapByteBufferDoesNotCorruptFollowingField() throws Exception {
+    final SavableByteBufferHolder holder = new SavableByteBufferHolder();
+    final ByteBuffer bb = ByteBuffer.allocate(16);
+    bb.put(new byte[] {10, 20, 30, 40});
+    bb.flip(); // position=0, limit=4, capacity=16
+
+    holder.buffer = bb;
+    holder.marker = 42;
+
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new BinaryExporter().save(holder, out);
+    final SavableByteBufferHolder restored =
+        (SavableByteBufferHolder) new BinaryImporter().load(new ByteArrayInputStream(out.toByteArray()));
+
+    // The field written AFTER the buffer must survive intact.
+    assertEquals(42, restored.marker);
+
+    // ...and the buffer content itself must be correct.
+    assertNotNull(restored.buffer);
+    assertEquals(4, restored.buffer.remaining());
+    final byte[] restoredBytes = new byte[restored.buffer.remaining()];
+    restored.buffer.get(restoredBytes);
+    assertArrayEquals(new byte[] {10, 20, 30, 40}, restoredBytes);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryByteBufferRoundTrip.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryByteBufferRoundTrip.java
@@ -52,4 +52,34 @@ public class TestBinaryByteBufferRoundTrip {
     restored.buffer.get(restoredBytes);
     assertArrayEquals(new byte[] {10, 20, 30, 40}, restoredBytes);
   }
+
+  /**
+   * A sliced heap ByteBuffer has arrayOffset() > 0. Serialization must copy length bytes starting at
+   * arrayOffset (not index 0), so both the slice's content and the field written after it survive.
+   */
+  @Test
+  public void testSlicedHeapByteBufferRoundTrips() throws Exception {
+    final ByteBuffer backing = ByteBuffer.allocate(16);
+    backing.put(new byte[] {99, 99}); // junk preceding the slice -> slice.arrayOffset() == 2
+    backing.position(2);
+    final ByteBuffer slice = backing.slice();
+    slice.put(new byte[] {10, 20, 30, 40});
+    slice.flip(); // position 0, limit 4, arrayOffset 2
+
+    final SavableByteBufferHolder holder = new SavableByteBufferHolder();
+    holder.buffer = slice;
+    holder.marker = 7;
+
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new BinaryExporter().save(holder, out);
+    final SavableByteBufferHolder restored =
+        (SavableByteBufferHolder) new BinaryImporter().load(new ByteArrayInputStream(out.toByteArray()));
+
+    assertEquals(7, restored.marker);
+    assertNotNull(restored.buffer);
+    assertEquals(4, restored.buffer.remaining());
+    final byte[] restoredBytes = new byte[restored.buffer.remaining()];
+    restored.buffer.get(restoredBytes);
+    assertArrayEquals(new byte[] {10, 20, 30, 40}, restoredBytes);
+  }
 }

--- a/ardor3d-ui/src/main/java/com/ardor3d/extension/ui/UIContainer.java
+++ b/ardor3d-ui/src/main/java/com/ardor3d/extension/ui/UIContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -115,8 +115,8 @@ public abstract class UIContainer extends UIComponent {
       final Spatial child = getChild(i);
       if (child.equals(component)) {
         return true;
-      } else if (recurse && component instanceof UIContainer) {
-        if (((UIContainer) component).contains(component, true)) {
+      } else if (recurse && child instanceof UIContainer) {
+        if (((UIContainer) child).contains(component, true)) {
           return true;
         }
       }

--- a/ardor3d-ui/src/test/java/com/ardor3d/extension/ui/TestUIContainerContains.java
+++ b/ardor3d-ui/src/test/java/com/ardor3d/extension/ui/TestUIContainerContains.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.ui;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TestUIContainerContains {
+
+  /**
+   * contains(component, true) must descend into sub-containers to find a nested component. The bug
+   * recursed on the search target instead of the child, so a recursive search never actually
+   * descended (and could StackOverflow when the target was itself a populated container).
+   */
+  @Test
+  public void testContainsRecursesIntoSubContainers() {
+    final UIPanel root = new UIPanel();
+    final UIPanel mid = new UIPanel();
+    final UIPanel leaf = new UIPanel();
+    mid.attachChild(leaf);
+    root.attachChild(mid);
+
+    // leaf is nested root -> mid -> leaf; a recursive search must find it
+    assertTrue(root.contains(leaf, true));
+    // a non-recursive search must NOT find a grandchild
+    assertFalse(root.contains(leaf, false));
+    // a component that isn't present must not be found
+    assertFalse(root.contains(new UIPanel(), true));
+  }
+}


### PR DESCRIPTION
Fixes the ten confirmed-correctness ("Tier 0") findings from a whole-codebase evaluation. One fix per commit, test-first wherever a deterministic red→green was possible.

### Honest framing
Every one of these sits on a **cold path** - dead/unused API, latent/no-op for current callers, structurally masked, or harmless at default settings - so none produced visibly-wrong behavior in normal use. The only changes that matter behaviorally to *users* are the two **serialization** fixes:

- **`TransformData`** read translation from the `"rotation"` capsule key, so every skeletal animation saved and reloaded via the binary format silently lost its joint translations.
- **`BinaryOutputCapsule`** wrote a heap `ByteBuffer`'s whole backing array (capacity) while recording `limit()`, desynchronising the stream and corrupting every field written after it.

The rest are latent/hardening: real bugs, but on paths the engine, examples, and tests don't exercise.

### The fixes
- `getSubchannelBySample` `i<=samples` off-by-one in 4 channel classes (AIOOBE on any trim) 
- `TransformData` translation read from the wrong capsule key 
- `BinaryOutputCapsule` heap-`ByteBuffer` over-write 
- `BufferUtils.createFloatBuffer` offset loop bound + Vector4 null branch (latent) 
- `Spatial.getProperty` NPE on a root spatial in `UseOursLast` 
- `PickResults` distance comparator violated the `Comparator` contract; `LightManager` hardened 
- `GameTask.get(timeout)` reported null/cancelled tasks as timeouts 
- `UIContainer.contains(_, true)` recursed on the search target → StackOverflow 
- `Mesh.reorderVertexData` rebuilt normals from vertex coordinates 
- `CollisionTree` leaf-size off-by-one; dead `shellSort(Comparable)` gap bug 

### Testing
17 new tests across 9 files; full `core`, `animation`, and `ui` suites green. `ardor3d-animation` had no tests before this; `core`'s buffer / serialization / scenegraph / intersection corners gained their first coverage. Inspection-only changes (`#7`, `#1`'s `LightManager` half, `#20`'s dead `shellSort`) are provably no-op or output-correct, so they carry guard tests or none rather than a faked red→green.

### Deliberately not changed
- The eval's "ControllerState" comparator claim was a misattribution - no such comparator exists; the real culprit (`PickResults`) is fixed here.
- `KeyframeController`'s min/max "bug" is a non-bug on inspection (`minTime` defaults to 0 and `time < 0` is rejected, so the min update can't fire; a mid-list insert is never a new max), so it's left alone.

(Assisted by Claude Code + Opus 4.8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed off-by-one issues when creating animation subchannels.
  * Corrected transform data translation deserialization.
  * Resolved float-buffer and byte-buffer serialization errors for non-zero offsets (including correct zero-fill sizing).
  * Improved pick ordering for equal distances; corrected collision tree leaf splitting at boundaries.
  * Fixed mesh normal reordering, shell sort gap comparisons, task cancellation/timeout behavior, property lookup null-safety, light sorting total-ordering, and UI container recursive containment.

* **Tests**
  * Added regression tests for animation subchannels, transform binary round-trips, pick ordering ties, collision boundary behavior, buffer offsets, mesh reorder, spatial properties, UI containment recursion, and task cancellation precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->