### PR TITLE
Harden binary serialization and add a round-trip test net

### DIFF
--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/Joint.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/Joint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.animation.skeletal;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 import com.ardor3d.annotation.SavableFactory;
 import com.ardor3d.math.Transform;
@@ -32,7 +31,7 @@ public class Joint implements Savable {
   private final Transform _inverseBindPose = new Transform(Transform.IDENTITY);
 
   /** A name, for display or debugging purposes. */
-  private final String _name;
+  private String _name;
 
   protected short _index;
 
@@ -99,14 +98,7 @@ public class Joint implements Savable {
 
   @Override
   public void read(final InputCapsule capsule) throws IOException {
-    final String name = capsule.readString("name", null);
-    try {
-      final Field field1 = Joint.class.getDeclaredField("_name");
-      field1.setAccessible(true);
-      field1.set(this, name);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _name = capsule.readString("name", null);
 
     _index = capsule.readShort("index", (short) 0);
     _parentIndex = capsule.readShort("parentIndex", (short) 0);

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/Skeleton.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/Skeleton.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.animation.skeletal;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 import com.ardor3d.annotation.SavableFactory;
 import com.ardor3d.util.export.CapsuleUtils;
@@ -30,10 +29,10 @@ public class Skeleton implements Savable {
   /**
    * An array of Joints associated with this Skeleton.
    */
-  private final Joint[] _joints;
+  private Joint[] _joints;
 
   /** A name, for display or debugging purposes. */
-  private final String _name;
+  private String _name;
 
   /**
    * 
@@ -87,19 +86,8 @@ public class Skeleton implements Savable {
 
   @Override
   public void read(final InputCapsule capsule) throws IOException {
-    final String name = capsule.readString("name", null);
-    final Joint[] joints = CapsuleUtils.asArray(capsule.readSavableArray("joints", null), Joint.class);
-    try {
-      final Field field1 = Skeleton.class.getDeclaredField("_name");
-      field1.setAccessible(true);
-      field1.set(this, name);
-
-      final Field field2 = Skeleton.class.getDeclaredField("_joints");
-      field2.setAccessible(true);
-      field2.set(this, joints);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _name = capsule.readString("name", null);
+    _joints = CapsuleUtils.asArray(capsule.readSavableArray("joints", null), Joint.class);
   }
 
   public static Skeleton initSavable() {

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/SkeletonPose.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/SkeletonPose.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.animation.skeletal;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,19 +30,19 @@ import com.ardor3d.util.export.Savable;
 public class SkeletonPose implements Savable {
 
   /** The skeleton being "posed". */
-  private final Skeleton _skeleton;
+  private Skeleton _skeleton;
 
   /** Local transforms for the joints of the associated skeleton. */
-  private final Transform[] _localTransforms;
+  private Transform[] _localTransforms;
 
   /** Global transforms for the joints of the associated skeleton. Not saved to savable. */
-  private transient final Transform[] _globalTransforms;
+  private transient Transform[] _globalTransforms;
 
   /**
    * A palette of matrices used in skin deformation - basically the global transform X the inverse
    * bind pose transform. Not saved to savable.
    */
-  private transient final Matrix4[] _matrixPalette;
+  private transient Matrix4[] _matrixPalette;
 
   /**
    * The list of elements interested in notification when this SkeletonPose updates. Not saved to
@@ -243,43 +242,24 @@ public class SkeletonPose implements Savable {
 
   @Override
   public void read(final InputCapsule capsule) throws IOException {
-    final Skeleton skeleton = capsule.readSavable("skeleton", null);
-    final Transform[] localTransforms =
-        CapsuleUtils.asArray(capsule.readSavableArray("localTransforms", null), Transform.class);
-    try {
-      final Field field1 = SkeletonPose.class.getDeclaredField("_skeleton");
-      field1.setAccessible(true);
-      field1.set(this, skeleton);
+    _skeleton = capsule.readSavable("skeleton", null);
+    _localTransforms = CapsuleUtils.asArray(capsule.readSavableArray("localTransforms", null), Transform.class);
 
-      final int jointCount = _skeleton.getJoints().length;
+    final int jointCount = _skeleton.getJoints().length;
 
-      // init local transforms
-      final Field field2 = SkeletonPose.class.getDeclaredField("_localTransforms");
-      field2.setAccessible(true);
-      field2.set(this, localTransforms);
-
-      // init global transforms
-      final Transform[] globalTransforms = new Transform[jointCount];
-      for (int i = 0; i < jointCount; i++) {
-        globalTransforms[i] = new Transform();
-      }
-      final Field field3 = SkeletonPose.class.getDeclaredField("_globalTransforms");
-      field3.setAccessible(true);
-      field3.set(this, globalTransforms);
-
-      // init palette
-      final Matrix4[] matrixPalette = new Matrix4[jointCount];
-      for (int i = 0; i < jointCount; i++) {
-        matrixPalette[i] = new Matrix4();
-      }
-      final Field field4 = SkeletonPose.class.getDeclaredField("_matrixPalette");
-      field4.setAccessible(true);
-      field4.set(this, matrixPalette);
-
-      updateTransforms();
-    } catch (final Exception e) {
-      e.printStackTrace();
+    // init global transforms
+    _globalTransforms = new Transform[jointCount];
+    for (int i = 0; i < jointCount; i++) {
+      _globalTransforms[i] = new Transform();
     }
+
+    // init palette
+    _matrixPalette = new Matrix4[jointCount];
+    for (int i = 0; i < jointCount; i++) {
+      _matrixPalette[i] = new Matrix4();
+    }
+
+    updateTransforms();
   }
 
   public static SkeletonPose initSavable() {

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/AbstractAnimationChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/AbstractAnimationChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.animation.skeletal.clip;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 import com.ardor3d.util.export.InputCapsule;
 import com.ardor3d.util.export.OutputCapsule;
@@ -25,13 +24,13 @@ import com.ardor3d.util.export.Savable;
 public abstract class AbstractAnimationChannel implements Savable {
 
   /** The name of this channel. */
-  protected final String _channelName;
+  protected String _channelName;
 
   /**
    * Our time indices. Each index of the array should contain a value that is > the value in the
    * previous index.
    */
-  protected final float[] _times;
+  protected float[] _times;
 
   /**
    * Construct a new channel.
@@ -196,18 +195,7 @@ public abstract class AbstractAnimationChannel implements Savable {
 
   @Override
   public void read(final InputCapsule capsule) throws IOException {
-    final String channelName = capsule.readString("channelName", null);
-    final float[] times = capsule.readFloatArray("times", null);
-    try {
-      final Field field1 = AbstractAnimationChannel.class.getDeclaredField("_channelName");
-      field1.setAccessible(true);
-      field1.set(this, channelName);
-
-      final Field field2 = AbstractAnimationChannel.class.getDeclaredField("_times");
-      field2.setAccessible(true);
-      field2.set(this, times);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _channelName = capsule.readString("channelName", null);
+    _times = capsule.readFloatArray("times", null);
   }
 }

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/AnimationClip.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/AnimationClip.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.animation.skeletal.clip;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +26,7 @@ import com.ardor3d.util.export.Savable;
 public class AnimationClip implements Savable {
 
   /** A referenceable name for this clip. In general, this should be unique. */
-  private final String _name;
+  private String _name;
 
   /** A list of animation channels managed by this clip. */
   private final List<AbstractAnimationChannel> _channels;
@@ -162,14 +161,7 @@ public class AnimationClip implements Savable {
 
   @Override
   public void read(final InputCapsule capsule) throws IOException {
-    final String name = capsule.readString("name", null);
-    try {
-      final Field field1 = AnimationClip.class.getDeclaredField("_name");
-      field1.setAccessible(true);
-      field1.set(this, name);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _name = capsule.readString("name", null);
 
     _channels.clear();
     final List<Savable> channels = capsule.readSavableList("channels", null);

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/InterpolatedDoubleChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/InterpolatedDoubleChannel.java
@@ -11,10 +11,10 @@
 package com.ardor3d.extension.animation.skeletal.clip;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.ardor3d.annotation.SavableFactory;
 import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.util.export.InputCapsule;
 import com.ardor3d.util.export.OutputCapsule;
@@ -24,10 +24,11 @@ import com.ardor3d.util.export.OutputCapsule;
  * between key frames. Potential uses for this channel include extracting and using forward motion
  * from walk animations, animating colors or texture coordinates, etc.
  */
+@SavableFactory(factoryMethod = "initSavable")
 public class InterpolatedDoubleChannel extends AbstractAnimationChannel {
 
   /** Our key samples. */
-  protected final double[] _values;
+  protected double[] _values;
 
   /**
    * Construct a new InterpolatedDoubleChannel.
@@ -144,14 +145,7 @@ public class InterpolatedDoubleChannel extends AbstractAnimationChannel {
   @Override
   public void read(final InputCapsule capsule) throws IOException {
     super.read(capsule);
-    final double[] values = capsule.readDoubleArray("values", null);
-    try {
-      final Field field1 = InterpolatedDoubleChannel.class.getDeclaredField("_values");
-      field1.setAccessible(true);
-      field1.set(this, values);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _values = capsule.readDoubleArray("values", null);
   }
 
   public static InterpolatedDoubleChannel initSavable() {

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/InterpolatedFloatChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/InterpolatedFloatChannel.java
@@ -11,10 +11,10 @@
 package com.ardor3d.extension.animation.skeletal.clip;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.ardor3d.annotation.SavableFactory;
 import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.util.export.InputCapsule;
 import com.ardor3d.util.export.OutputCapsule;
@@ -24,10 +24,11 @@ import com.ardor3d.util.export.OutputCapsule;
  * between key frames. Potential uses for this channel include extracting and using forward motion
  * from walk animations, animating colors or texture coordinates, etc.
  */
+@SavableFactory(factoryMethod = "initSavable")
 public class InterpolatedFloatChannel extends AbstractAnimationChannel {
 
   /** Our key samples. */
-  protected final float[] _values;
+  protected float[] _values;
 
   /**
    * Construct a new InterpolatedFloatChannel.
@@ -143,14 +144,7 @@ public class InterpolatedFloatChannel extends AbstractAnimationChannel {
   @Override
   public void read(final InputCapsule capsule) throws IOException {
     super.read(capsule);
-    final float[] values = capsule.readFloatArray("values", null);
-    try {
-      final Field field1 = InterpolatedFloatChannel.class.getDeclaredField("_values");
-      field1.setAccessible(true);
-      field1.set(this, values);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _values = capsule.readFloatArray("values", null);
   }
 
   public static InterpolatedFloatChannel initSavable() {

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/JointChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/JointChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.animation.skeletal.clip;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 import com.ardor3d.annotation.SavableFactory;
 import com.ardor3d.extension.animation.skeletal.Joint;
@@ -32,7 +31,7 @@ public class JointChannel extends TransformChannel {
   public static final String JOINT_CHANNEL_NAME = "_jnt";
 
   /** The human readable version of the name. */
-  private final String _jointName;
+  private String _jointName;
 
   /** The joint index. */
   private int _jointIndex;
@@ -152,14 +151,7 @@ public class JointChannel extends TransformChannel {
   @Override
   public void read(final InputCapsule capsule) throws IOException {
     super.read(capsule);
-    final String jointName = capsule.readString("jointName", null);
-    try {
-      final Field field1 = JointChannel.class.getDeclaredField("_jointName");
-      field1.setAccessible(true);
-      field1.set(this, jointName);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _jointName = capsule.readString("jointName", null);
 
     if (_channelName.startsWith(JointChannel.JOINT_CHANNEL_NAME)) {
       _jointIndex = Integer.parseInt(_channelName.substring(JointChannel.JOINT_CHANNEL_NAME.length()));

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/TransformChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/TransformChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.animation.skeletal.clip;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -40,13 +39,13 @@ public class TransformChannel extends AbstractAnimationChannel {
   // (s)lerps.
 
   /** Our rotation samples. */
-  private final ReadOnlyQuaternion[] _rotations;
+  private ReadOnlyQuaternion[] _rotations;
 
   /** Our translation samples. */
-  private final ReadOnlyVector3[] _translations;
+  private ReadOnlyVector3[] _translations;
 
   /** Our scale samples. */
-  private final ReadOnlyVector3[] _scales;
+  private ReadOnlyVector3[] _scales;
 
   private final Quaternion _compQuat1 = new Quaternion();
   private final Quaternion _compQuat2 = new Quaternion();
@@ -288,27 +287,9 @@ public class TransformChannel extends AbstractAnimationChannel {
   @Override
   public void read(final InputCapsule capsule) throws IOException {
     super.read(capsule);
-    final ReadOnlyQuaternion[] rotations =
-        CapsuleUtils.asArray(capsule.readSavableArray("rotations", null), ReadOnlyQuaternion.class);
-    final ReadOnlyVector3[] scales =
-        CapsuleUtils.asArray(capsule.readSavableArray("scales", null), ReadOnlyVector3.class);
-    final ReadOnlyVector3[] translations =
-        CapsuleUtils.asArray(capsule.readSavableArray("translations", null), ReadOnlyVector3.class);
-    try {
-      final Field field1 = TransformChannel.class.getDeclaredField("_rotations");
-      field1.setAccessible(true);
-      field1.set(this, rotations);
-
-      final Field field2 = TransformChannel.class.getDeclaredField("_scales");
-      field2.setAccessible(true);
-      field2.set(this, scales);
-
-      final Field field3 = TransformChannel.class.getDeclaredField("_translations");
-      field3.setAccessible(true);
-      field3.set(this, translations);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _rotations = CapsuleUtils.asArray(capsule.readSavableArray("rotations", null), ReadOnlyQuaternion.class);
+    _scales = CapsuleUtils.asArray(capsule.readSavableArray("scales", null), ReadOnlyVector3.class);
+    _translations = CapsuleUtils.asArray(capsule.readSavableArray("translations", null), ReadOnlyVector3.class);
   }
 
   public static TransformChannel initSavable() {

--- a/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/TriggerChannel.java
+++ b/ardor3d-animation/src/main/java/com/ardor3d/extension/animation/skeletal/clip/TriggerChannel.java
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.animation.skeletal.clip;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +26,7 @@ import com.ardor3d.util.export.OutputCapsule;
 public class TriggerChannel extends AbstractAnimationChannel {
 
   /** Our key samples. */
-  protected final String[] _keys;
+  protected String[] _keys;
 
   /**
    * Construct a new TriggerChannel.
@@ -142,14 +141,7 @@ public class TriggerChannel extends AbstractAnimationChannel {
   @Override
   public void read(final InputCapsule capsule) throws IOException {
     super.read(capsule);
-    final String[] keys = capsule.readStringArray("keys", null);
-    try {
-      final Field field1 = TriggerChannel.class.getDeclaredField("_keys");
-      field1.setAccessible(true);
-      field1.set(this, keys);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _keys = capsule.readStringArray("keys", null);
   }
 
   public static TriggerChannel initSavable() {

--- a/ardor3d-animation/src/test/java/com/ardor3d/extension/animation/skeletal/TestAnimationSerialization.java
+++ b/ardor3d-animation/src/test/java/com/ardor3d/extension/animation/skeletal/TestAnimationSerialization.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.animation.skeletal;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Test;
+
+import com.ardor3d.extension.animation.skeletal.clip.AnimationClip;
+import com.ardor3d.extension.animation.skeletal.clip.InterpolatedDoubleChannel;
+import com.ardor3d.extension.animation.skeletal.clip.InterpolatedFloatChannel;
+import com.ardor3d.extension.animation.skeletal.clip.JointChannel;
+import com.ardor3d.extension.animation.skeletal.clip.TriggerChannel;
+import com.ardor3d.math.Quaternion;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyQuaternion;
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.util.export.Savable;
+import com.ardor3d.util.export.binary.BinaryExporter;
+import com.ardor3d.util.export.binary.BinaryImporter;
+
+/**
+ * Round-trips the skeletal/clip Savables whose read() methods were converted from reflective
+ * setAccessible/field.set into normal assignment. These guard against the de-reflection silently
+ * dropping a field - the value-bearing fields must still survive a save/load.
+ */
+public class TestAnimationSerialization {
+
+  static Savable roundTrip(final Savable in) throws Exception {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new BinaryExporter().save(in, out);
+    return new BinaryImporter().load(new ByteArrayInputStream(out.toByteArray()));
+  }
+
+  @Test
+  public void testInterpolatedFloatChannelRoundTrip() throws Exception {
+    final InterpolatedFloatChannel src =
+        new InterpolatedFloatChannel("scalar", new float[] {0f, 0.5f, 1f}, new float[] {10f, 20f, 30f});
+
+    final InterpolatedFloatChannel r = (InterpolatedFloatChannel) roundTrip(src);
+
+    assertEquals("scalar", r.getChannelName());
+    assertArrayEquals(new float[] {0f, 0.5f, 1f}, r.getTimes(), 0f);
+    assertArrayEquals(new float[] {10f, 20f, 30f}, r.getValues(), 0f);
+  }
+
+  @Test
+  public void testInterpolatedDoubleChannelRoundTrip() throws Exception {
+    final InterpolatedDoubleChannel src =
+        new InterpolatedDoubleChannel("scalarD", new float[] {0f, 1f}, new double[] {1.25, 2.5});
+
+    final InterpolatedDoubleChannel r = (InterpolatedDoubleChannel) roundTrip(src);
+
+    assertEquals("scalarD", r.getChannelName());
+    assertArrayEquals(new float[] {0f, 1f}, r.getTimes(), 0f);
+    assertArrayEquals(new double[] {1.25, 2.5}, r.getValues(), 0.0);
+  }
+
+  @Test
+  public void testTriggerChannelRoundTrip() throws Exception {
+    final TriggerChannel src =
+        new TriggerChannel("triggers", new float[] {0f, 1f}, new String[] {"footstep", "land"});
+
+    final TriggerChannel r = (TriggerChannel) roundTrip(src);
+
+    assertEquals("triggers", r.getChannelName());
+    assertArrayEquals(new float[] {0f, 1f}, r.getTimes(), 0f);
+    assertArrayEquals(new String[] {"footstep", "land"}, r.getKeys());
+  }
+
+  @Test
+  public void testJointChannelRoundTrip() throws Exception {
+    final float[] times = {0f, 1f};
+    final ReadOnlyQuaternion[] rot = {new Quaternion(0, 0, 0, 1), new Quaternion(0, 1, 0, 0)};
+    final ReadOnlyVector3[] trans = {new Vector3(1, 2, 3), new Vector3(4, 5, 6)};
+    final ReadOnlyVector3[] scale = {new Vector3(1, 1, 1), new Vector3(2, 2, 2)};
+    final JointChannel src = new JointChannel("hip", 7, times, rot, trans, scale);
+
+    final JointChannel r = (JointChannel) roundTrip(src);
+
+    assertEquals("hip", r.getJointName());
+    assertEquals(7, r.getJointIndex()); // recovered from the channel name on read
+    assertArrayEquals(times, r.getTimes(), 0f);
+    assertEquals(new Vector3(1, 2, 3), r.getTranslations().get(0));
+    assertEquals(new Vector3(2, 2, 2), r.getScales().get(1));
+  }
+
+  @Test
+  public void testAnimationClipRoundTrip() throws Exception {
+    final AnimationClip src = new AnimationClip("walk");
+    src.addChannel(new InterpolatedFloatChannel("c", new float[] {0f, 1f}, new float[] {1f, 2f}));
+
+    final AnimationClip r = (AnimationClip) roundTrip(src);
+
+    assertEquals("walk", r.getName());
+    assertEquals(1, r.getChannels().size());
+    assertEquals("c", r.getChannels().get(0).getChannelName());
+  }
+
+  @Test
+  public void testSkeletonAndJointRoundTrip() throws Exception {
+    final Joint root = new Joint("root");
+    root.setIndex((short) 0);
+    root.setParentIndex(Joint.NO_PARENT);
+    final Joint child = new Joint("spine");
+    child.setIndex((short) 1);
+    child.setParentIndex((short) 0);
+    final Skeleton src = new Skeleton("rig", new Joint[] {root, child});
+
+    final Skeleton r = (Skeleton) roundTrip(src);
+
+    assertEquals("rig", r.getName());
+    assertEquals(2, r.getJoints().length);
+    assertEquals("root", r.getJoints()[0].getName());
+    assertEquals((short) 1, r.getJoints()[1].getIndex());
+    assertEquals((short) 0, r.getJoints()[1].getParentIndex());
+  }
+
+  @Test
+  public void testSkeletonPoseRoundTrip() throws Exception {
+    final Joint root = new Joint("root");
+    root.setIndex((short) 0);
+    root.setParentIndex(Joint.NO_PARENT);
+    final Skeleton skel = new Skeleton("rig", new Joint[] {root});
+    final SkeletonPose src = new SkeletonPose(skel);
+    src.getLocalJointTransforms()[0].setTranslation(3, 4, 5);
+
+    final SkeletonPose r = (SkeletonPose) roundTrip(src);
+
+    assertEquals(1, r.getSkeleton().getJoints().length);
+    assertEquals(new Vector3(3, 4, 5), r.getLocalJointTransforms()[0].getTranslation());
+    // transient palettes are not serialized; read() must rebuild them sized to the joint count
+    assertNotNull(r.getGlobalJointTransforms());
+    assertEquals(1, r.getGlobalJointTransforms().length);
+    assertNotNull(r.getMatrixPalette());
+    assertEquals(1, r.getMatrixPalette().length);
+  }
+}

--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/data/AnimationItem.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/data/AnimationItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.model.collada.jdom.data;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +22,7 @@ import com.ardor3d.util.export.Savable;
 
 @SavableFactory(factoryMethod = "initSavable")
 public class AnimationItem implements Savable {
-  private final String _name;
+  private String _name;
   private final List<AnimationItem> _children = new ArrayList<>();
   private AnimationClip _animationClip;
 
@@ -53,14 +52,7 @@ public class AnimationItem implements Savable {
 
   @Override
   public void read(final InputCapsule capsule) throws IOException {
-    final String name = capsule.readString("name", "");
-    try {
-      final Field field1 = AnimationClip.class.getDeclaredField("_name");
-      field1.setAccessible(true);
-      field1.set(this, name);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _name = capsule.readString("name", "");
     _children.clear();
     _children.addAll(capsule.readSavableList("children", new ArrayList<>()));
     _animationClip = capsule.readSavable("animationClip", null);

--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/data/SkinData.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/data/SkinData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,7 +11,6 @@
 package com.ardor3d.extension.model.collada.jdom.data;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +32,7 @@ public class SkinData implements Savable {
   private SkeletonPose _pose;
   private Node _skinBaseNode;
   private final List<SkinnedMesh> _skins = new ArrayList<>();
-  private final String _name;
+  private String _name;
 
   /**
    * Construct a new SkinData object.
@@ -81,14 +80,7 @@ public class SkinData implements Savable {
 
   @Override
   public void read(final InputCapsule capsule) throws IOException {
-    final String name = capsule.readString("name", "");
-    try {
-      final Field field1 = SkinData.class.getDeclaredField("_name");
-      field1.setAccessible(true);
-      field1.set(this, name);
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
+    _name = capsule.readString("name", "");
     _skinBaseNode = capsule.readSavable("baseNode", null);
     _skins.clear();
     _skins.addAll(capsule.readSavableList("skins", new ArrayList<>()));

--- a/ardor3d-collada/src/test/java/com/ardor3d/extension/model/collada/jdom/data/TestAnimationItemSerialization.java
+++ b/ardor3d-collada/src/test/java/com/ardor3d/extension/model/collada/jdom/data/TestAnimationItemSerialization.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.model.collada.jdom.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Test;
+
+import com.ardor3d.extension.animation.skeletal.clip.AnimationClip;
+import com.ardor3d.util.export.Savable;
+import com.ardor3d.util.export.binary.BinaryExporter;
+import com.ardor3d.util.export.binary.BinaryImporter;
+
+/**
+ * AnimationItem.read previously reflected into AnimationClip's _name field on an AnimationItem
+ * instance, which threw IllegalArgumentException on every load and was swallowed - so the name came
+ * back null. This verifies the name (and the nested children/clip) now survive a round-trip.
+ */
+public class TestAnimationItemSerialization {
+
+  static Savable roundTrip(final Savable in) throws Exception {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new BinaryExporter().save(in, out);
+    return new BinaryImporter().load(new ByteArrayInputStream(out.toByteArray()));
+  }
+
+  @Test
+  public void testNameAndChildrenRestoredOnLoad() throws Exception {
+    final AnimationItem root = new AnimationItem("root-anim");
+    final AnimationItem child = new AnimationItem("child-anim");
+    root.getChildren().add(child);
+    root.setAnimationClip(new AnimationClip("clip1"));
+
+    final AnimationItem r = (AnimationItem) roundTrip(root);
+
+    assertEquals("root-anim", r.getName()); // was null before the de-reflection fix
+    assertEquals(1, r.getChildren().size());
+    assertEquals("child-anim", r.getChildren().get(0).getName());
+    assertNotNull(r.getAnimationClip());
+    assertEquals("clip1", r.getAnimationClip().getName());
+  }
+}

--- a/ardor3d-core/src/main/java/com/ardor3d/util/export/binary/BinaryImporter.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/util/export/binary/BinaryImporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -13,6 +13,7 @@ package com.ardor3d.util.export.binary;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -163,10 +164,9 @@ public class BinaryImporter implements Ardor3dImporter {
   }
 
   public Savable load(final URL url, final ReadListener listener) throws IOException {
-    final InputStream is = url.openStream();
-    final Savable rVal = load(is, listener);
-    is.close();
-    return rVal;
+    try (InputStream is = url.openStream()) {
+      return load(is, listener);
+    }
   }
 
   @Override
@@ -175,23 +175,31 @@ public class BinaryImporter implements Ardor3dImporter {
   }
 
   public Savable load(final File file, final ReadListener listener) throws IOException {
-    final FileInputStream fis = new FileInputStream(file);
-    final Savable rVal = load(fis, listener);
-    fis.close();
-    return rVal;
+    try (FileInputStream fis = new FileInputStream(file)) {
+      return load(fis, listener);
+    }
   }
 
   @Override
   public Savable load(final byte[] data) throws IOException {
-    final ByteArrayInputStream bais = new ByteArrayInputStream(data);
-    final Savable rVal = load(bais);
-    bais.close();
-    return rVal;
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(data)) {
+      return load(bais);
+    }
   }
 
   protected String readString(final InputStream is, final int length) throws IOException {
-    final byte[] data = new byte[length];
-    is.read(data, 0, length);
+    if (length < 0) {
+      // a corrupt/tampered header can decode a negative length; surface it as a corrupt-file
+      // IOException rather than letting readNBytes throw an unchecked IllegalArgumentException.
+      throw new IOException("Invalid negative string length in stream: " + length);
+    }
+    // readNBytes loops until length bytes are read or the stream ends; a single read() may return
+    // fewer bytes than requested (notably through the buffered/gzip streams this reads through),
+    // which previously left the tail of the name zeroed.
+    final byte[] data = is.readNBytes(length);
+    if (data.length != length) {
+      throw new EOFException("Expected " + length + " bytes but reached end of stream after " + data.length);
+    }
     return new String(data, StandardCharsets.UTF_8);
   }
 

--- a/ardor3d-core/src/main/java/com/ardor3d/util/export/binary/BinaryOutputCapsule.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/util/export/binary/BinaryOutputCapsule.java
@@ -1264,15 +1264,15 @@ public class BinaryOutputCapsule implements OutputCapsule {
 
   @Override
   public void write(final Enum<?>[] value, final String name) throws IOException {
-    if (value == null) {
-      write(NULL_OBJECT);
-    } else {
-      final String[] toWrite = new String[value.length];
+    // route both cases through the aliased String[] writer so a null array is handled like any other
+    String[] toWrite = null;
+    if (value != null) {
+      toWrite = new String[value.length];
       int i = 0;
       for (final Enum<?> val : value) {
         toWrite[i++] = val.name();
       }
-      write(toWrite, name, null);
     }
+    write(toWrite, name, null);
   }
 }

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/AllTypesHolder.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/AllTypesHolder.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
+import java.util.BitSet;
+
+import com.ardor3d.util.export.InputCapsule;
+import com.ardor3d.util.export.OutputCapsule;
+import com.ardor3d.util.export.Savable;
+
+/**
+ * Exhaustive test Savable carrying one field of every primitive scalar, 1D array, 2D array, buffer,
+ * BitSet, Enum and String type the capsule API supports. Used to prove the binary format round-trips
+ * each leaf type, and that no field desynchronises the ones written after it.
+ */
+public class AllTypesHolder implements Savable {
+
+  public enum Flavor {
+    ALPHA, BETA, GAMMA
+  }
+
+  public boolean z;
+  public byte b;
+  public short s;
+  public int i;
+  public long l;
+  public float f;
+  public double d;
+  public String str;
+  public Flavor en;
+
+  public boolean[] zArr;
+  public byte[] bArr;
+  public short[] sArr;
+  public int[] iArr;
+  public long[] lArr;
+  public float[] fArr;
+  public double[] dArr;
+  public String[] strArr;
+  public Flavor[] enArr;
+
+  public boolean[][] zArr2;
+  public byte[][] bArr2;
+  public short[][] sArr2;
+  public int[][] iArr2;
+  public long[][] lArr2;
+  public float[][] fArr2;
+  public double[][] dArr2;
+  public String[][] strArr2;
+
+  public ByteBuffer byteBuf;
+  public FloatBuffer floatBuf;
+  public IntBuffer intBuf;
+  public ShortBuffer shortBuf;
+
+  public BitSet bits;
+
+  public AllTypesHolder() {}
+
+  @Override
+  public Class<? extends AllTypesHolder> getClassTag() { return this.getClass(); }
+
+  @Override
+  public void write(final OutputCapsule capsule) throws IOException {
+    // scalar defaults are deliberately chosen to differ from the populated values so every field is
+    // actually emitted (the format omits fields equal to their default).
+    capsule.write(z, "z", false);
+    capsule.write(b, "b", (byte) 0);
+    capsule.write(s, "s", (short) 0);
+    capsule.write(i, "i", 0);
+    capsule.write(l, "l", 0L);
+    capsule.write(f, "f", 0f);
+    capsule.write(d, "d", 0.0);
+    capsule.write(str, "str", null);
+    capsule.write(en, "en", null);
+
+    capsule.write(zArr, "zArr", null);
+    capsule.write(bArr, "bArr", null);
+    capsule.write(sArr, "sArr", null);
+    capsule.write(iArr, "iArr", null);
+    capsule.write(lArr, "lArr", null);
+    capsule.write(fArr, "fArr", null);
+    capsule.write(dArr, "dArr", null);
+    capsule.write(strArr, "strArr", null);
+    capsule.write(enArr, "enArr");
+
+    capsule.write(zArr2, "zArr2", null);
+    capsule.write(bArr2, "bArr2", null);
+    capsule.write(sArr2, "sArr2", null);
+    capsule.write(iArr2, "iArr2", null);
+    capsule.write(lArr2, "lArr2", null);
+    capsule.write(fArr2, "fArr2", null);
+    capsule.write(dArr2, "dArr2", null);
+    capsule.write(strArr2, "strArr2", null);
+
+    capsule.write(byteBuf, "byteBuf", null);
+    capsule.write(floatBuf, "floatBuf", null);
+    capsule.write(intBuf, "intBuf", null);
+    capsule.write(shortBuf, "shortBuf", null);
+
+    capsule.write(bits, "bits", null);
+  }
+
+  @Override
+  public void read(final InputCapsule capsule) throws IOException {
+    z = capsule.readBoolean("z", false);
+    b = capsule.readByte("b", (byte) 0);
+    s = capsule.readShort("s", (short) 0);
+    i = capsule.readInt("i", 0);
+    l = capsule.readLong("l", 0L);
+    f = capsule.readFloat("f", 0f);
+    d = capsule.readDouble("d", 0.0);
+    str = capsule.readString("str", null);
+    en = capsule.readEnum("en", Flavor.class, null);
+
+    zArr = capsule.readBooleanArray("zArr", null);
+    bArr = capsule.readByteArray("bArr", null);
+    sArr = capsule.readShortArray("sArr", null);
+    iArr = capsule.readIntArray("iArr", null);
+    lArr = capsule.readLongArray("lArr", null);
+    fArr = capsule.readFloatArray("fArr", null);
+    dArr = capsule.readDoubleArray("dArr", null);
+    strArr = capsule.readStringArray("strArr", null);
+    enArr = capsule.readEnumArray("enArr", Flavor.class, null);
+
+    zArr2 = capsule.readBooleanArray2D("zArr2", null);
+    bArr2 = capsule.readByteArray2D("bArr2", null);
+    sArr2 = capsule.readShortArray2D("sArr2", null);
+    iArr2 = capsule.readIntArray2D("iArr2", null);
+    lArr2 = capsule.readLongArray2D("lArr2", null);
+    fArr2 = capsule.readFloatArray2D("fArr2", null);
+    dArr2 = capsule.readDoubleArray2D("dArr2", null);
+    strArr2 = capsule.readStringArray2D("strArr2", null);
+
+    byteBuf = capsule.readByteBuffer("byteBuf", null);
+    floatBuf = capsule.readFloatBuffer("floatBuf", null);
+    intBuf = capsule.readIntBuffer("intBuf", null);
+    shortBuf = capsule.readShortBuffer("shortBuf", null);
+
+    bits = capsule.readBitSet("bits", null);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/CollectionsHolder.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/CollectionsHolder.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.util.List;
+import java.util.Map;
+
+import com.ardor3d.util.export.InputCapsule;
+import com.ardor3d.util.export.OutputCapsule;
+import com.ardor3d.util.export.Savable;
+
+/**
+ * Test Savable exercising the Savable-graph collection writers/readers: object arrays, lists, list
+ * arrays, buffer lists, and the three map flavours (Savable->Savable, String->Savable,
+ * String->Object). Object arrays come back as runtime {@code Savable[]} so those fields are typed as
+ * such on purpose.
+ */
+public class CollectionsHolder implements Savable {
+
+  public Savable[] savArr;
+  public Savable[][] savArr2;
+  public List<SavableLeaf> savList;
+  public List<Savable>[] savListArr;
+  public List<FloatBuffer> floatBufList;
+  public List<ByteBuffer> byteBufList;
+  public Map<SavableLeaf, SavableLeaf> savMap;
+  public Map<String, SavableLeaf> strSavMap;
+  public Map<String, Object> strObjMap;
+
+  public CollectionsHolder() {}
+
+  @Override
+  public Class<? extends CollectionsHolder> getClassTag() { return this.getClass(); }
+
+  @Override
+  public void write(final OutputCapsule capsule) throws IOException {
+    capsule.write(savArr, "savArr", null);
+    capsule.write(savArr2, "savArr2", null);
+    capsule.writeSavableList(savList, "savList", null);
+    capsule.writeSavableListArray(savListArr, "savListArr", null);
+    capsule.writeFloatBufferList(floatBufList, "floatBufList", null);
+    capsule.writeByteBufferList(byteBufList, "byteBufList", null);
+    capsule.writeSavableMap(savMap, "savMap", null);
+    capsule.writeStringSavableMap(strSavMap, "strSavMap", null);
+    capsule.writeStringObjectMap(strObjMap, "strObjMap", null);
+  }
+
+  @Override
+  public void read(final InputCapsule capsule) throws IOException {
+    savArr = capsule.readSavableArray("savArr", null);
+    savArr2 = capsule.readSavableArray2D("savArr2", null);
+    savList = capsule.readSavableList("savList", null);
+    savListArr = capsule.readSavableListArray("savListArr", null);
+    floatBufList = capsule.readFloatBufferList("floatBufList", null);
+    byteBufList = capsule.readByteBufferList("byteBufList", null);
+    savMap = capsule.readSavableMap("savMap", null);
+    strSavMap = capsule.readStringSavableMap("strSavMap", null);
+    strObjMap = capsule.readStringObjectMap("strObjMap", null);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/RefHolder.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/RefHolder.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import java.io.IOException;
+
+import com.ardor3d.util.export.InputCapsule;
+import com.ardor3d.util.export.OutputCapsule;
+import com.ardor3d.util.export.Savable;
+
+/**
+ * Holder with two Savable reference slots and an int tag, used to test reference identity semantics:
+ * shared references collapsing to one instance, distinct-but-equal references staying distinct, and
+ * reference cycles surviving a round-trip.
+ */
+public class RefHolder implements Savable {
+
+  public Savable left;
+  public Savable right;
+  public int tag;
+
+  public RefHolder() {}
+
+  public RefHolder(final int tag) {
+    this.tag = tag;
+  }
+
+  @Override
+  public Class<? extends RefHolder> getClassTag() { return this.getClass(); }
+
+  @Override
+  public void write(final OutputCapsule capsule) throws IOException {
+    capsule.write(left, "left", null);
+    capsule.write(right, "right", null);
+    capsule.write(tag, "tag", 0);
+  }
+
+  @Override
+  public void read(final InputCapsule capsule) throws IOException {
+    left = capsule.readSavable("left", null);
+    right = capsule.readSavable("right", null);
+    tag = capsule.readInt("tag", 0);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/SavableLeaf.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/SavableLeaf.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import com.ardor3d.util.export.InputCapsule;
+import com.ardor3d.util.export.OutputCapsule;
+import com.ardor3d.util.export.Savable;
+
+/**
+ * Tiny value-bearing Savable used as the element type for collection / map / shared-reference tests.
+ * Carries content equality so restored graphs can be compared by value, while identity comparisons
+ * remain meaningful for shared-reference tests.
+ */
+public class SavableLeaf implements Savable {
+
+  public int id;
+  public String label;
+
+  public SavableLeaf() {}
+
+  public SavableLeaf(final int id, final String label) {
+    this.id = id;
+    this.label = label;
+  }
+
+  @Override
+  public Class<? extends SavableLeaf> getClassTag() { return this.getClass(); }
+
+  @Override
+  public void write(final OutputCapsule capsule) throws IOException {
+    capsule.write(id, "id", 0);
+    capsule.write(label, "label", null);
+  }
+
+  @Override
+  public void read(final InputCapsule capsule) throws IOException {
+    id = capsule.readInt("id", 0);
+    label = capsule.readString("label", null);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SavableLeaf other)) {
+      return false;
+    }
+    return id == other.id && Objects.equals(label, other.label);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, label);
+  }
+
+  @Override
+  public String toString() {
+    return "SavableLeaf[" + id + "," + label + "]";
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryClonerParity.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryClonerParity.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * {@link BinaryCloner} deep-copies through an in-memory export/import. These tests pin its contract:
+ * the copy is a fully independent object graph (mutating it never touches the source) yet preserves
+ * internal sharing (one instance referenced twice stays shared in the copy).
+ */
+public class TestBinaryClonerParity {
+
+  @Test
+  public void testCopyIsIndependentButContentEqual() {
+    final RefHolder src = new RefHolder(5);
+    src.left = new SavableLeaf(1, "a");
+    src.right = new SavableLeaf(2, "b");
+
+    final RefHolder copy = new BinaryCloner().copy(src);
+
+    assertNotSame(src, copy);
+    assertNotSame(src.left, copy.left);
+    assertEquals(5, copy.tag);
+    assertEquals(src.left, copy.left);
+    assertEquals(src.right, copy.right);
+
+    // mutating the copy must not bleed back into the source
+    ((SavableLeaf) copy.left).id = 999;
+    copy.tag = -1;
+    assertEquals(1, ((SavableLeaf) src.left).id);
+    assertEquals(5, src.tag);
+  }
+
+  @Test
+  public void testCopyPreservesInternalSharing() {
+    final RefHolder src = new RefHolder(0);
+    final SavableLeaf shared = new SavableLeaf(8, "shared");
+    src.left = shared;
+    src.right = shared;
+
+    final RefHolder copy = new BinaryCloner().copy(src);
+
+    assertNotSame(shared, copy.left);
+    assertSame("shared sub-graph must remain shared in the clone", copy.left, copy.right);
+  }
+
+  @Test
+  public void testCopyPreservesCycles() {
+    final RefHolder a = new RefHolder(1);
+    final RefHolder b = new RefHolder(2);
+    a.left = b;
+    b.left = a;
+
+    final RefHolder copy = new BinaryCloner().copy(a);
+
+    assertNotSame(a, copy);
+    assertSame("clone of a cyclic graph must be cyclic too", copy, ((RefHolder) copy.left).left);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryCollectionsRoundTrip.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryCollectionsRoundTrip.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.ardor3d.buffer.BufferUtils;
+
+/**
+ * Round-trips the Savable-graph collection types - object arrays, lists, list-arrays, buffer lists
+ * and the three map flavours. Together with {@link TestBinaryRoundTrip} this covers the full capsule
+ * write/read surface.
+ */
+public class TestBinaryCollectionsRoundTrip {
+
+  private static float[] toArray(final FloatBuffer b) {
+    final FloatBuffer dup = b.duplicate();
+    dup.rewind();
+    final float[] a = new float[dup.remaining()];
+    dup.get(a);
+    return a;
+  }
+
+  private static byte[] toArray(final ByteBuffer b) {
+    final ByteBuffer dup = b.duplicate();
+    dup.rewind();
+    final byte[] a = new byte[dup.remaining()];
+    dup.get(a);
+    return a;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testSavableCollectionsRoundTrip() throws Exception {
+    final CollectionsHolder h = new CollectionsHolder();
+
+    h.savArr = new SavableLeaf[] {new SavableLeaf(1, "one"), new SavableLeaf(2, "two")};
+    h.savArr2 = new SavableLeaf[][] {{new SavableLeaf(3, "three")}, {new SavableLeaf(4, "four"), new SavableLeaf(5, "five")}};
+    h.savList = Arrays.asList(new SavableLeaf(10, "ten"), new SavableLeaf(11, "eleven"));
+    h.savListArr = new List[] {Arrays.asList(new SavableLeaf(20, "twenty")),
+        Arrays.asList(new SavableLeaf(21, "t21"), new SavableLeaf(22, "tt"))};
+    h.floatBufList =
+        Arrays.asList(BufferUtils.createFloatBuffer(1f, 2f), BufferUtils.createFloatBuffer(3f, 4f, 5f));
+    h.byteBufList = Arrays.asList((ByteBuffer) BufferUtils.createByteBuffer(2).put(new byte[] {7, 8}).flip(),
+        (ByteBuffer) BufferUtils.createByteBuffer(1).put(new byte[] {9}).flip());
+
+    h.savMap = new LinkedHashMap<>();
+    h.savMap.put(new SavableLeaf(100, "k1"), new SavableLeaf(200, "v1"));
+    h.savMap.put(new SavableLeaf(101, "k2"), new SavableLeaf(201, "v2"));
+
+    h.strSavMap = new LinkedHashMap<>();
+    h.strSavMap.put("alpha", new SavableLeaf(300, "a"));
+    h.strSavMap.put("beta", new SavableLeaf(301, "b"));
+
+    h.strObjMap = new LinkedHashMap<>();
+    h.strObjMap.put("anInt", Integer.valueOf(7));
+    h.strObjMap.put("aStr", "hello");
+    h.strObjMap.put("aFloatArr", new float[] {1.5f, 2.5f});
+    h.strObjMap.put("aSavable", new SavableLeaf(42, "deep"));
+
+    final CollectionsHolder r = (CollectionsHolder) TestBinaryRoundTrip.roundTrip(h);
+
+    // object arrays - come back as Savable[] with SavableLeaf elements
+    assertArrayEquals(h.savArr, r.savArr);
+    assertEquals(2, r.savArr2.length);
+    assertArrayEquals(h.savArr2[0], r.savArr2[0]);
+    assertArrayEquals(h.savArr2[1], r.savArr2[1]);
+
+    // lists
+    assertEquals(h.savList, r.savList);
+    assertEquals(2, r.savListArr.length);
+    assertEquals(h.savListArr[0], r.savListArr[0]);
+    assertEquals(h.savListArr[1], r.savListArr[1]);
+
+    // buffer lists
+    assertEquals(2, r.floatBufList.size());
+    assertArrayEquals(new float[] {1f, 2f}, toArray(r.floatBufList.get(0)), 0f);
+    assertArrayEquals(new float[] {3f, 4f, 5f}, toArray(r.floatBufList.get(1)), 0f);
+    assertEquals(2, r.byteBufList.size());
+    assertArrayEquals(new byte[] {7, 8}, toArray(r.byteBufList.get(0)));
+    assertArrayEquals(new byte[] {9}, toArray(r.byteBufList.get(1)));
+
+    // maps
+    assertEquals(h.savMap, r.savMap);
+    assertEquals(h.strSavMap, r.strSavMap);
+
+    // string->object map: assert each typed value individually
+    assertEquals(Integer.valueOf(7), r.strObjMap.get("anInt"));
+    assertEquals("hello", r.strObjMap.get("aStr"));
+    assertArrayEquals(new float[] {1.5f, 2.5f}, (float[]) r.strObjMap.get("aFloatArr"), 0f);
+    assertEquals(new SavableLeaf(42, "deep"), r.strObjMap.get("aSavable"));
+  }
+
+  /**
+   * An empty Savable list must survive as an empty (non-null) list, distinct from an unset/null one.
+   */
+  @Test
+  public void testEmptyAndNullCollections() throws Exception {
+    final CollectionsHolder h = new CollectionsHolder();
+    h.savList = List.of();
+    h.savArr = new SavableLeaf[0];
+
+    final CollectionsHolder r = (CollectionsHolder) TestBinaryRoundTrip.roundTrip(h);
+
+    assertTrue(r.savList != null && r.savList.isEmpty());
+    assertEquals(0, r.savArr.length);
+    // unset map fields stay null
+    assertEquals(null, r.savMap);
+    assertEquals(null, r.strObjMap);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryDefaultOmission.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryDefaultOmission.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.BitSet;
+
+import org.junit.Test;
+
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.util.export.binary.AllTypesHolder.Flavor;
+
+/**
+ * The binary format omits any field equal to its default and walks the per-object field stream by a
+ * leading alias byte. A field that emits the wrong number of bytes (e.g. latent bug #3) would shift
+ * every following alias and silently corrupt subsequent fields. These tests scatter present and
+ * omitted fields of differing widths - including a variable-length buffer in the middle - to prove
+ * the alias walk stays synchronised regardless of which fields were written.
+ */
+public class TestBinaryDefaultOmission {
+
+  @Test
+  public void testScatteredPresentAndOmittedFieldsStayInSync() throws Exception {
+    final AllTypesHolder h = new AllTypesHolder();
+    // populate a non-contiguous subset spread across the whole field order; leave the rest default.
+    h.b = (byte) 42;
+    h.d = 9.99;
+    h.en = Flavor.BETA;
+    h.iArr = new int[] {7, 8, 9};
+    h.floatBuf = BufferUtils.createFloatBuffer(1f, 2f, 3f, 4f, 5f); // variable-length field mid-stream
+    h.bits = new BitSet();
+    h.bits.set(3);
+    h.bits.set(70);
+
+    final AllTypesHolder r = (AllTypesHolder) TestBinaryRoundTrip.roundTrip(h);
+
+    // the populated fields survive, in spite of the omitted neighbours between them
+    assertEquals((byte) 42, r.b);
+    assertEquals(9.99, r.d, 0.0);
+    assertEquals(Flavor.BETA, r.en);
+    assertArrayEquals(new int[] {7, 8, 9}, r.iArr);
+    final float[] fb = new float[r.floatBuf.remaining()];
+    r.floatBuf.duplicate().get(fb);
+    assertArrayEquals(new float[] {1f, 2f, 3f, 4f, 5f}, fb, 0f);
+    assertEquals(h.bits, r.bits);
+
+    // the omitted fields come back as their read-side defaults, not as garbage shifted in from a
+    // neighbouring field
+    assertEquals(false, r.z);
+    assertEquals(0, r.s);
+    assertEquals(0, r.i);
+    assertEquals(0L, r.l);
+    assertEquals(0f, r.f, 0f);
+    assertNull(r.str);
+    assertNull(r.lArr);
+    assertNull(r.strArr2);
+    assertNull(r.intBuf);
+  }
+
+  /**
+   * A value that happens to equal its declared default is intentionally not written, and must come
+   * back as that default - the omission is invisible to the caller.
+   */
+  @Test
+  public void testValueEqualToDefaultRoundTripsAsDefault() throws Exception {
+    final AllTypesHolder h = new AllTypesHolder();
+    h.i = 0; // equals the default passed to write(...,0) -> omitted
+    h.str = null; // equals default -> omitted
+    h.f = 5f; // not the default -> written
+
+    final AllTypesHolder r = (AllTypesHolder) TestBinaryRoundTrip.roundTrip(h);
+
+    assertEquals(0, r.i);
+    assertNull(r.str);
+    assertEquals(5f, r.f, 0f);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryImporterReadString.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryImporterReadString.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+/**
+ * BinaryImporter.readString(InputStream, length) - used to parse class and field names from the
+ * header - filled its buffer with a single read() call and ignored the count. A stream returning
+ * fewer bytes than requested (legal for the BufferedInputStream/GZIPInputStream it actually reads
+ * through) left the name truncated with trailing NULs. This feeds one byte per read to make the
+ * short read deterministic.
+ */
+public class TestBinaryImporterReadString {
+
+  private static final class OneBytePerReadStream extends ByteArrayInputStream {
+    OneBytePerReadStream(final byte[] buf) {
+      super(buf);
+    }
+
+    @Override
+    public synchronized int read(final byte[] b, final int off, final int len) {
+      return super.read(b, off, Math.min(len, 1));
+    }
+  }
+
+  @Test
+  public void testReadStringSurvivesShortReads() throws Exception {
+    final String value = "com.ardor3d.scenegraph.Node"; // representative of a header class name
+    final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+
+    final String result = new BinaryImporter().readString(new OneBytePerReadStream(bytes), bytes.length);
+
+    assertEquals(value, result);
+  }
+
+  /**
+   * A corrupt/tampered header can decode a negative length. That must surface as an IOException (the
+   * importer's declared corrupt-file channel), not an unchecked IllegalArgumentException out of
+   * readNBytes that bypasses callers' catch (IOException) handling.
+   */
+  @Test(expected = IOException.class)
+  public void testNegativeLengthThrowsIOException() throws Exception {
+    new BinaryImporter().readString(new ByteArrayInputStream(new byte[] {1, 2, 3}), -1);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryRoundTrip.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinaryRoundTrip.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
+import java.util.BitSet;
+
+import org.junit.Test;
+
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.util.export.Savable;
+import com.ardor3d.util.export.binary.AllTypesHolder.Flavor;
+
+/**
+ * Round-trips every leaf type the capsule API supports (scalars, 1D/2D arrays, all four nio buffer
+ * kinds, BitSet, Enum and String) through {@link BinaryExporter}/{@link BinaryImporter} and asserts
+ * each value survives intact. This is the GL-independent persistence net the codebase lacked; it
+ * exercises exactly the machinery that latent serialization bugs (heap-buffer length desync, wrong
+ * capsule keys) corrupted.
+ */
+public class TestBinaryRoundTrip {
+
+  static Savable roundTrip(final Savable in) throws Exception {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new BinaryExporter().save(in, out);
+    return new BinaryImporter().load(new ByteArrayInputStream(out.toByteArray()));
+  }
+
+  private static float[] toArray(final FloatBuffer b) {
+    final FloatBuffer dup = b.duplicate();
+    dup.rewind();
+    final float[] a = new float[dup.remaining()];
+    dup.get(a);
+    return a;
+  }
+
+  private static int[] toArray(final IntBuffer b) {
+    final IntBuffer dup = b.duplicate();
+    dup.rewind();
+    final int[] a = new int[dup.remaining()];
+    dup.get(a);
+    return a;
+  }
+
+  private static short[] toArray(final ShortBuffer b) {
+    final ShortBuffer dup = b.duplicate();
+    dup.rewind();
+    final short[] a = new short[dup.remaining()];
+    dup.get(a);
+    return a;
+  }
+
+  private static byte[] toArray(final ByteBuffer b) {
+    final ByteBuffer dup = b.duplicate();
+    dup.rewind();
+    final byte[] a = new byte[dup.remaining()];
+    dup.get(a);
+    return a;
+  }
+
+  @Test
+  public void testEveryLeafTypeRoundTrips() throws Exception {
+    final AllTypesHolder h = new AllTypesHolder();
+    h.z = true;
+    h.b = (byte) -7;
+    h.s = (short) 1234;
+    h.i = 0x0BADBEEF;
+    h.l = 0x0123456789ABCDEFL;
+    h.f = 3.14159f;
+    h.d = -2.718281828459045;
+    h.str = "héllo·wörld"; // multi-byte UTF-8 to catch byte-length bugs
+    h.en = Flavor.GAMMA;
+
+    h.zArr = new boolean[] {true, false, true};
+    h.bArr = new byte[] {1, -2, 3, -128, 127};
+    h.sArr = new short[] {-32768, 0, 32767};
+    h.iArr = new int[] {Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE};
+    h.lArr = new long[] {Long.MIN_VALUE, 0L, Long.MAX_VALUE};
+    h.fArr = new float[] {Float.NEGATIVE_INFINITY, -0.5f, 0f, 0.5f, Float.POSITIVE_INFINITY};
+    h.dArr = new double[] {Double.MIN_VALUE, 0.0, Double.MAX_VALUE};
+    h.strArr = new String[] {"a", "", "déjà"};
+    h.enArr = new Flavor[] {Flavor.BETA, Flavor.ALPHA};
+
+    h.zArr2 = new boolean[][] {{true}, {false, true}};
+    h.bArr2 = new byte[][] {{1, 2}, {3}};
+    h.sArr2 = new short[][] {{10, 20}, {30}};
+    h.iArr2 = new int[][] {{1, 2, 3}, {4, 5}};
+    h.lArr2 = new long[][] {{1L}, {2L, 3L}};
+    h.fArr2 = new float[][] {{1.5f, 2.5f}, {3.5f}};
+    h.dArr2 = new double[][] {{1.25}, {2.25, 3.25}};
+    h.strArr2 = new String[][] {{"x", "y"}, {"z"}};
+
+    h.byteBuf = (ByteBuffer) BufferUtils.createByteBuffer(3).put(new byte[] {9, 8, 7}).flip();
+    h.floatBuf = BufferUtils.createFloatBuffer(1.1f, 2.2f, 3.3f, 4.4f);
+    h.intBuf = BufferUtils.createIntBuffer(100, 200, 300);
+    h.shortBuf = BufferUtils.createShortBuffer(new short[] {5, 6, 7, 8});
+
+    h.bits = new BitSet();
+    h.bits.set(1);
+    h.bits.set(64);
+    h.bits.set(200);
+
+    final AllTypesHolder r = (AllTypesHolder) roundTrip(h);
+
+    assertEquals(h.z, r.z);
+    assertEquals(h.b, r.b);
+    assertEquals(h.s, r.s);
+    assertEquals(h.i, r.i);
+    assertEquals(h.l, r.l);
+    assertEquals(h.f, r.f, 0f);
+    assertEquals(h.d, r.d, 0.0);
+    assertEquals(h.str, r.str);
+    assertEquals(h.en, r.en);
+
+    assertArrayEquals(h.zArr, r.zArr);
+    assertArrayEquals(h.bArr, r.bArr);
+    assertArrayEquals(h.sArr, r.sArr);
+    assertArrayEquals(h.iArr, r.iArr);
+    assertArrayEquals(h.lArr, r.lArr);
+    assertArrayEquals(h.fArr, r.fArr, 0f);
+    assertArrayEquals(h.dArr, r.dArr, 0.0);
+    assertArrayEquals(h.strArr, r.strArr);
+    assertArrayEquals(h.enArr, r.enArr);
+
+    assertArrayEquals(h.zArr2, r.zArr2);
+    assertArrayEquals(h.bArr2, r.bArr2);
+    assertArrayEquals(h.sArr2, r.sArr2);
+    assertArrayEquals(h.iArr2, r.iArr2);
+    assertArrayEquals(h.lArr2, r.lArr2);
+    for (int row = 0; row < h.fArr2.length; row++) {
+      assertArrayEquals(h.fArr2[row], r.fArr2[row], 0f);
+    }
+    for (int row = 0; row < h.dArr2.length; row++) {
+      assertArrayEquals(h.dArr2[row], r.dArr2[row], 0.0);
+    }
+    assertArrayEquals(h.strArr2, r.strArr2);
+
+    assertArrayEquals(new byte[] {9, 8, 7}, toArray(r.byteBuf));
+    assertArrayEquals(new float[] {1.1f, 2.2f, 3.3f, 4.4f}, toArray(r.floatBuf), 0f);
+    assertArrayEquals(new int[] {100, 200, 300}, toArray(r.intBuf));
+    assertArrayEquals(new short[] {5, 6, 7, 8}, toArray(r.shortBuf));
+
+    assertEquals(h.bits, r.bits);
+  }
+
+  /**
+   * A freshly-constructed holder writes nothing but defaults; everything must come back null/default
+   * rather than as empty-but-non-null artifacts.
+   */
+  @Test
+  public void testAllDefaultsRoundTripAsNull() throws Exception {
+    final AllTypesHolder r = (AllTypesHolder) roundTrip(new AllTypesHolder());
+
+    assertEquals(false, r.z);
+    assertEquals(0, r.i);
+    assertEquals(0.0, r.d, 0.0);
+    assertNull(r.str);
+    assertNull(r.en);
+    assertNull(r.iArr);
+    assertNull(r.strArr2);
+    assertNull(r.floatBuf);
+    assertNull(r.bits);
+  }
+
+  /**
+   * Zero-length arrays and buffers are a distinct case from null: an empty array must restore as a
+   * non-null length-0 array, not collapse to null.
+   */
+  @Test
+  public void testEmptyArraysAndBuffersRoundTrip() throws Exception {
+    final AllTypesHolder h = new AllTypesHolder();
+    h.iArr = new int[0];
+    h.strArr = new String[0];
+    h.fArr2 = new float[0][];
+    h.floatBuf = BufferUtils.createFloatBuffer(0);
+    h.byteBuf = BufferUtils.createByteBuffer(0);
+    h.bits = new BitSet(); // empty bitset
+
+    final AllTypesHolder r = (AllTypesHolder) roundTrip(h);
+
+    assertNotNull(r.iArr);
+    assertEquals(0, r.iArr.length);
+    assertNotNull(r.strArr);
+    assertEquals(0, r.strArr.length);
+    assertNotNull(r.fArr2);
+    assertEquals(0, r.fArr2.length);
+    assertNotNull(r.floatBuf);
+    assertEquals(0, r.floatBuf.remaining());
+    assertNotNull(r.byteBuf);
+    assertEquals(0, r.byteBuf.remaining());
+    assertNotNull(r.bits);
+    assertTrue(r.bits.isEmpty());
+  }
+
+  /**
+   * String arrays with embedded nulls round-trip those null slots (the per-element length is encoded
+   * specially, so a null element must not be confused with an empty string).
+   */
+  @Test
+  public void testStringArrayWithNullElement() throws Exception {
+    final AllTypesHolder h = new AllTypesHolder();
+    h.strArr = new String[] {"first", null, "", "last"};
+
+    final AllTypesHolder r = (AllTypesHolder) roundTrip(h);
+
+    assertArrayEquals(new String[] {"first", null, "", "last"}, r.strArr);
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinarySavableGraphRoundTrip.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinarySavableGraphRoundTrip.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.FloatBuffer;
+
+import org.junit.Test;
+
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.buffer.IndexBufferData;
+import com.ardor3d.math.Transform;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.scenegraph.Mesh;
+import com.ardor3d.scenegraph.MeshData;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.Spatial;
+
+/**
+ * The "protects real user data" test: build a representative scene graph (a transformed Node parent
+ * with a transformed Mesh child whose MeshData carries vertex / normal / color buffers and an index
+ * buffer), serialize it with {@link BinaryExporter}, reload with {@link BinaryImporter}, and assert
+ * the hierarchy, names, transforms and every buffer survive byte-for-byte. This is the scenario the
+ * serialization landmines (#3 heap-buffer desync, #4 wrong transform key) silently corrupted.
+ */
+public class TestBinarySavableGraphRoundTrip {
+
+  private static float[] toArray(final FloatBuffer b) {
+    final FloatBuffer dup = b.duplicate();
+    dup.rewind();
+    final float[] a = new float[dup.remaining()];
+    dup.get(a);
+    return a;
+  }
+
+  @Test
+  public void testSceneGraphRoundTrips() throws Exception {
+    final float[] verts = {0, 0, 0, 1, 0, 0, 1, 1, 0};
+    final float[] normals = {0, 0, 1, 0, 0, 1, 0, 0, 1};
+    final float[] colors = {1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1};
+    final int[] indices = {0, 1, 2};
+
+    final Node root = new Node("root");
+    final Transform rootXf = new Transform();
+    rootXf.setTranslation(1, 2, 3);
+    rootXf.setScale(2.0);
+    root.setTransform(rootXf);
+
+    final Mesh geo = new Mesh("geo");
+    final MeshData md = new MeshData();
+    md.setVertexBuffer(BufferUtils.createFloatBuffer(verts));
+    md.setNormalBuffer(BufferUtils.createFloatBuffer(normals));
+    md.setColorBuffer(BufferUtils.createFloatBuffer(colors));
+    md.setIndices(BufferUtils.createIndexBufferData(indices, 2));
+    geo.setMeshData(md);
+    final Transform geoXf = new Transform();
+    geoXf.setTranslation(-5, 0.5, 10);
+    geo.setTransform(geoXf);
+
+    root.attachChild(geo);
+
+    // round-trip
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new BinaryExporter().save(root, out);
+    final Node r = (Node) new BinaryImporter().load(new ByteArrayInputStream(out.toByteArray()));
+
+    // hierarchy + names
+    assertEquals("root", r.getName());
+    assertEquals(1, r.getNumberOfChildren());
+    final Spatial child = r.getChild(0);
+    assertTrue("child must deserialize as a Mesh", child instanceof Mesh);
+    assertEquals("geo", child.getName());
+
+    // transforms (local)
+    assertEquals(new Vector3(1, 2, 3), r.getTransform().getTranslation());
+    assertEquals(2.0, r.getTransform().getScale().getX(), 0.0);
+    assertEquals(new Vector3(-5, 0.5, 10), child.getTransform().getTranslation());
+
+    // mesh data buffers
+    final MeshData rmd = ((Mesh) child).getMeshData();
+    assertArrayEquals(verts, toArray(rmd.getVertexBuffer()), 0f);
+    assertArrayEquals(normals, toArray(rmd.getNormalBuffer()), 0f);
+    assertArrayEquals(colors, toArray(rmd.getColorBuffer()), 0f);
+
+    final IndexBufferData<?> ri = rmd.getIndices();
+    assertEquals(indices.length, ri.getBufferLimit());
+    for (int i = 0; i < indices.length; i++) {
+      assertEquals(indices[i], ri.get(i));
+    }
+  }
+
+  /**
+   * A deeper, branching hierarchy must keep its exact shape (child counts at each level) after a
+   * round-trip.
+   */
+  @Test
+  public void testNestedHierarchyShapePreserved() throws Exception {
+    final Node root = new Node("root");
+    final Node branchA = new Node("a");
+    final Node branchB = new Node("b");
+    branchA.attachChild(new Node("a1"));
+    branchA.attachChild(new Node("a2"));
+    branchB.attachChild(new Node("b1"));
+    root.attachChild(branchA);
+    root.attachChild(branchB);
+
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new BinaryExporter().save(root, out);
+    final Node r = (Node) new BinaryImporter().load(new ByteArrayInputStream(out.toByteArray()));
+
+    assertEquals(2, r.getNumberOfChildren());
+    final Node ra = (Node) r.getChild(0);
+    final Node rb = (Node) r.getChild(1);
+    assertEquals("a", ra.getName());
+    assertEquals(2, ra.getNumberOfChildren());
+    assertEquals("b", rb.getName());
+    assertEquals(1, rb.getNumberOfChildren());
+    assertEquals("a1", ra.getChild(0).getName());
+    assertEquals("a2", ra.getChild(1).getName());
+    assertEquals("b1", rb.getChild(0).getName());
+  }
+}

--- a/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinarySharedReference.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/export/binary/TestBinarySharedReference.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export.binary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * The format keys saved objects by identity and caches restored objects by id, so a graph that
+ * references the same instance twice must restore as a single shared instance, a cycle must restore
+ * as a cycle, and two distinct-but-equal instances must stay distinct. These invariants are what let
+ * the binary format double as a structure-preserving deep-copy.
+ */
+public class TestBinarySharedReference {
+
+  /** The same instance referenced from two slots must restore as one shared instance. */
+  @Test
+  public void testSharedReferenceCollapsesToOneInstance() throws Exception {
+    final RefHolder root = new RefHolder(1);
+    final SavableLeaf shared = new SavableLeaf(7, "shared");
+    root.left = shared;
+    root.right = shared;
+
+    final RefHolder r = (RefHolder) TestBinaryRoundTrip.roundTrip(root);
+
+    assertNotNull(r.left);
+    assertSame("a single instance referenced twice must stay a single instance", r.left, r.right);
+    assertEquals(shared, r.left);
+  }
+
+  /** Two distinct instances with equal content must remain two distinct instances. */
+  @Test
+  public void testDistinctButEqualReferencesStayDistinct() throws Exception {
+    final RefHolder root = new RefHolder(2);
+    root.left = new SavableLeaf(7, "same");
+    root.right = new SavableLeaf(7, "same");
+
+    final RefHolder r = (RefHolder) TestBinaryRoundTrip.roundTrip(root);
+
+    assertEquals(r.left, r.right); // equal by content
+    assertNotSame("distinct instances must not be merged on load", r.left, r.right);
+  }
+
+  /** A reference cycle (a<->b) must round-trip back into a cycle, not infinite-recurse or break. */
+  @Test
+  public void testReferenceCycleSurvives() throws Exception {
+    final RefHolder a = new RefHolder(10);
+    final RefHolder b = new RefHolder(20);
+    a.left = b;
+    b.left = a;
+
+    final RefHolder ra = (RefHolder) TestBinaryRoundTrip.roundTrip(a);
+
+    assertEquals(10, ra.tag);
+    final RefHolder rb = (RefHolder) ra.left;
+    assertNotNull(rb);
+    assertEquals(20, rb.tag);
+    assertSame("the cycle must close back on the original instance", ra, rb.left);
+  }
+
+  /** Null reference slots round-trip as null. */
+  @Test
+  public void testNullReferencesRoundTrip() throws Exception {
+    final RefHolder root = new RefHolder(3);
+    root.left = new SavableLeaf(1, "only-left");
+    root.right = null;
+
+    final RefHolder r = (RefHolder) TestBinaryRoundTrip.roundTrip(root);
+
+    assertNotNull(r.left);
+    assertNull(r.right);
+  }
+}

--- a/ardor3d-savable/src/main/java/com/ardor3d/util/export/ByteUtils.java
+++ b/ardor3d-savable/src/main/java/com/ardor3d/util/export/ByteUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,6 +11,7 @@
 package com.ardor3d.util.export;
 
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -91,7 +92,7 @@ public abstract class ByteUtils {
     final byte[] byteArray = new byte[2];
 
     // Read in the next 2 bytes
-    inputStream.read(byteArray);
+    readFully(inputStream, byteArray);
 
     final short number = convertShortFromBytes(byteArray);
 
@@ -151,7 +152,7 @@ public abstract class ByteUtils {
     final byte[] byteArray = new byte[4];
 
     // Read in the next 4 bytes
-    inputStream.read(byteArray);
+    readFully(inputStream, byteArray);
 
     final int number = convertIntFromBytes(byteArray);
 
@@ -224,7 +225,7 @@ public abstract class ByteUtils {
     final byte[] byteArray = new byte[8];
 
     // Read in the next 8 bytes
-    inputStream.read(byteArray);
+    readFully(inputStream, byteArray);
 
     final long number = convertLongFromBytes(byteArray);
 
@@ -281,7 +282,7 @@ public abstract class ByteUtils {
     final byte[] byteArray = new byte[8];
 
     // Read in the next 8 bytes
-    inputStream.read(byteArray);
+    readFully(inputStream, byteArray);
 
     final double number = convertDoubleFromBytes(byteArray);
 
@@ -336,7 +337,7 @@ public abstract class ByteUtils {
     final byte[] byteArray = new byte[4];
 
     // Read in the next 4 bytes
-    inputStream.read(byteArray);
+    readFully(inputStream, byteArray);
 
     final float number = convertFloatFromBytes(byteArray);
 
@@ -392,7 +393,7 @@ public abstract class ByteUtils {
     final byte[] byteArray = new byte[1];
 
     // Read in the next byte
-    inputStream.read(byteArray);
+    readFully(inputStream, byteArray);
 
     return convertBooleanFromBytes(byteArray);
   }
@@ -403,6 +404,25 @@ public abstract class ByteUtils {
 
   public static boolean convertBooleanFromBytes(final byte[] byteArray, final int offset) {
     return byteArray[offset] != 0;
+  }
+
+  /**
+   * Fill the given array completely from the stream, looping until it is full. A single
+   * InputStream.read can legally return fewer bytes than requested (notably through buffered or
+   * inflating streams), so callers that need an exact count must not trust one read.
+   *
+   * @throws EOFException
+   *           if the stream ends before the array is filled.
+   */
+  private static void readFully(final InputStream inputStream, final byte[] bytes) throws IOException {
+    int pos = 0;
+    while (pos < bytes.length) {
+      final int read = inputStream.read(bytes, pos, bytes.length - pos);
+      if (read < 0) {
+        throw new EOFException("Expected " + bytes.length + " bytes but reached end of stream after " + pos);
+      }
+      pos += read;
+    }
   }
 
   public static byte[] rightAlignBytes(final byte[] bytes, final int width) {

--- a/ardor3d-savable/src/test/java/com/ardor3d/util/export/TestByteUtilsShortRead.java
+++ b/ardor3d-savable/src/test/java/com/ardor3d/util/export/TestByteUtilsShortRead.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.export;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+
+import org.junit.Test;
+
+/**
+ * The ByteUtils.read* helpers fill a fixed-size array with a single InputStream.read() call and
+ * ignore its return count. A stream that hands back fewer bytes than requested - exactly what
+ * BufferedInputStream/GZIPInputStream are permitted to do at buffer boundaries - then leaves the
+ * trailing bytes zeroed, silently corrupting the decoded value. These tests feed a stream that
+ * returns one byte per call so the short read is deterministic.
+ */
+public class TestByteUtilsShortRead {
+
+  /** An InputStream that hands back at most one byte per read(byte[], int, int) call. */
+  private static final class OneBytePerReadStream extends ByteArrayInputStream {
+    OneBytePerReadStream(final byte[] buf) {
+      super(buf);
+    }
+
+    @Override
+    public synchronized int read(final byte[] b, final int off, final int len) {
+      return super.read(b, off, Math.min(len, 1));
+    }
+  }
+
+  @Test
+  public void testReadShortSurvivesShortReads() throws Exception {
+    final short value = (short) 0x1234;
+    assertEquals(value, ByteUtils.readShort(new OneBytePerReadStream(ByteUtils.convertToBytes(value))));
+  }
+
+  @Test
+  public void testReadIntSurvivesShortReads() throws Exception {
+    final int value = 0x01020304;
+    assertEquals(value, ByteUtils.readInt(new OneBytePerReadStream(ByteUtils.convertToBytes(value))));
+  }
+
+  @Test
+  public void testReadLongSurvivesShortReads() throws Exception {
+    final long value = 0x0102030405060708L;
+    assertEquals(value, ByteUtils.readLong(new OneBytePerReadStream(ByteUtils.convertToBytes(value))));
+  }
+
+  @Test
+  public void testReadFloatSurvivesShortReads() throws Exception {
+    final float value = 3.14159f;
+    assertEquals(value, ByteUtils.readFloat(new OneBytePerReadStream(ByteUtils.convertToBytes(value))), 0f);
+  }
+
+  @Test
+  public void testReadDoubleSurvivesShortReads() throws Exception {
+    final double value = -2.718281828459045;
+    assertEquals(value, ByteUtils.readDouble(new OneBytePerReadStream(ByteUtils.convertToBytes(value))), 0.0);
+  }
+
+  /** A genuinely truncated stream must fail loudly rather than return a half-read value. */
+  @Test(expected = EOFException.class)
+  public void testReadIntOnTruncatedStreamThrows() throws Exception {
+    ByteUtils.readInt(new ByteArrayInputStream(new byte[] {1, 2})); // only 2 of 4 bytes
+  }
+}


### PR DESCRIPTION
Adds the GL-independent serialization regression net the format lacked and closes the remaining binary-format findings from the codebase evaluation.

- Round-trip tests over the full capsule type surface (scalars, 1D/2D arrays, all four nio buffers, BitSet, Enum, String), Savable collections (lists, the three map flavours, list-arrays, buffer-lists), shared-reference and cycle identity, BinaryCloner deep-copy parity, and a real Node/Mesh/MeshData graph. ardor3d-savable and ardor3d-collada gain their first tests.
- Retire the reflective setAccessible+field.set Savable.read pattern across all 12 sites (10 animation, 2 collada): drop final and assign fields directly.
- Fix BinaryOutputCapsule.write(Enum[], name) emitting an alias-less NULL_OBJECT for a null array, which desynced the whole object's field stream on load (reachable via MeshData._indexModes); route the null case through the aliased String[] writer so it is simply omitted.
- Add the missing @SavableFactory to InterpolatedFloatChannel and InterpolatedDoubleChannel, which previously threw IllegalAccessException on load (un-deserializable, including via the XML importer).
- Fix AnimationItem.read reflecting into AnimationClip's _name field on an AnimationItem, which threw on every load and silently dropped the name.
- Read fixed-size header fields fully in ByteUtils.read* and BinaryImporter.readString rather than trusting a single InputStream.read; throw EOFException on truncation and IOException on a negative length instead of silently zero-padding, and close the stream in load(URL/File/byte[]).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed serialization and deserialization of animation clips, skeletons, and animation channels to preserve data correctly during save/load cycles
- Improved robustness when reading corrupted or truncated files with enhanced end-of-file detection
- Fixed resource leaks by properly closing file streams during import operations

**Tests**
- Added extensive test coverage for serialization round-trips of animation and scene graph objects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->