### PR TITLE
Fix equals/hashCode contracts on ResourceLocator and Tile

### DIFF
--- a/ardor3d-core/src/main/java/com/ardor3d/util/resource/SimpleResourceLocator.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/util/resource/SimpleResourceLocator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Objects;
 
 /**
  * This locator takes a base location for finding resources specified with a relative path. If it
@@ -143,5 +144,13 @@ public class SimpleResourceLocator implements ResourceLocator {
       return _baseDir.equals(((SimpleResourceLocator) obj)._baseDir);
     }
     return false;
+  }
+
+  @Override
+  public int hashCode() {
+    // Keyed on the base dir only, and intentionally inherited by MultiFormatResourceLocator: equals
+    // above treats any SimpleResourceLocator with a matching base dir as equal, so a base-dir-only
+    // hash is what keeps the equals/hashCode contract consistent across both types.
+    return Objects.hashCode(_baseDir);
   }
 }

--- a/ardor3d-core/src/test/java/com/ardor3d/util/resource/TestResourceLocatorHashCode.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/util/resource/TestResourceLocatorHashCode.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.util.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+/**
+ * SimpleResourceLocator and MultiFormatResourceLocator override equals but inherited Object's
+ * identity hashCode, so two equal locators got different hash codes - broken as HashSet/HashMap keys.
+ * The hashCode is keyed on the base directory, shared down the hierarchy: because
+ * SimpleResourceLocator.equals treats any SimpleResourceLocator (including a MultiFormatResourceLocator)
+ * with the same base dir as equal, a base-dir-only hash is what keeps the contract consistent across
+ * both types.
+ */
+public class TestResourceLocatorHashCode {
+
+  @Test
+  public void testEqualSimpleLocatorsShareHashCode() throws Exception {
+    final SimpleResourceLocator a = new SimpleResourceLocator(new URI("file:/assets/models/"));
+    final SimpleResourceLocator b = new SimpleResourceLocator(new URI("file:/assets/models/"));
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testEqualMultiLocatorsShareHashCode() throws Exception {
+    final MultiFormatResourceLocator a = new MultiFormatResourceLocator(new URI("file:/assets/"), "png", "jpg");
+    final MultiFormatResourceLocator b = new MultiFormatResourceLocator(new URI("file:/assets/"), "png", "jpg");
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testSimpleEqualToMultiSharesHashCode() throws Exception {
+    // Simple.equals treats a Multi with the same base dir as equal, so the hashCode contract
+    // requires them to hash the same.
+    final SimpleResourceLocator simple = new SimpleResourceLocator(new URI("file:/assets/"));
+    final MultiFormatResourceLocator multi = new MultiFormatResourceLocator(new URI("file:/assets/"), "png");
+    assertTrue(simple.equals(multi));
+    assertEquals(simple.hashCode(), multi.hashCode());
+  }
+}

--- a/ardor3d-terrain/src/main/java/com/ardor3d/extension/terrain/util/Tile.java
+++ b/ardor3d-terrain/src/main/java/com/ardor3d/extension/terrain/util/Tile.java
@@ -23,8 +23,8 @@ public class Tile implements Serializable {
   @Override
   public int hashCode() {
     int result = 17;
-    result += 31 * result + x;
-    result += 31 * result + y;
+    result = 31 * result + x;
+    result = 31 * result + y;
     return result;
   }
 

--- a/ardor3d-terrain/src/test/java/com/ardor3d/extension/terrain/util/TestTileHashCode.java
+++ b/ardor3d-terrain/src/test/java/com/ardor3d/extension/terrain/util/TestTileHashCode.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.terrain.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+/**
+ * Tile.hashCode used `result += 31 * result + x` (a typo of the standard `result = 31 * result + x`),
+ * which algebraically collapses to `32*x + y + const`. That makes tiles offset by (+1, -32) hash
+ * identically - e.g. (1,0) and (0,32) - bucket-colliding in the terrain cache maps that key on Tile.
+ */
+public class TestTileHashCode {
+
+  @Test
+  public void testEqualTilesShareHashCode() {
+    final Tile a = new Tile(3, 4);
+    final Tile b = new Tile(3, 4);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testOffsetTilesDoNotCollide() {
+    // (1,0) and (0,32) both hashed to the same value under the += accumulation bug.
+    assertNotEquals(new Tile(1, 0).hashCode(), new Tile(0, 32).hashCode());
+  }
+}


### PR DESCRIPTION
Two small `equals`/`hashCode` correctness fixes from the codebase evaluation (Tier-4 #27 / #21), each with a red→green test. Fixed by hand rather than converted to records (deferred — a Kotlin 2.0 migration is under consideration, and `record`→`data class` is near-mechanical, so pure modernization isn't worth pre-paying).

- **`SimpleResourceLocator` / `MultiFormatResourceLocator`** overrode `equals` but inherited `Object`'s identity `hashCode`, so two equal locators produced different hash codes — broken as `HashSet`/`HashMap` keys. Added a base-dir-based `hashCode` on `SimpleResourceLocator`, **inherited** by `MultiFormatResourceLocator`: since `Simple.equals` treats any same-base-dir subclass as equal, a base-dir-only hash is what keeps the contract consistent across the hierarchy.
- **`Tile.hashCode`** used `result += 31 * result + x` (a typo of the standard `result = 31 * result + x`), which collapses to `32*x + y` and collides tiles offset by (+1, −32) — e.g. `(1,0)`/`(0,32)`. Corrected to the standard idiom. This is a **correctness/clarity** fix: a one-off benchmark confirmed the perf impact on the terrain tile-validity set is a wash (the old form was effectively a row-major index), so it's kept for the idiom, not for speed.

Full project test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hash code implementations in resource locators and tile management utilities to comply with equality contracts, ensuring proper operation in hash-based collections and improving application reliability.

* **Tests**
  * Added test suites to validate hash code correctness for resource locators and tile utilities, preventing regressions in collection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->