### PR TITLE
Harden COLLADA/OBJ/MD2 model import: XXE, stream leaks, Error→Ardor3dException

### DIFF
--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaDOMUtil.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaDOMUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -29,6 +29,7 @@ import org.jdom2.xpath.XPathFactory;
 
 import com.ardor3d.extension.model.collada.jdom.data.DataCache;
 import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.util.Ardor3dException;
 
 /**
  * Utility methods for parsing Collada data related to node hierarchy and arrays, using XPath or
@@ -133,11 +134,13 @@ public class ColladaDOMUtil {
     }
 
     final XPathFactory xpf = XPathFactory.instance();
-    XPathExpression<?> xPathExpression = null;
+    final XPathExpression<?> xPathExpression;
     try {
       xPathExpression = xpf.compile(query);
     } catch (final Exception e) {
-      e.printStackTrace();
+      // Fail loud rather than swallow the error and cache a null that callers would then silently
+      // treat as "no results". The queries are internal constants, so a failure here is a bug.
+      throw new Ardor3dException("Unable to compile XPath query: " + query, e);
     }
 
     _dataCache.getxPathExpressions().put(query, xPathExpression);

--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaImporter.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaImporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -266,6 +266,16 @@ public class ColladaImporter {
           // Just kill what's usually done here...
         }
       }, jdomFac);
+
+      // Harden against XXE / external-entity / billion-laughs attacks in untrusted .dae files.
+      // COLLADA is an XSD-schema format and never legitimately uses a DOCTYPE, so disallowing
+      // DOCTYPE outright is safe and is the strongest single mitigation; the remaining features are
+      // defense-in-depth for parsers that do not honor disallow-doctype-decl.
+      builder.setExpandEntities(false);
+      builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
       return builder.build(resource.openStream()).getRootElement();
     } catch (final Exception e) {

--- a/ardor3d-collada/src/test/java/com/ardor3d/extension/model/collada/jdom/TestColladaImportHardening.java
+++ b/ardor3d-collada/src/test/java/com/ardor3d/extension/model/collada/jdom/TestColladaImportHardening.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.model.collada.jdom;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Locale;
+
+import org.jdom2.Element;
+import org.junit.Test;
+
+import com.ardor3d.extension.model.collada.jdom.data.ColladaStorage;
+import com.ardor3d.extension.model.collada.jdom.data.DataCache;
+import com.ardor3d.util.Ardor3dException;
+import com.ardor3d.util.resource.StringResourceSource;
+
+/**
+ * Hardening of the COLLADA import path: the SAXBuilder must refuse DOCTYPE declarations (XXE /
+ * billion-laughs), and a malformed XPath query must fail loudly rather than be swallowed and cached
+ * as a null that is then silently treated as "no results".
+ *
+ * <p>
+ * (The resource stream is <em>not</em> covered here: the SAX parser closes the stream handed to
+ * {@code build()} on both the success and failure paths, so there is no leak to fix - verified by
+ * an earlier close-tracking probe.)
+ */
+public class TestColladaImportHardening {
+
+  /** A minimal, DOCTYPE-free COLLADA document that loads cleanly. */
+  private static final String BENIGN_DAE =
+      "<?xml version=\"1.0\"?><COLLADA version=\"1.4.1\"><asset/></COLLADA>";
+
+  private static boolean chainMentionsDoctype(Throwable t) {
+    while (t != null) {
+      final String msg = t.getMessage();
+      if (msg != null && msg.toLowerCase(Locale.ROOT).contains("doctype")) {
+        return true;
+      }
+      t = t.getCause();
+    }
+    return false;
+  }
+
+  @Test
+  public void doctypeWithExternalEntityIsRejected() {
+    // An external-entity XXE payload. The SYSTEM target need not exist: the point is that the
+    // DOCTYPE declaration itself must be refused before any entity is resolved.
+    final String xxe = "<?xml version=\"1.0\"?>\n" //
+        + "<!DOCTYPE COLLADA [ <!ENTITY xxe SYSTEM \"file:///nonexistent-ardor3d-xxe-probe\"> ]>\n" //
+        + "<COLLADA version=\"1.4.1\"><asset><contributor><author>&xxe;</author></contributor></asset></COLLADA>";
+    try {
+      new ColladaImporter().load(new StringResourceSource(xxe, ".dae"));
+      fail("Expected the load to fail: a DOCTYPE declaration should be disallowed.");
+    } catch (final Exception e) {
+      assertTrue("Expected a DOCTYPE-disallowed failure, but got: " + e, chainMentionsDoctype(e));
+    }
+  }
+
+  @Test
+  public void benignDocumentWithoutDoctypeStillLoads() throws Exception {
+    final ColladaImporter importer = new ColladaImporter();
+    importer.setLoadAnimations(false);
+    final ColladaStorage storage = importer.load(new StringResourceSource(BENIGN_DAE, ".dae"));
+    assertNotNull("A DOCTYPE-free COLLADA document should still parse after hardening.", storage);
+  }
+
+  @Test
+  public void malformedXPathQueryFailsLoudlyInsteadOfBeingSwallowed() {
+    final ColladaDOMUtil util = new ColladaDOMUtil(new DataCache());
+    try {
+      util.selectNodes(new Element("root"), "!!! not a valid xpath [");
+      fail("Expected a malformed XPath query to be reported, not swallowed and cached as null.");
+    } catch (final Ardor3dException expected) {
+      // good: the compile failure surfaces instead of being cached as a null that is then silently
+      // treated as an empty result set.
+    }
+  }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/model/md2/Md2Importer.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/model/md2/Md2Importer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -101,8 +101,7 @@ public class Md2Importer {
       throw new IllegalArgumentException("resource was null");
     }
 
-    try {
-      final InputStream md2Stream = resource.openStream();
+    try (final InputStream md2Stream = resource.openStream()) {
       if (md2Stream == null) {
         throw new IOException("resource stream was null");
       }
@@ -345,7 +344,7 @@ public class Md2Importer {
 
       return store;
     } catch (final Exception e) {
-      throw new Error("Unable to load md2 resource from URL: " + resource, e);
+      throw new Ardor3dException("Unable to load md2 resource from URL: " + resource, e);
     }
   }
 
@@ -398,7 +397,7 @@ public class Md2Importer {
     }
 
     if (source == null) {
-      throw new Error("Unable to locate '" + resource + "'");
+      throw new Ardor3dException("Unable to locate '" + resource + "'");
     }
 
     return load(source);

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjImporter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjImporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -21,6 +21,7 @@ import com.ardor3d.image.Texture.MinificationFilter;
 import com.ardor3d.image.TextureStoreFormat;
 import com.ardor3d.math.Vector3;
 import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.util.Ardor3dException;
 import com.ardor3d.util.TextureManager;
 import com.ardor3d.util.resource.ResourceLocator;
 import com.ardor3d.util.resource.ResourceLocatorTool;
@@ -103,7 +104,7 @@ public class ObjImporter {
     }
 
     if (source == null) {
-      throw new Error("Unable to locate '" + resource + "'");
+      throw new Ardor3dException("Unable to locate '" + resource + "'");
     }
 
     return load(source);
@@ -117,11 +118,11 @@ public class ObjImporter {
    * @return an ObjGeometryStore data object containing the scene and other useful elements.
    */
   public ObjGeometryStore load(final ResourceSource resource) {
-    try {
+    try (final BufferedReader reader =
+        new BufferedReader(new InputStreamReader(resource.openStream()))) {
       final ObjGeometryStore store = new ObjGeometryStore();
       int currentSmoothGroup = -1;
 
-      final BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream()));
       String line;
       int lineNo = 0;
       while ((line = reader.readLine()) != null) {
@@ -219,7 +220,7 @@ public class ObjImporter {
           if (argCount <= 2) {
             store.setCurrentGroupNames(null);
             continue;
-            // throw new Error("wrong number of args. g must have at least 1 argument. (line " + lineNo
+            // throw new Ardor3dException("wrong number of args. g must have at least 1 argument. (line " + lineNo
             // + ") " + line);
           }
 
@@ -232,7 +233,7 @@ public class ObjImporter {
         // if smoothing group
         else if ("s".equals(keyword)) {
           if (argCount != 1) {
-            throw new Error("wrong number of args.  s must have 1 argument.  (line " + lineNo + ") " + line);
+            throw new Ardor3dException("wrong number of args.  s must have 1 argument.  (line " + lineNo + ") " + line);
           }
 
           if ("off".equalsIgnoreCase(tokens[1])) {
@@ -251,7 +252,7 @@ public class ObjImporter {
         // if object name
         else if ("o".equals(keyword)) {
           if (argCount < 1) {
-            throw new Error("wrong number of args.  o must have 1 argument.  (line " + lineNo + ") " + line);
+            throw new Ardor3dException("wrong number of args.  o must have 1 argument.  (line " + lineNo + ") " + line);
           }
           store.setCurrentObjectName(tokens[1]);
         }
@@ -261,7 +262,7 @@ public class ObjImporter {
         // if material library(ies)
         else if ("mtllib".equals(keyword)) {
           if (argCount < 1) {
-            throw new Error(
+            throw new Ardor3dException(
                 "wrong number of args.  mtllib must have at least 1 argument.  (line " + lineNo + ") " + line);
           }
 
@@ -274,7 +275,7 @@ public class ObjImporter {
         // if use material command
         else if ("usemtl".equals(keyword)) {
           if (argCount != 1) {
-            throw new Error("wrong number of args.  usemtl must have 1 argument.  (line " + lineNo + ") " + line);
+            throw new Ardor3dException("wrong number of args.  usemtl must have 1 argument.  (line " + lineNo + ") " + line);
           }
 
           // set new material
@@ -306,7 +307,7 @@ public class ObjImporter {
         // if face
         else if (("f".equals(keyword) || "fo".equals(keyword)) && argCount > 0) {
           if (argCount < 3) {
-            throw new Error("wrong number of args.  f must have at least 3 vertices.  (line " + lineNo + ") " + line);
+            throw new Ardor3dException("wrong number of args.  f must have at least 3 vertices.  (line " + lineNo + ") " + line);
           }
 
           // Each token corresponds to 1 vertex entry and possibly one texture entry and normal entry.
@@ -340,7 +341,7 @@ public class ObjImporter {
       store.cleanup();
       return store;
     } catch (final Exception e) {
-      throw new Error("Unable to load obj resource from URL: " + resource, e);
+      throw new Ardor3dException("Unable to load obj resource from URL: " + resource, e);
     }
   }
 
@@ -365,7 +366,7 @@ public class ObjImporter {
     }
 
     if (source == null) {
-      throw new Error("Unable to locate mtllib '" + fileName + "'");
+      throw new Ardor3dException("Unable to locate mtllib '" + fileName + "'");
     }
 
     loadMaterialLibrary(source, store);
@@ -380,8 +381,8 @@ public class ObjImporter {
    *          our material store to place the contents of the file in.
    */
   private void loadMaterialLibrary(final ResourceSource resource, final Map<String, ObjMaterial> store) {
-    try {
-      final BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream()));
+    try (final BufferedReader reader =
+        new BufferedReader(new InputStreamReader(resource.openStream()))) {
       String line;
       ObjMaterial currentMaterial = null;
       while ((line = reader.readLine()) != null) {
@@ -487,7 +488,7 @@ public class ObjImporter {
         }
       }
     } catch (final Exception e) {
-      throw new Error("Unable to load mtllib resource from URL: " + resource, e);
+      throw new Ardor3dException("Unable to load mtllib resource from URL: " + resource, e);
     }
   }
 }

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/model/TestModelImportHardening.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/model/TestModelImportHardening.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.model;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import com.ardor3d.extension.model.md2.Md2Importer;
+import com.ardor3d.extension.model.obj.ObjImporter;
+import com.ardor3d.util.Ardor3dException;
+import com.ardor3d.util.resource.StringResourceSource;
+
+/**
+ * Hardening of the OBJ and MD2 model importers: the resource stream must be closed after a load (no
+ * handle leak - nothing else closes it, unlike the SAX-based COLLADA path), and a bad asset must
+ * raise an {@link Ardor3dException} rather than a bare {@link java.lang.Error}.
+ */
+public class TestModelImportHardening {
+
+  private static final String VALID_OBJ = "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n";
+
+  /** Wraps StringResourceSource so we can observe whether the stream it hands out gets closed. */
+  private static class TrackingSource extends StringResourceSource {
+    private CloseTrackingInputStream lastStream;
+
+    TrackingSource(final String data) {
+      super(data);
+    }
+
+    @Override
+    public InputStream openStream() throws IOException {
+      lastStream = new CloseTrackingInputStream(super.openStream());
+      return lastStream;
+    }
+  }
+
+  private static class CloseTrackingInputStream extends FilterInputStream {
+    private boolean closed = false;
+
+    CloseTrackingInputStream(final InputStream in) {
+      super(in);
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed = true;
+      super.close();
+    }
+  }
+
+  // ---- OBJ ----
+
+  @Test
+  public void objStreamIsClosedAfterLoad() {
+    final TrackingSource source = new TrackingSource(VALID_OBJ);
+    new ObjImporter().load(source);
+    assertNotNull(source.lastStream);
+    assertTrue("ObjImporter must close the resource stream it opened.", source.lastStream.closed);
+  }
+
+  @Test
+  public void objMalformedContentThrowsArdor3dExceptionNotError() {
+    try {
+      // A face needs at least three vertices.
+      new ObjImporter().load(new StringResourceSource("v 0 0 0\nv 1 0 0\nf 1 2\n", ".obj"));
+      fail("Expected a malformed OBJ to raise an Ardor3dException.");
+    } catch (final Ardor3dException expected) {
+      // good
+    }
+  }
+
+  @Test
+  public void objMissingResourceThrowsArdor3dExceptionNotError() {
+    try {
+      new ObjImporter().load("no-such-resource-zzz.obj");
+      fail("Expected a missing OBJ resource to raise an Ardor3dException.");
+    } catch (final Ardor3dException expected) {
+      // good
+    }
+  }
+
+  // ---- MD2 ----
+
+  @Test
+  public void md2BadContentThrowsArdor3dExceptionAndClosesStream() {
+    final TrackingSource source = new TrackingSource("this is plainly not an MD2 binary file");
+    try {
+      new Md2Importer().load(source);
+      fail("Expected non-MD2 content to raise an Ardor3dException.");
+    } catch (final Ardor3dException expected) {
+      // good
+    }
+    assertNotNull(source.lastStream);
+    assertTrue("Md2Importer must close the resource stream even when parsing fails.",
+        source.lastStream.closed);
+  }
+
+  @Test
+  public void md2MissingResourceThrowsArdor3dExceptionNotError() {
+    try {
+      new Md2Importer().load("no-such-resource-zzz.md2");
+      fail("Expected a missing MD2 resource to raise an Ardor3dException.");
+    } catch (final Ardor3dException expected) {
+      // good
+    }
+  }
+}


### PR DESCRIPTION
Load-side hardening of the model importers — the mirror of the serialization (save-side) work in #129. Language-future-agnostic, fully headless-testable, and it adds the first tests to `ardor3d-extras` (and only the second to `ardor3d-collada`). Two commits, one concern each, every fix carries a red→green test.

## COLLADA — XXE + fail-loud XPath (commit 1)
- **XXE / billion-laughs (the security fix).** `ColladaImporter.readCollada` built a `SAXBuilder` with JAXP defaults and parsed untrusted `.dae` content — open to external-entity file disclosure and entity-expansion DoS. COLLADA is an XSD-schema format and never legitimately carries a DOCTYPE, so `disallow-doctype-decl` is set (strongest single mitigation) plus external-general/parameter-entity, load-external-dtd, and expand-entities off as defense-in-depth. A `.dae` containing a DOCTYPE is now refused.
- **Swallowed XPath compile error.** `getXPathExpression` did `printStackTrace` and **cached the resulting null**, which `selectNodes`/`selectSingleNode` then dereferenced and re-swallowed → a bad query became a silent empty result. Now throws `Ardor3dException`. Honest caveat: every query is an internal constant, so this can't fire today — it removes latent fragility, tested via a deliberately malformed query.

## OBJ / MD2 — stream leaks + Error→Ardor3dException (commit 2)
- **Stream leaks.** `ObjImporter` (model load + `.mtl` library) and `Md2Importer` opened `resource.openStream()` and never closed it — nothing else does. Wrapped each in try-with-resources.
- **`Error` for bad assets.** Both threw `java.lang.Error` for malformed/missing assets, which signals an unrecoverable JVM fault and slips past normal `catch (Exception)`. Replaced with the already-used unchecked `Ardor3dException`, preserving the `load()` signatures (they declare no `throws`, so `IOException` wasn't an option).

## Verified non-bug (honesty note)
COLLADA was initially suspected of leaking its stream too, but a close-tracking probe showed the SAX parser closes the stream on **both** the success and failure paths — so there's no COLLADA leak to fix, and `readCollada` is intentionally left alone on that front.

## Out of scope
The `throw new Error` sites in the DDS/HDR/TGA image loaders (`ardor3d-core`) and the AWT/SWT image utils — a separate, larger cross-module sweep.

## Testing
Full `ardor3d-collada` and `ardor3d-extras` suites green (4 and 5 tests); whole-project `compileJava` clean. Copyright headers on changed files bumped to 2008-2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security for model file imports to prevent external entity attacks and DOCTYPE-based vulnerabilities.

* **Bug Fixes**
  * Improved error handling to explicitly report failures instead of silently failing during model loading.
  * Fixed resource stream management to ensure proper cleanup after import operations.

* **Tests**
  * Added comprehensive security and resource management tests for model importers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
