### PR TITLE
Fix OBJ "g" statement dropping single/double group names

### DIFF
--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjGeometryStore.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjGeometryStore.java
@@ -13,6 +13,7 @@ package com.ardor3d.extension.model.obj;
 import java.nio.Buffer;
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -354,5 +355,5 @@ public class ObjGeometryStore {
    * @return a map of group name (from the OBJ "g" statement) to the spatial filed under it. Geometry
    *         declared without a group is filed under {@value #DEFAULT_GROUP}.
    */
-  public Map<String, Spatial> getGroupMap() { return _groupMap; }
+  public Map<String, Spatial> getGroupMap() { return Collections.unmodifiableMap(_groupMap); }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjGeometryStore.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjGeometryStore.java
@@ -361,5 +361,9 @@ public class ObjGeometryStore {
    *         may map to more than one spatial (e.g. one Mesh per material or per "o" object). Geometry
    *         declared without a group is filed under {@value #DEFAULT_GROUP}.
    */
-  public Map<String, List<Spatial>> getGroupMap() { return Collections.unmodifiableMap(_groupMap); }
+  public Map<String, List<Spatial>> getGroupMap() {
+    final Map<String, List<Spatial>> view = new HashMap<>();
+    _groupMap.forEach((name, spatials) -> view.put(name, Collections.unmodifiableList(spatials)));
+    return Collections.unmodifiableMap(view);
+  }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjGeometryStore.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjGeometryStore.java
@@ -43,7 +43,7 @@ public class ObjGeometryStore {
   private int _totalLines = 0;
   private int _totalMeshes = 0;
   private final Node _root = new Node();
-  private final Map<String, Spatial> _groupMap = new HashMap<>();
+  private final Map<String, List<Spatial>> _groupMap = new HashMap<>();
 
   private ObjMaterial _currentMaterial = new ObjMaterial("default");
   private String _currentObjectName;
@@ -341,19 +341,25 @@ public class ObjGeometryStore {
   private void mapToGroups(final Spatial target) {
     if (_currentGroupNames != null) {
       for (final String groupName : _currentGroupNames) {
-        _groupMap.put(groupName, target);
+        addToGroup(groupName, target);
       }
     } else {
-      _groupMap.put(ObjGeometryStore.DEFAULT_GROUP, target);
+      addToGroup(ObjGeometryStore.DEFAULT_GROUP, target);
     }
+  }
 
+  private void addToGroup(final String groupName, final Spatial target) {
+    // A single group can span several spatials (e.g. one Mesh per material or per "o" object), so
+    // accumulate rather than overwrite.
+    _groupMap.computeIfAbsent(groupName, k -> new ArrayList<>()).add(target);
   }
 
   public Map<Spatial, String> getMaterialMap() { return _materialMap; }
 
   /**
-   * @return a map of group name (from the OBJ "g" statement) to the spatial filed under it. Geometry
+   * @return a map of group name (from the OBJ "g" statement) to the spatials filed under it. A group
+   *         may map to more than one spatial (e.g. one Mesh per material or per "o" object). Geometry
    *         declared without a group is filed under {@value #DEFAULT_GROUP}.
    */
-  public Map<String, Spatial> getGroupMap() { return Collections.unmodifiableMap(_groupMap); }
+  public Map<String, List<Spatial>> getGroupMap() { return Collections.unmodifiableMap(_groupMap); }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjGeometryStore.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjGeometryStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -349,4 +349,10 @@ public class ObjGeometryStore {
   }
 
   public Map<Spatial, String> getMaterialMap() { return _materialMap; }
+
+  /**
+   * @return a map of group name (from the OBJ "g" statement) to the spatial filed under it. Geometry
+   *         declared without a group is filed under {@value #DEFAULT_GROUP}.
+   */
+  public Map<String, Spatial> getGroupMap() { return _groupMap; }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjImporter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/model/obj/ObjImporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -216,11 +216,10 @@ public class ObjImporter {
 
         // if group name(s)
         else if ("g".equals(keyword)) {
-          if (argCount <= 2) {
+          if (argCount < 1) {
+            // A bare "g" with no names selects the default group.
             store.setCurrentGroupNames(null);
             continue;
-            // throw new Error("wrong number of args. g must have at least 1 argument. (line " + lineNo
-            // + ") " + line);
           }
 
           // Each token is a name

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/model/obj/TestObjImporterGroups.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/model/obj/TestObjImporterGroups.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.model.obj;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ardor3d.util.resource.StringResourceSource;
+
+/**
+ * The "g" group statement records one group name per token after the keyword. ObjImporter used to
+ * treat {@code argCount <= 2} as "no group", silently discarding the common {@code g name} and
+ * {@code g name1 name2} forms and filing their geometry under the default group instead.
+ */
+public class TestObjImporterGroups {
+
+  private static final String VERTS = "v 0 0 0\nv 1 0 0\nv 0 1 0\n";
+
+  private ObjGeometryStore load(final String obj) {
+    return new ObjImporter().load(new StringResourceSource(obj, ".obj"));
+  }
+
+  @Test
+  public void singleGroupNameIsRecorded() {
+    final ObjGeometryStore store = load(VERTS + "g mygroup\nf 1 2 3\n");
+    assertTrue("'g mygroup' should register the group 'mygroup'.", store.getGroupMap().containsKey("mygroup"));
+    assertFalse("Named geometry should not fall back to the default group.",
+        store.getGroupMap().containsKey("_default_"));
+  }
+
+  @Test
+  public void twoGroupNamesAreRecorded() {
+    final ObjGeometryStore store = load(VERTS + "g left right\nf 1 2 3\n");
+    assertTrue("'g left right' should register 'left'.", store.getGroupMap().containsKey("left"));
+    assertTrue("'g left right' should register 'right'.", store.getGroupMap().containsKey("right"));
+  }
+
+  @Test
+  public void namelessGroupStillFallsBackToDefault() {
+    final ObjGeometryStore store = load(VERTS + "g\nf 1 2 3\n");
+    assertTrue("A bare 'g' with no names should map to the default group.",
+        store.getGroupMap().containsKey("_default_"));
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/model/obj/TestObjImporterGroups.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/model/obj/TestObjImporterGroups.java
@@ -10,6 +10,7 @@
 
 package com.ardor3d.extension.model.obj;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -50,5 +51,15 @@ public class TestObjImporterGroups {
     final ObjGeometryStore store = load(VERTS + "g\nf 1 2 3\n");
     assertTrue("A bare 'g' with no names should map to the default group.",
         store.getGroupMap().containsKey("_default_"));
+  }
+
+  @Test
+  public void groupSpanningMultipleObjectsKeepsAllSpatials() {
+    // A single group can contain several committed spatials - here two "o" objects each force a
+    // commit while the group name stays "mygroup". Both must be retained, not overwritten.
+    final ObjGeometryStore store =
+        load("v 0 0 0\nv 1 0 0\nv 0 1 0\nv 0 0 1\n" + "g mygroup\no partA\nf 1 2 3\no partB\nf 1 2 4\n");
+    assertEquals("Both spatials committed under 'mygroup' should be retained.", 2,
+        store.getGroupMap().get("mygroup").size());
   }
 }


### PR DESCRIPTION
`ObjImporter` treated a `g` statement with two or fewer names (`argCount <= 2`) as "no group" — it filed the geometry under the default group and threw the names away. That silently swallows the two most common forms, `g name` and `g name1 name2`, and only honored a `g` with **three or more** names, which is backwards. The comment right below (`// Each token is a name`) confirms the intent: every token after the keyword is a group name.

- **Fix:** guard changed to `argCount < 1`, so only a bare `g` selects the default group and any named group is recorded. Dropped the stale commented-out `throw new Error(...)` lines.
- **Expose the result:** added `ObjGeometryStore.getGroupMap()` (mirrors the existing `getMaterialMap()`). The group map was populated but **write-only** — there was no accessor, so even a correctly-parsed group name went nowhere observable. The getter makes parsed groups usable by callers and lets the fix be tested behaviorally.

No regression risk: the map had no readers, so changing what it's keyed by is invisible to existing code; the getter is purely additive.

## Testing
New red→green test (`TestObjImporterGroups`) covering the single-name, two-name, and bare-`g` (default) forms. Full `ardor3d-extras` suite green; whole-project `compileJava` clean. Copyright headers on changed files bumped to 2008-2026.

Independent of #131 (different lines / new method), so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed OBJ geometry group mappings via a new public accessor, where a group can correspond to multiple spatials.
* **Bug Fixes**
  * Improved OBJ `g` (group) handling so only a truly empty `g` selects the default group; `g` lines with 1–2 names are now recorded correctly.
* **Tests**
  * Added new test coverage for OBJ group statement behavior, including multiple names per `g` line and group continuity across multiple objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->