### PR TITLE
Warn when a second GL context is registered without useMultipleContexts

### DIFF
--- a/ardor3d-core/src/main/java/com/ardor3d/renderer/ContextManager.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/renderer/ContextManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -11,19 +11,32 @@
 package com.ardor3d.renderer;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.logging.Logger;
 
 import com.ardor3d.renderer.RenderContext.RenderContextRef;
+import com.ardor3d.util.Constants;
 
 public class ContextManager {
+
+  private static final Logger logger = Logger.getLogger(ContextManager.class.getName());
 
   protected static RenderContext currentContext = null;
 
   private static List<ContextCleanListener> _cleanListeners = new ArrayList<>();
 
   protected static final Map<Object, RenderContext> contextStore = new WeakHashMap<>();
+
+  /**
+   * Latches true once we have warned about unsafe multi-context use, so the warning fires once.
+   * {@code volatile} so a set on one registration thread is visible to another; a narrow check-then-set
+   * race could still log twice, which is harmless for a one-time diagnostic.
+   */
+  protected static volatile boolean _warnedSingleContextMode = false;
 
   /**
    * @return a RenderContext object representing the current OpenGL context.
@@ -44,6 +57,31 @@ public class ContextManager {
 
   public static void addContext(final Object contextKey, final RenderContext context) {
     contextStore.put(contextKey, context);
+    warnIfUnsafeMultiContext();
+  }
+
+  /**
+   * Warn (once) if more than one distinct context is registered while
+   * {@link Constants#useMultipleContexts} is off. In that mode {@link com.ardor3d.util.gc.ContextValueReference}
+   * ignores the per-context key and keeps a single value, so non-sharable GL resources (VAOs, FBOs)
+   * created in one context get handed back for another, corrupting rendering on the second context.
+   * The fix is to launch with {@code -Dardor3d.useMultipleContexts}; this surfaces the silent
+   * misconfiguration in one log line.
+   */
+  private static void warnIfUnsafeMultiContext() {
+    if (_warnedSingleContextMode || Constants.useMultipleContexts) {
+      return;
+    }
+    // Distinct RenderContext instances each carry a unique context ref, so >1 of them is exactly
+    // the condition under which non-sharable GL resources would be wrongly reused across contexts.
+    final Set<RenderContext> distinct = new HashSet<>(contextStore.values());
+    if (distinct.size() > 1) {
+      _warnedSingleContextMode = true;
+      logger.warning("More than one OpenGL context has been registered, but Constants.useMultipleContexts"
+          + " is false. Per-context GL resources (VAOs, FBOs, ...) are not tracked per context in this mode"
+          + " and will be shared across all contexts, which can corrupt rendering on the second context."
+          + " Launch with -Dardor3d.useMultipleContexts to enable per-context resource tracking.");
+    }
   }
 
   public static RenderContext getContextForKey(final Object key) {

--- a/ardor3d-core/src/test/java/com/ardor3d/renderer/TestContextManager.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/renderer/TestContextManager.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.renderer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ardor3d.util.Constants;
+
+/**
+ * Covers {@link ContextManager#addContext}'s diagnostic warning: when more than one distinct GL
+ * context is registered while {@link Constants#useMultipleContexts} is off, per-context GL resources
+ * (VAOs, FBOs, ...) silently collapse to a single shared value, which is a rendering-corruption
+ * hazard. The engine should say so, once.
+ */
+public class TestContextManager {
+
+  private final List<LogRecord> _records = new ArrayList<>();
+  private final Logger _logger = Logger.getLogger(ContextManager.class.getName());
+  private Handler _handler;
+  private Level _priorLevel;
+  private boolean _priorUseParent;
+
+  @Before
+  public void setUp() {
+    // ContextManager is all-static shared state; isolate each test from the others.
+    ContextManager.contextStore.clear();
+    ContextManager.currentContext = null;
+    ContextManager._warnedSingleContextMode = false;
+
+    _records.clear();
+    _handler = new Handler() {
+      @Override
+      public void publish(final LogRecord record) {
+        _records.add(record);
+      }
+
+      @Override
+      public void flush() {}
+
+      @Override
+      public void close() {}
+    };
+    _priorLevel = _logger.getLevel();
+    _priorUseParent = _logger.getUseParentHandlers();
+    _logger.addHandler(_handler);
+    _logger.setLevel(Level.ALL);
+    _logger.setUseParentHandlers(false);
+  }
+
+  @After
+  public void tearDown() {
+    _logger.removeHandler(_handler);
+    _logger.setLevel(_priorLevel);
+    _logger.setUseParentHandlers(_priorUseParent);
+    ContextManager.contextStore.clear();
+    ContextManager.currentContext = null;
+    ContextManager._warnedSingleContextMode = false;
+  }
+
+  private long warningCount() {
+    return _records.stream().filter(r -> r.getLevel() == Level.WARNING).count();
+  }
+
+  @Test
+  public void singleContextDoesNotWarn() {
+    ContextManager.addContext("canvasA", new RenderContext("canvasA"));
+    assertEquals("A single registered context is normal and must never warn.", 0, warningCount());
+  }
+
+  @Test
+  public void reAddingSameKeyDoesNotWarn() {
+    final Object key = "canvasA";
+    ContextManager.addContext(key, new RenderContext(key));
+    // Re-registering the same canvas key models a context recreation (e.g. on resize), not a
+    // second coexisting context, so it must not trip the warning.
+    ContextManager.addContext(key, new RenderContext(key));
+    assertEquals("Re-registering one canvas key is recreation, not a second context.", 0, warningCount());
+  }
+
+  @Test
+  public void secondDistinctContextWarnsOnceInSingleContextMode() {
+    // Only meaningful in the default single-context mode; skip if the JVM enabled multi-context.
+    Assume.assumeFalse(Constants.useMultipleContexts);
+
+    ContextManager.addContext("canvasA", new RenderContext("canvasA"));
+    assertEquals("First context must not warn.", 0, warningCount());
+
+    ContextManager.addContext("canvasB", new RenderContext("canvasB"));
+    assertEquals("A second distinct context without useMultipleContexts must warn.", 1, warningCount());
+
+    // The diagnostic is one-time: further contexts must not spam the log.
+    ContextManager.addContext("canvasC", new RenderContext("canvasC"));
+    assertEquals("The unsafe-multi-context warning must fire at most once.", 1, warningCount());
+  }
+
+  @Test
+  public void multipleContextsDoNotWarnWhenModeEnabled() {
+    // When the per-context tracking is correctly enabled, multiple contexts are normal.
+    Assume.assumeTrue(Constants.useMultipleContexts);
+
+    ContextManager.addContext("canvasA", new RenderContext("canvasA"));
+    ContextManager.addContext("canvasB", new RenderContext("canvasB"));
+    assertEquals("Multiple contexts are correct when useMultipleContexts is on.", 0, warningCount());
+  }
+}


### PR DESCRIPTION
## What

`ContextManager.addContext` now logs a one-time **WARNING** when more than one distinct GL context is registered while `Constants.useMultipleContexts` is `false`.

## Why

The engine's per-context GL-resource keying is correct *by design*: VAOs are keyed by `RenderContext`'s unique ref, while buffers/textures/programs are keyed by the sharable ref (matching what GL actually shares between contexts). But all of that keying is gated behind `Constants.useMultipleContexts`, which is read once at class-load from `-Dardor3d.useMultipleContexts` and defaults to **off**.

When it's off, `ContextValueReference.get/put` ignore the per-context key entirely and read/write a single value:

```java
public U getValue(final RenderContextRef glContext) {
  if (Constants.useMultipleContexts) {
    return _valueCache.get(glContext);   // keyed by context
  } else {
    return _singleContextValue;          // ref ignored — one value for ALL contexts
  }
}
```

So an app that runs **multiple** GL contexts but forgets the flag is in a quietly-broken state:

- **Buffers / textures / programs** survive it — the contexts genuinely share those at the GL level, so reusing one id is accidentally fine.
- **VAOs do not** — they aren't shareable across contexts. A VAO genned in context A and then handed back for context B is invalid there → `GL_INVALID_OPERATION` or missing/garbage geometry on the second context.

Nothing surfaced this. `addContext` is the one place that knows how many contexts are live, so it's the natural spot to turn a silent misconfiguration into an actionable log line that names the fix (`-Dardor3d.useMultipleContexts`).

## Notes

- **Not a behavior change** — purely a diagnostic. No fix is needed (or attempted) for the keying itself; it's correct when the flag is set.
- The warn-latch is `volatile` and fires once. `addContext` is otherwise unsynchronized by existing design, so a narrow check-then-set race could log twice — harmless for a one-time diagnostic; full locking just this one boolean while the backing `WeakHashMap` stays unsynchronized would be inconsistent.
- Decided against making the flag dynamic: it's a deliberate perf/JIT gate, and a startup warning gets the same benefit at far less risk.

## Test

`TestContextManager` — `ardor3d-core`'s first coverage for this class. Verifies a single context (and same-key recreation, e.g. on resize) stays quiet, and a second distinct context warns exactly once. Red→green; full `ardor3d-core` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented diagnostic warning system that automatically detects and logs when multiple rendering contexts are inadvertently registered in single-context mode, improving reliability and safety.

* **Tests**
  * Added comprehensive test suite validating multi-context detection behavior, covering registration scenarios, warning notifications, and mode configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->