### PR TITLE
Read lwjgl3 LWJGL version/natives from the root project explicitly

### DIFF
--- a/ardor3d-lwjgl3-nuklear/build.gradle.kts
+++ b/ardor3d-lwjgl3-nuklear/build.gradle.kts
@@ -1,8 +1,8 @@
 
 description = "Ardor 3D LWJGL3 Nuklear"
 
-val lwjglVersion: String? = project.findProperty("lwjglVersion") as String?
-val lwjglNatives: String? = project.findProperty("lwjglNatives") as String?
+val lwjglVersion = rootProject.extra["lwjglVersion"] as String
+val lwjglNatives = rootProject.extra["lwjglNatives"] as String
 
 dependencies {
 	api(project(":ardor3d-lwjgl3"))

--- a/ardor3d-lwjgl3/build.gradle.kts
+++ b/ardor3d-lwjgl3/build.gradle.kts
@@ -1,8 +1,8 @@
 
 description = "Ardor 3D LWJGL3"
 
-val lwjglVersion: String? = project.findProperty("lwjglVersion") as String?
-val lwjglNatives: String? = project.findProperty("lwjglNatives") as String?
+val lwjglVersion = rootProject.extra["lwjglVersion"] as String
+val lwjglNatives = rootProject.extra["lwjglNatives"] as String
 
 dependencies {
 	api(project(":ardor3d-core"))


### PR DESCRIPTION
Gradle 9.6 deprecated implicit lookup of properties in parent projects (it becomes a hard error in Gradle 10). The `ardor3d-lwjgl3` and `ardor3d-lwjgl3-nuklear` modules read `lwjglVersion`/`lwjglNatives` via `project.findProperty(...)`, which resolved them by walking up to the root project's `extra` properties — the deprecated path. They now read `rootProject.extra[...]` directly.

Surfaced by the Gradle 9.6 bump in #134; the awt/swt lwjgl3 modules were never affected (they carry their own versions).

Verified on Gradle 9.6.0: `./gradlew help --warning-mode all` reports zero deprecations, and `:ardor3d-lwjgl3:dependencies` still resolves `org.lwjgl:lwjgl:3.3.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized how shared library version and native settings are read during the build, using root-level configuration values for more consistent dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->