### PR TITLE
Add opt-in transform orthonormalization to the Collada importer

### DIFF
--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaAnimUtils.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaAnimUtils.java
@@ -13,6 +13,7 @@ package com.ardor3d.extension.model.collada.jdom;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.annotation.Target;
 import java.nio.FloatBuffer;
 import java.nio.ShortBuffer;
 import java.util.ArrayList;
@@ -1055,52 +1056,57 @@ public class ColladaAnimUtils {
     final Matrix4 workingMat = Matrix4.fetchTempInstance();
     final Matrix4 finalMat = Matrix4.fetchTempInstance();
     finalMat.setIdentity();
-    for (final TransformElement transform : transforms) {
-      final double[] array = transform.getArray();
-      final TransformElementType type = transform.getType();
-      if (type == TransformElementType.Translation) {
-        workingMat.setIdentity();
-        workingMat.setColumn(3, new Vector4(array[0], array[1], array[2], 1.0));
-        finalMat.multiplyLocal(workingMat);
-      } else if (type == TransformElementType.Rotation) {
-        if (array[3] != 0) {
+    try {
+      for (final TransformElement transform : transforms) {
+        final double[] array = transform.getArray();
+        final TransformElementType type = transform.getType();
+        if (type == TransformElementType.Translation) {
           workingMat.setIdentity();
-          final Matrix3 rotate =
-              new Matrix3().fromAngleAxis(array[3] * MathUtils.DEG_TO_RAD, new Vector3(array[0], array[1], array[2]));
-          workingMat.set(rotate);
+          workingMat.setColumn(3, new Vector4(array[0], array[1], array[2], 1.0));
           finalMat.multiplyLocal(workingMat);
-        }
-      } else if (type == TransformElementType.Scale) {
-        workingMat.setIdentity();
-        workingMat.scale(new Vector4(array[0], array[1], array[2], 1), workingMat);
-        finalMat.multiplyLocal(workingMat);
-      } else if (type == TransformElementType.Matrix) {
-        workingMat.fromArray(array);
-        finalMat.multiplyLocal(workingMat);
-      } else if (type == TransformElementType.Lookat) {
-        final Vector3 pos = new Vector3(array[0], array[1], array[2]);
-        final Vector3 target = new Vector3(array[3], array[4], array[5]);
-        final Vector3 up = new Vector3(array[6], array[7], array[8]);
-        final Matrix3 rot = new Matrix3();
-        rot.lookAt(target.subtractLocal(pos), up);
-        workingMat.set(rot);
-        workingMat.setColumn(3, new Vector4(array[0], array[1], array[2], 1.0));
-        finalMat.multiplyLocal(workingMat);
-      } else {
-        if (logger.isLoggable(Level.WARNING)) {
-          logger.warning("transform not currently supported: " + transform.getClass().getCanonicalName());
+        } else if (type == TransformElementType.Rotation) {
+          if (array[3] != 0) {
+            workingMat.setIdentity();
+            final Matrix3 rotate =
+                new Matrix3().fromAngleAxis(array[3] * MathUtils.DEG_TO_RAD, new Vector3(array[0], array[1], array[2]));
+            workingMat.set(rotate);
+            finalMat.multiplyLocal(workingMat);
+          }
+        } else if (type == TransformElementType.Scale) {
+          workingMat.setIdentity();
+          workingMat.scale(new Vector4(array[0], array[1], array[2], 1), workingMat);
+          finalMat.multiplyLocal(workingMat);
+        } else if (type == TransformElementType.Matrix) {
+          workingMat.fromArray(array);
+          finalMat.multiplyLocal(workingMat);
+        } else if (type == TransformElementType.Lookat) {
+          final Vector3 pos = new Vector3(array[0], array[1], array[2]);
+          final Vector3 target = new Vector3(array[3], array[4], array[5]);
+          final Vector3 up = new Vector3(array[6], array[7], array[8]);
+          final Matrix3 rot = new Matrix3();
+          rot.lookAt(target.subtractLocal(pos), up);
+          workingMat.set(rot);
+          workingMat.setColumn(3, new Vector4(array[0], array[1], array[2], 1.0));
+          finalMat.multiplyLocal(workingMat);
+        } else {
+          if (logger.isLoggable(Level.WARNING)) {
+            logger.warning("transform not currently supported: " + transform.getClass().getCanonicalName());
+          }
         }
       }
-    }
-    if (_importer.isOrthonormalizeTransforms()) {
-      try {
-        finalMat.orthonormalizeLocal();
-      } catch (final ArithmeticException e) {
-        logger.warning("Could not orthonormalize an animation transform with a rank-deficient "
-            + "rotation block; leaving it as-is.");
+      if (_importer.isOrthonormalizeTransforms()) {
+        try {
+          finalMat.orthonormalizeLocal();
+        } catch (final ArithmeticException e) {
+          logger.warning("Could not orthonormalize an animation transform with a rank-deficient "
+              + "rotation block; leaving it as-is.");
+        }
       }
+      return new Transform().fromHomogeneousMatrix(finalMat);
+    } finally {
+      Matrix4.releaseTempInstance(workingMat);
+      Matrix4.releaseTempInstance(finalMat);
     }
-    return new Transform().fromHomogeneousMatrix(finalMat);
   }
 
   /**

--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaAnimUtils.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaAnimUtils.java
@@ -74,13 +74,15 @@ import com.ardor3d.util.geom.VertMap;
 public class ColladaAnimUtils {
   private static final Logger logger = Logger.getLogger(ColladaAnimUtils.class.getName());
 
+  private final ColladaImporter _importer;
   private final ColladaStorage _colladaStorage;
   private final DataCache _dataCache;
   private final ColladaDOMUtil _colladaDOMUtil;
   private final ColladaMeshUtils _colladaMeshUtils;
 
-  public ColladaAnimUtils(final ColladaStorage colladaStorage, final DataCache dataCache,
-    final ColladaDOMUtil colladaDOMUtil, final ColladaMeshUtils colladaMeshUtils) {
+  public ColladaAnimUtils(final ColladaImporter importer, final ColladaStorage colladaStorage,
+    final DataCache dataCache, final ColladaDOMUtil colladaDOMUtil, final ColladaMeshUtils colladaMeshUtils) {
+    _importer = importer;
     _colladaStorage = colladaStorage;
     _dataCache = dataCache;
     _colladaDOMUtil = colladaDOMUtil;
@@ -1088,6 +1090,14 @@ public class ColladaAnimUtils {
         if (logger.isLoggable(Level.WARNING)) {
           logger.warning("transform not currently supported: " + transform.getClass().getCanonicalName());
         }
+      }
+    }
+    if (_importer.isOrthonormalizeTransforms()) {
+      try {
+        finalMat.orthonormalizeLocal();
+      } catch (final ArithmeticException e) {
+        logger.warning("Could not orthonormalize an animation transform with a rank-deficient "
+            + "rotation block; leaving it as-is.");
       }
     }
     return new Transform().fromHomogeneousMatrix(finalMat);

--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaImporter.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaImporter.java
@@ -56,6 +56,7 @@ public class ColladaImporter {
   private ResourceLocator _modelLocator;
   private boolean _compressTextures = false;
   private boolean _optimizeMeshes = false;
+  private boolean _orthonormalizeTransforms = false;
   private final EnumSet<MatchCondition> _optimizeSettings =
       EnumSet.of(MatchCondition.UVs, MatchCondition.Normal, MatchCondition.Color);
   private Map<String, Joint> _externalJointMapping;
@@ -128,6 +129,24 @@ public class ColladaImporter {
 
   public void setOptimizeMeshes(final boolean optimizeMeshes) { _optimizeMeshes = optimizeMeshes; }
 
+  public boolean isOrthonormalizeTransforms() { return _orthonormalizeTransforms; }
+
+  /**
+   * @param orthonormalizeTransforms
+   *          if true, the rotational (upper-left 3x3) part of every imported node and animation
+   *          channel transform is orthonormalized (Gram-Schmidt) as it is baked. This cleans up the
+   *          rounding error some exporters (e.g. Autodesk FBX-to-Collada, OpenCollada) bake into
+   *          {@code <matrix>} transforms, which otherwise leaves Transforms reporting non-rotational
+   *          matrices and degrades rotation extraction (notably the warning flood on skeletal
+   *          import). Off by default: enabling it discards any scale or shear carried in those
+   *          matrices, so only turn it on when your source encodes pure rotation plus translation.
+   * @return this importer, for chaining
+   */
+  public ColladaImporter setOrthonormalizeTransforms(final boolean orthonormalizeTransforms) {
+    _orthonormalizeTransforms = orthonormalizeTransforms;
+    return this;
+  }
+
   public Set<MatchCondition> getOptimizeSettings() { return Set.copyOf(_optimizeSettings); }
 
   public void setOptimizeSettings(final MatchCondition... optimizeSettings) {
@@ -180,7 +199,7 @@ public class ColladaImporter {
     final ColladaMeshUtils colladaMeshUtils =
         new ColladaMeshUtils(dataCache, colladaDOMUtil, colladaMaterialUtils, _optimizeMeshes, _optimizeSettings);
     final ColladaAnimUtils colladaAnimUtils =
-        new ColladaAnimUtils(colladaStorage, dataCache, colladaDOMUtil, colladaMeshUtils);
+        new ColladaAnimUtils(this, colladaStorage, dataCache, colladaDOMUtil, colladaMeshUtils);
     final ColladaNodeUtils colladaNodeUtils =
         new ColladaNodeUtils(this, dataCache, colladaDOMUtil, colladaMaterialUtils, colladaMeshUtils, colladaAnimUtils);
 

--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaNodeUtils.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaNodeUtils.java
@@ -397,6 +397,14 @@ public class ColladaNodeUtils {
         logger.warning("transform not currently supported: " + transform.getClass().getCanonicalName());
       }
     }
+    if (_importer.isOrthonormalizeTransforms()) {
+      try {
+        finalMat.orthonormalizeLocal();
+      } catch (final ArithmeticException e) {
+        logger.warning("Could not orthonormalize a node transform with a rank-deficient rotation "
+            + "block; leaving it as-is.");
+      }
+    }
     return new Transform().fromHomogeneousMatrix(finalMat);
   }
 

--- a/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaNodeUtils.java
+++ b/ardor3d-collada/src/main/java/com/ardor3d/extension/model/collada/jdom/ColladaNodeUtils.java
@@ -363,49 +363,54 @@ public class ColladaNodeUtils {
     final Matrix4 workingMat = Matrix4.fetchTempInstance();
     final Matrix4 finalMat = Matrix4.fetchTempInstance();
     finalMat.setIdentity();
-    for (final Element transform : transforms) {
-      final double[] array = _colladaDOMUtil.parseDoubleArray(transform);
-      if ("translate".equals(transform.getName())) {
-        workingMat.setIdentity();
-        workingMat.setColumn(3, new Vector4(array[0], array[1], array[2], 1.0));
-        finalMat.multiplyLocal(workingMat);
-      } else if ("rotate".equals(transform.getName())) {
-        if (array[3] != 0) {
+    try {
+      for (final Element transform : transforms) {
+        final double[] array = _colladaDOMUtil.parseDoubleArray(transform);
+        if ("translate".equals(transform.getName())) {
           workingMat.setIdentity();
-          final Matrix3 rotate =
-              new Matrix3().fromAngleAxis(array[3] * MathUtils.DEG_TO_RAD, new Vector3(array[0], array[1], array[2]));
-          workingMat.set(rotate);
+          workingMat.setColumn(3, new Vector4(array[0], array[1], array[2], 1.0));
           finalMat.multiplyLocal(workingMat);
+        } else if ("rotate".equals(transform.getName())) {
+          if (array[3] != 0) {
+            workingMat.setIdentity();
+            final Matrix3 rotate =
+                new Matrix3().fromAngleAxis(array[3] * MathUtils.DEG_TO_RAD, new Vector3(array[0], array[1], array[2]));
+            workingMat.set(rotate);
+            finalMat.multiplyLocal(workingMat);
+          }
+        } else if ("scale".equals(transform.getName())) {
+          workingMat.setIdentity();
+          workingMat.scale(new Vector4(array[0], array[1], array[2], 1), workingMat);
+          finalMat.multiplyLocal(workingMat);
+        } else if ("matrix".equals(transform.getName())) {
+          workingMat.fromArray(array);
+          finalMat.multiplyLocal(workingMat);
+        } else if ("lookat".equals(transform.getName())) {
+          final Vector3 pos = new Vector3(array[0], array[1], array[2]);
+          final Vector3 target = new Vector3(array[3], array[4], array[5]);
+          final Vector3 up = new Vector3(array[6], array[7], array[8]);
+          final Matrix3 rot = new Matrix3();
+          rot.lookAt(target.subtractLocal(pos), up);
+          workingMat.set(rot);
+          workingMat.setColumn(3, new Vector4(array[0], array[1], array[2], 1));
+          finalMat.multiplyLocal(workingMat);
+        } else {
+          logger.warning("transform not currently supported: " + transform.getClass().getCanonicalName());
         }
-      } else if ("scale".equals(transform.getName())) {
-        workingMat.setIdentity();
-        workingMat.scale(new Vector4(array[0], array[1], array[2], 1), workingMat);
-        finalMat.multiplyLocal(workingMat);
-      } else if ("matrix".equals(transform.getName())) {
-        workingMat.fromArray(array);
-        finalMat.multiplyLocal(workingMat);
-      } else if ("lookat".equals(transform.getName())) {
-        final Vector3 pos = new Vector3(array[0], array[1], array[2]);
-        final Vector3 target = new Vector3(array[3], array[4], array[5]);
-        final Vector3 up = new Vector3(array[6], array[7], array[8]);
-        final Matrix3 rot = new Matrix3();
-        rot.lookAt(target.subtractLocal(pos), up);
-        workingMat.set(rot);
-        workingMat.setColumn(3, new Vector4(array[0], array[1], array[2], 1));
-        finalMat.multiplyLocal(workingMat);
-      } else {
-        logger.warning("transform not currently supported: " + transform.getClass().getCanonicalName());
       }
-    }
-    if (_importer.isOrthonormalizeTransforms()) {
-      try {
-        finalMat.orthonormalizeLocal();
-      } catch (final ArithmeticException e) {
-        logger.warning("Could not orthonormalize a node transform with a rank-deficient rotation "
-            + "block; leaving it as-is.");
+      if (_importer.isOrthonormalizeTransforms()) {
+        try {
+          finalMat.orthonormalizeLocal();
+        } catch (final ArithmeticException e) {
+          logger.warning("Could not orthonormalize a node transform with a rank-deficient rotation "
+              + "block; leaving it as-is.");
+        }
       }
+      return new Transform().fromHomogeneousMatrix(finalMat);
+    } finally {
+      Matrix4.releaseTempInstance(workingMat);
+      Matrix4.releaseTempInstance(finalMat);
     }
-    return new Transform().fromHomogeneousMatrix(finalMat);
   }
 
   public void reattachAttachments(final Node scene) {

--- a/ardor3d-collada/src/test/java/com/ardor3d/extension/model/collada/jdom/TestColladaOrthonormalize.java
+++ b/ardor3d-collada/src/test/java/com/ardor3d/extension/model/collada/jdom/TestColladaOrthonormalize.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.model.collada.jdom;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ardor3d.extension.model.collada.jdom.data.ColladaStorage;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyTransform;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.util.resource.StringResourceSource;
+
+/**
+ * Some exporters (e.g. Autodesk FBX-to-Collada, OpenCollada) bake enough rounding error into a
+ * {@code <node>}'s {@code <matrix>} that its rotational 3x3 block is no longer orthonormal, which
+ * trips Ardor3D's "non-rotational matrices" handling. {@link ColladaImporter#setOrthonormalizeTransforms(boolean)}
+ * cleans that up at import time while preserving translation.
+ */
+public class TestColladaOrthonormalize {
+
+  /**
+   * A minimal scene whose single node carries a near-rotation {@code <matrix>}: the upper-left 3x3 is
+   * a slightly skewed identity (off by more than ZERO_TOLERANCE) and the last column is a (5, 6, 7)
+   * translation. COLLADA matrices are row-major.
+   */
+  private static final String SKEWED_MATRIX_DAE = "<?xml version=\"1.0\"?>" //
+      + "<COLLADA version=\"1.4.1\">" //
+      + "<asset/>" //
+      + "<library_visual_scenes><visual_scene id=\"scene\">" //
+      + "<node id=\"n1\" name=\"n1\">" //
+      + "<matrix>" //
+      + "1 0.02 0 5 " //
+      + "0 1 0.03 6 " //
+      + "0.04 0 1 7 " //
+      + "0 0 0 1" //
+      + "</matrix>" //
+      + "</node>" //
+      + "</visual_scene></library_visual_scenes>" //
+      + "<scene><instance_visual_scene url=\"#scene\"/></scene>" //
+      + "</COLLADA>";
+
+  private static ReadOnlyTransform loadNodeTransform(final boolean orthonormalize) throws Exception {
+    final ColladaImporter importer = new ColladaImporter() //
+        .setLoadAnimations(false) //
+        .setOrthonormalizeTransforms(orthonormalize);
+    final ColladaStorage storage = importer.load(new StringResourceSource(SKEWED_MATRIX_DAE, ".dae"));
+    final Node node = (Node) storage.getScene().getChild("n1");
+    return node.getTransform();
+  }
+
+  @Test
+  public void offByDefault_leavesTheNonRotationalMatrixAlone() throws Exception {
+    final ReadOnlyTransform t = loadNodeTransform(false);
+    // The skewed 3x3 is not orthonormal, so the Transform reports it is not a rotation matrix.
+    assertFalse(t.isRotationMatrix());
+    assertFalse(t.getMatrix().isOrthonormal());
+  }
+
+  @Test
+  public void whenEnabled_orthonormalizesRotationButKeepsTranslation() throws Exception {
+    final ReadOnlyTransform t = loadNodeTransform(true);
+    assertTrue("rotation block should have been orthonormalized", t.isRotationMatrix());
+    assertTrue(t.getMatrix().isOrthonormal());
+    // the translation column must be passed through untouched.
+    assertEquals(new Vector3(5, 6, 7), t.getTranslation());
+  }
+}


### PR DESCRIPTION
## What

Adds `ColladaImporter.setOrthonormalizeTransforms(boolean)` (off by default). When enabled, the rotational upper-left 3×3 of every baked **node** and **animation-channel** transform is cleaned with `Matrix4.orthonormalizeLocal()` (Gram-Schmidt, added in #137) right before it becomes a `Transform` — preserving the translation column.

Wiring:
- New flag on `ColladaImporter`, following the existing `setLoadTextures`/`setFlipTransparency` pattern.
- Applied at the two `fromHomogeneousMatrix` choke points: `ColladaNodeUtils.getNodeTransforms` (node/joint transforms) and `ColladaAnimUtils.bakeTransforms` (animation samples).
- `ColladaAnimUtils` is now handed the `ColladaImporter` in its constructor so it can read the flag, mirroring how `ColladaNodeUtils` and `ColladaMaterialUtils` already take it.

## Why

Autodesk FBX→Collada and OpenCollada exporters frequently bake enough floating-point rounding error into `<matrix>` transforms that the 3×3 rotational block fails `isOrthonormal()`. On skeletal import this trips the long-standing `"supplied transform with non-rotational matrices. May have unexpected results."` warning flood and degrades the rotation extracted for each channel. This gives users a one-call opt-in to clean those matrices at import. Addresses the importer half of #32.

## Design notes

- **Opt-in on purpose.** Orthonormalizing discards any scale/shear baked into a `<matrix>`, and we can't tell intentional shear from rounding noise — so it's off by default and documented as "only enable when your source encodes pure rotation + translation." This matches the conclusion reached in the #32 discussion (don't auto-enforce).
- **Best-effort, never fatal.** A genuinely rank-deficient block (e.g. a collapsed/zero-scale transform) makes `orthonormalizeLocal()` throw `ArithmeticException`; that's caught per-transform and the matrix is left as-is with a warning, rather than aborting the whole load.

## Tests

New `TestColladaOrthonormalize` loads an inline `.dae` whose single node carries a slightly-skewed near-identity `<matrix>` plus a translation:
- **off by default** → the node's transform reports a non-rotational matrix (current behavior preserved).
- **enabled** → the 3×3 is orthonormal (`isRotationMatrix()` true) and the `(5, 6, 7)` translation is preserved.

Full `ardor3d-collada` suite green (7 tests, 0 failures). The node path is covered directly; the animation-channel path shares the identical mechanism at the sibling choke point.

## Follow-up

Depends on #137 (merged). Issue #32 can be closed once this lands; I'll leave the issue comment to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: temp-pool cleanup

Folded in a fix for a pre-existing leak in the two methods this PR already touches: `bakeTransforms` and `getNodeTransforms` each fetched two `Matrix4.fetchTempInstance()` temps and never released them. Their bodies are now wrapped in `try/finally` so both temps are returned to the per-thread pool on all paths (including exceptions). `finalMat` is still consumed by `fromHomogeneousMatrix` in the `return` expression before the `finally` runs, so there is no use-after-release.