### PR TITLE
Fix lit rendering on strict GL drivers; add a GL smoke test to CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,8 +23,15 @@ jobs:
         distribution: 'temurin'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+    - name: Install Xvfb and Mesa for the GL smoke test
+      run: sudo apt-get update && sudo apt-get install -y xvfb libgl1-mesa-dri libxrandr2 libxinerama1 libxcursor1 libxi6
+    # Xvfb + llvmpipe give the GL smoke test (GlLitRenderSmokeTest) a strict software GL stack;
+    # ARDOR3D_REQUIRE_GL_SMOKE turns its no-GL-available skip into a failure so the net can't rot.
     - name: Build with Gradle
-      run: ./gradlew build
+      run: xvfb-run -a --server-args="-screen 0 1280x720x24" ./gradlew build
+      env:
+        LIBGL_ALWAYS_SOFTWARE: "1"
+        ARDOR3D_REQUIRE_GL_SMOKE: "1"
     - name: Publish artifacts
       uses: actions/upload-artifact@v4.3.3
       with:

--- a/ardor3d-core/src/main/java/com/ardor3d/light/Light.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/light/Light.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -151,6 +151,20 @@ public abstract class Light extends Spatial implements Serializable, Savable, IU
    *          appropriate RenderMaterial.)
    */
   public void setShadowCaster(final boolean mayCastShadows) { _shadowCaster = mayCastShadows; }
+
+  @Override
+  public Light makeCopy(final boolean shareGeometricData) {
+    // get copy of basic spatial info
+    final Light light = (Light) super.makeCopy(shareGeometricData);
+
+    // copy our light properties
+    light.setColor(_color);
+    light.setIntensity(_intensity);
+    light.setEnabled(_enabled);
+    light.setShadowCaster(_shadowCaster);
+
+    return light;
+  }
 
   @Override
   public List<UniformRef> getUniforms() { return _cachedUniforms; }

--- a/ardor3d-core/src/main/java/com/ardor3d/light/LightManager.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/light/LightManager.java
@@ -54,10 +54,13 @@ public class LightManager implements IUniformSupplier {
     for (int i = 0; i < LightManager.MAX_LIGHTS; i++) {
       _cachedUniforms.add(new UniformRef("lights[" + i + "]", UniformType.UniformSupplier, UniformSource.Ardor3dState,
           Ardor3dStateProperty.Light, i, null));
+      // The two sampler arrays have different GLSL types, so they must resolve to disjoint
+      // texture units - strict drivers (all of Mesa) reject draws where two sampler types
+      // share a unit with GL_INVALID_OPERATION.
       _cachedUniforms.add(new UniformRef("spotShadowMaps[" + i + "]", UniformType.Int1, UniformSource.Ardor3dState,
-          Ardor3dStateProperty.ShadowTexture, i, null));
+          Ardor3dStateProperty.SpotShadowTexture, i, null));
       _cachedUniforms.add(new UniformRef("pointShadowMaps[" + i + "]", UniformType.Int1, UniformSource.Ardor3dState,
-          Ardor3dStateProperty.ShadowTexture, i, null));
+          Ardor3dStateProperty.PointShadowTexture, i, null));
     }
 
     _cachedUniforms.add(new UniformRef("globalAmbient", UniformType.Float3, UniformSource.Ardor3dState,

--- a/ardor3d-core/src/main/java/com/ardor3d/light/PointLight.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/light/PointLight.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -126,6 +126,20 @@ public class PointLight extends Light {
    *          the maximum world distance at which this light will affect geometry
    */
   public void setRange(final float range) { _range = range; }
+
+  @Override
+  public PointLight makeCopy(final boolean shareGeometricData) {
+    // get copy of basic light info
+    final PointLight light = (PointLight) super.makeCopy(shareGeometricData);
+
+    // copy our attenuation properties
+    light.setConstant(_constant);
+    light.setLinear(_linear);
+    light.setQuadratic(_quadratic);
+    light.setRange(_range);
+
+    return light;
+  }
 
   @Override
   public AbstractShadowData getShadowData() { return _shadowData; }

--- a/ardor3d-core/src/main/java/com/ardor3d/light/SpotLight.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/light/SpotLight.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -147,6 +147,18 @@ public class SpotLight extends PointLight {
    *          the angle (in radians)
    */
   public void setInnerAngle(final float angle) { _innerAngle = angle; }
+
+  @Override
+  public SpotLight makeCopy(final boolean shareGeometricData) {
+    // get copy of basic light info
+    final SpotLight light = (SpotLight) super.makeCopy(shareGeometricData);
+
+    // copy our cone properties
+    light.setAngle(_angle);
+    light.setInnerAngle(_innerAngle);
+
+    return light;
+  }
 
   /**
    * <code>getType</code> returns the type of this light (Type.Spot).

--- a/ardor3d-core/src/main/java/com/ardor3d/renderer/material/uniform/Ardor3dStateProperty.java
+++ b/ardor3d-core/src/main/java/com/ardor3d/renderer/material/uniform/Ardor3dStateProperty.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -46,6 +46,20 @@ public enum Ardor3dStateProperty {
    * Bind a shadow texture to a given unit and return the unit to the shader.
    */
   ShadowTexture,
+
+  /**
+   * Unit for a spot light's 2D shadow map (sampler2DShadow). The light index comes from the extra
+   * field. Uses a texture unit range disjoint from {@link #PointShadowTexture} - two sampler
+   * uniforms of different types must never point at the same unit, or strict drivers reject the
+   * draw with GL_INVALID_OPERATION.
+   */
+  SpotShadowTexture,
+
+  /**
+   * Unit for a point light's cube shadow map (samplerCubeShadow). The light index comes from the
+   * extra field. See {@link #SpotShadowTexture} for why the ranges are disjoint.
+   */
+  PointShadowTexture,
 
   /**
    * Current global ambient set on the current LightManager (from current SceneIndexer).

--- a/ardor3d-core/src/test/java/com/ardor3d/light/TestLightMakeCopy.java
+++ b/ardor3d-core/src/test/java/com/ardor3d/light/TestLightMakeCopy.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.light;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ardor3d.math.ColorRGBA;
+
+/**
+ * Tests that Spatial.makeCopy on lights preserves light state, not just the base spatial
+ * fields. (Before the Light overrides existed, a copied light silently reverted to defaults -
+ * white, intensity 1, enabled.)
+ */
+public class TestLightMakeCopy {
+
+  @Test
+  public void pointLightCopiesLightAndAttenuationState() {
+    final PointLight light = new PointLight();
+    light.setName("point");
+    light.setColor(ColorRGBA.RED);
+    light.setIntensity(0.3f);
+    light.setEnabled(false);
+    light.setShadowCaster(true);
+    light.setConstant(0.5f);
+    light.setLinear(0.25f);
+    light.setQuadratic(0.125f);
+    light.setRange(42f);
+
+    final PointLight copy = (PointLight) light.makeCopy(true);
+
+    assertEquals("point", copy.getName());
+    assertEquals(ColorRGBA.RED, copy.getColor());
+    assertEquals(0.3f, copy.getIntensity(), 0f);
+    assertFalse(copy.isEnabled());
+    assertTrue(copy.isShadowCaster());
+    assertEquals(0.5f, copy.getConstant(), 0f);
+    assertEquals(0.25f, copy.getLinear(), 0f);
+    assertEquals(0.125f, copy.getQuadratic(), 0f);
+    assertEquals(42f, copy.getRange(), 0f);
+  }
+
+  @Test
+  public void spotLightCopiesConeState() {
+    final SpotLight light = new SpotLight();
+    light.setColor(ColorRGBA.GREEN);
+    light.setIntensity(2f);
+    light.setAngle(0.75f);
+    light.setInnerAngle(0.5f);
+    light.setRange(10f);
+
+    final SpotLight copy = (SpotLight) light.makeCopy(true);
+
+    assertEquals(ColorRGBA.GREEN, copy.getColor());
+    assertEquals(2f, copy.getIntensity(), 0f);
+    assertEquals(0.75f, copy.getAngle(), 0f);
+    assertEquals(0.5f, copy.getInnerAngle(), 0f);
+    assertEquals(10f, copy.getRange(), 0f);
+  }
+
+  @Test
+  public void directionalLightCopiesBaseLightState() {
+    final DirectionalLight light = new DirectionalLight();
+    light.setColor(ColorRGBA.BLUE);
+    light.setIntensity(1.5f);
+    light.setEnabled(false);
+
+    final DirectionalLight copy = (DirectionalLight) light.makeCopy(true);
+
+    assertEquals(ColorRGBA.BLUE, copy.getColor());
+    assertEquals(1.5f, copy.getIntensity(), 0f);
+    assertFalse(copy.isEnabled());
+  }
+}

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/probe/WslgTriangleProbe.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/probe/WslgTriangleProbe.java
@@ -43,6 +43,20 @@ import com.ardor3d.util.MaterialUtil;
  */
 public class WslgTriangleProbe extends ExampleBase {
 
+  /** Background clear color; pixel classification matches readback against its 8-bit channels. */
+  private static final ColorRGBA CLEAR_COLOR = new ColorRGBA(0.1f, 0.15f, 0.3f, 1f);
+  private static final int BG_RED = Math.round(CLEAR_COLOR.getRed() * 255);
+  private static final int BG_GREEN = Math.round(CLEAR_COLOR.getGreen() * 255);
+  private static final int BG_BLUE = Math.round(CLEAR_COLOR.getBlue() * 255);
+  /** Max per-channel distance from the clear color to still count as background. */
+  private static final int BG_TOLERANCE = 15;
+  /** The control line is saturated green: green above this floor and dominating red/blue. */
+  private static final int LINE_MIN_GREEN = 96;
+  private static final int LINE_GREEN_DOMINANCE = 2;
+  /** The box is bright and near-neutral: red/blue floors plus an overall brightness floor. */
+  private static final int BOX_MIN_RED_BLUE = 40;
+  private static final int BOX_MIN_BRIGHTNESS = 150;
+
   private int _frames = 0;
 
   public static void main(final String[] args) {
@@ -87,7 +101,7 @@ public class WslgTriangleProbe extends ExampleBase {
     if (_frames == 0) {
       // Non-black clear color: if the readback can't even see this, glReadPixels itself is
       // broken and pixel counts of zero say nothing about drawing.
-      renderer.setBackgroundColor(new ColorRGBA(0.1f, 0.15f, 0.3f, 1f));
+      renderer.setBackgroundColor(CLEAR_COLOR);
     }
 
     super.renderExample(renderer);
@@ -113,12 +127,12 @@ public class WslgTriangleProbe extends ExampleBase {
       final int r = buff.get(i * 3) & 0xFF;
       final int g = buff.get(i * 3 + 1) & 0xFF;
       final int b = buff.get(i * 3 + 2) & 0xFF;
-      // clear color is (0.1, 0.15, 0.3) -> roughly (26, 38, 77)
-      if (Math.abs(r - 26) < 15 && Math.abs(g - 38) < 15 && Math.abs(b - 77) < 15) {
+      if (Math.abs(r - BG_RED) < BG_TOLERANCE && Math.abs(g - BG_GREEN) < BG_TOLERANCE
+          && Math.abs(b - BG_BLUE) < BG_TOLERANCE) {
         background++;
-      } else if (g > 96 && g > 2 * r && g > 2 * b) {
+      } else if (g > LINE_MIN_GREEN && g > LINE_GREEN_DOMINANCE * r && g > LINE_GREEN_DOMINANCE * b) {
         linePixels++; // saturated green - the control line
-      } else if (r > 40 && b > 40 && r + g + b > 150) {
+      } else if (r > BOX_MIN_RED_BLUE && b > BOX_MIN_RED_BLUE && r + g + b > BOX_MIN_BRIGHTNESS) {
         boxPixels++; // white/gray - the box under white light (or unlit white)
       }
     }

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/probe/WslgTriangleProbe.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/probe/WslgTriangleProbe.java
@@ -21,6 +21,7 @@ import org.lwjgl.opengl.GL11C;
 import com.ardor3d.bounding.BoundingBox;
 import com.ardor3d.buffer.BufferUtils;
 import com.ardor3d.example.ExampleBase;
+import com.ardor3d.example.PropertiesGameSettings;
 import com.ardor3d.image.ImageDataFormat;
 import com.ardor3d.math.ColorRGBA;
 import com.ardor3d.math.Vector3;
@@ -61,6 +62,12 @@ public class WslgTriangleProbe extends ExampleBase {
 
   public static void main(final String[] args) {
     start(WslgTriangleProbe.class);
+  }
+
+  @Override
+  protected PropertiesGameSettings getAttributes(final PropertiesGameSettings settings) {
+    // Never show the settings dialog - this probe runs unattended.
+    return settings;
   }
 
   @Override
@@ -113,6 +120,10 @@ public class WslgTriangleProbe extends ExampleBase {
     System.out.println("PROBE GL_VENDOR:   " + GL11C.glGetString(GL11C.GL_VENDOR));
     System.out.println("PROBE GL_RENDERER: " + GL11C.glGetString(GL11C.GL_RENDERER));
     System.out.println("PROBE GL_VERSION:  " + GL11C.glGetString(GL11C.GL_VERSION));
+    System.out.println("PROBE MAX_TEXTURE_IMAGE_UNITS (fragment): "
+        + GL11C.glGetInteger(org.lwjgl.opengl.GL20C.GL_MAX_TEXTURE_IMAGE_UNITS));
+    System.out.println("PROBE MAX_COMBINED_TEXTURE_IMAGE_UNITS:   "
+        + GL11C.glGetInteger(org.lwjgl.opengl.GL20C.GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS));
 
     final Camera cam = _canvas.getCanvasRenderer().getCamera();
     final int width = cam.getWidth();

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/probe/WslgTriangleProbe.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/probe/WslgTriangleProbe.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.example.probe;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.ByteBuffer;
+
+import javax.imageio.ImageIO;
+
+import org.lwjgl.opengl.GL11C;
+
+import com.ardor3d.bounding.BoundingBox;
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.example.ExampleBase;
+import com.ardor3d.image.ImageDataFormat;
+import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.Renderer;
+import com.ardor3d.renderer.state.CullState;
+import com.ardor3d.scenegraph.Line;
+import com.ardor3d.scenegraph.shape.Box;
+import com.ardor3d.util.MaterialUtil;
+
+/**
+ * Self-measuring probe for the WSLg missing-triangles issue: renders a box (the triangle-mesh
+ * case under test) beside a bright green line X (the control - engine lines are known to render
+ * under WSLg), then reads back the framebuffer at frame 30, classifies pixels, optionally saves
+ * a PNG, prints one PROBE result line and exits.
+ *
+ * System properties: -Dprobe.material=unlit forces basic_white.yaml on the box (the editor grid
+ * uses the unlit path); -Dprobe.cull=none disables face culling on the box; -Dprobe.out=path
+ * writes the grabbed frame as a PNG.
+ */
+public class WslgTriangleProbe extends ExampleBase {
+
+  private int _frames = 0;
+
+  public static void main(final String[] args) {
+    start(WslgTriangleProbe.class);
+  }
+
+  @Override
+  protected void initExample() {
+    _canvas.setTitle("WSLg triangle probe");
+
+    final Camera cam = _canvas.getCanvasRenderer().getCamera();
+    cam.setLocation(new Vector3(0, 0, 22));
+    cam.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+
+    final Box box = new Box("Box", Vector3.ZERO, 3, 3, 3);
+    box.setModelBound(new BoundingBox());
+    if ("unlit".equals(System.getProperty("probe.material"))) {
+      box.setRenderMaterial("basic_white.yaml");
+    }
+    if ("none".equals(System.getProperty("probe.cull"))) {
+      final CullState cull = new CullState();
+      cull.setCullFace(CullState.Face.None);
+      box.setRenderState(cull);
+    }
+    _root.attachChild(box);
+
+    // Control: a green X of engine Lines beside the box.
+    final Vector3[] verts = {
+        new Vector3(-9, -4, 0), new Vector3(-5, 4, 0),
+        new Vector3(-5, -4, 0), new Vector3(-9, 4, 0)
+    };
+    final Line line = new Line("ControlLine", verts, null, null, null);
+    line.setDefaultColor(new ColorRGBA(0f, 1f, 0f, 1f));
+    line.setLineWidth(3f);
+    _root.attachChild(line);
+
+    MaterialUtil.autoMaterials(_root);
+  }
+
+  @Override
+  protected void renderExample(final Renderer renderer) {
+    if (_frames == 0) {
+      // Non-black clear color: if the readback can't even see this, glReadPixels itself is
+      // broken and pixel counts of zero say nothing about drawing.
+      renderer.setBackgroundColor(new ColorRGBA(0.1f, 0.15f, 0.3f, 1f));
+    }
+
+    super.renderExample(renderer);
+
+    if (++_frames != 30) {
+      return;
+    }
+
+    System.out.println("PROBE GL_VENDOR:   " + GL11C.glGetString(GL11C.GL_VENDOR));
+    System.out.println("PROBE GL_RENDERER: " + GL11C.glGetString(GL11C.GL_RENDERER));
+    System.out.println("PROBE GL_VERSION:  " + GL11C.glGetString(GL11C.GL_VERSION));
+
+    final Camera cam = _canvas.getCanvasRenderer().getCamera();
+    final int width = cam.getWidth();
+    final int height = cam.getHeight();
+    final ByteBuffer buff = BufferUtils.createByteBuffer(width * height * 3);
+    renderer.grabScreenContents(buff, ImageDataFormat.RGB, 0, 0, width, height);
+
+    int background = 0;
+    int linePixels = 0;
+    int boxPixels = 0;
+    for (int i = 0, max = width * height; i < max; i++) {
+      final int r = buff.get(i * 3) & 0xFF;
+      final int g = buff.get(i * 3 + 1) & 0xFF;
+      final int b = buff.get(i * 3 + 2) & 0xFF;
+      // clear color is (0.1, 0.15, 0.3) -> roughly (26, 38, 77)
+      if (Math.abs(r - 26) < 15 && Math.abs(g - 38) < 15 && Math.abs(b - 77) < 15) {
+        background++;
+      } else if (g > 96 && g > 2 * r && g > 2 * b) {
+        linePixels++; // saturated green - the control line
+      } else if (r > 40 && b > 40 && r + g + b > 150) {
+        boxPixels++; // white/gray - the box under white light (or unlit white)
+      }
+    }
+
+    final int cx = width / 2, cy = height / 2;
+    final int ci = (cy * width + cx) * 3;
+    System.out.println("PROBE size=" + width + "x" + height + " bgPixels=" + background + " linePixels=" + linePixels
+        + " boxPixels=" + boxPixels + " centerRGB=" + (buff.get(ci) & 0xFF) + "," + (buff.get(ci + 1) & 0xFF) + ","
+        + (buff.get(ci + 2) & 0xFF));
+
+    final String out = System.getProperty("probe.out");
+    if (out != null) {
+      try {
+        final BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < height; y++) {
+          for (int x = 0; x < width; x++) {
+            final int i = (y * width + x) * 3;
+            final int rgb = ((buff.get(i) & 0xFF) << 16) | ((buff.get(i + 1) & 0xFF) << 8) | (buff.get(i + 2) & 0xFF);
+            img.setRGB(x, height - 1 - y, rgb); // GL rows are bottom-up
+          }
+        }
+        ImageIO.write(img, "png", new File(out));
+        System.out.println("PROBE png=" + out);
+      } catch (final Exception ex) {
+        System.out.println("PROBE png write failed: " + ex);
+      }
+    }
+
+    _exit = true;
+  }
+}

--- a/ardor3d-lwjgl3/src/main/java/com/ardor3d/scene/state/lwjgl3/util/Lwjgl3ShaderUtils.java
+++ b/ardor3d-lwjgl3/src/main/java/com/ardor3d/scene/state/lwjgl3/util/Lwjgl3ShaderUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -36,6 +36,8 @@ import org.lwjgl.system.MemoryStack;
 
 import com.ardor3d.buffer.AbstractBufferData;
 import com.ardor3d.buffer.AbstractBufferData.VBOAccessMode;
+import com.ardor3d.image.Texture2D;
+import com.ardor3d.image.TextureCubeMap;
 import com.ardor3d.light.LightManager;
 import com.ardor3d.light.LightProperties;
 import com.ardor3d.math.Matrix3;
@@ -585,6 +587,32 @@ public class Lwjgl3ShaderUtils implements IShaderUtils {
         final var unit = LightManager.FIRST_SHADOW_INDEX + index;
         // bind to texture unit
         if (tex != null) {
+          Lwjgl3TextureStateUtil.doTextureBind(tex, unit, false);
+        }
+        return stack.mallocInt(1).put(unit).flip();
+      }
+
+      // Spot and point shadow samplers have different GLSL types, so they get disjoint texture
+      // unit ranges - two sampler uniforms of different types pointing at the same unit make
+      // strict drivers (all of Mesa) reject every draw with GL_INVALID_OPERATION. Each case
+      // binds only its own texture kind; the light at this index has at most one of the two.
+      case SpotShadowTexture: {
+        final int index = ((Number) extra).intValue();
+        final var lm = SceneIndexer.getCurrent().getLightManager();
+        final var tex = lm.getCurrentShadowTexture(index);
+        final var unit = LightManager.FIRST_SHADOW_INDEX + index;
+        if (tex instanceof Texture2D) {
+          Lwjgl3TextureStateUtil.doTextureBind(tex, unit, false);
+        }
+        return stack.mallocInt(1).put(unit).flip();
+      }
+
+      case PointShadowTexture: {
+        final int index = ((Number) extra).intValue();
+        final var lm = SceneIndexer.getCurrent().getLightManager();
+        final var tex = lm.getCurrentShadowTexture(index);
+        final var unit = LightManager.FIRST_SHADOW_INDEX + LightManager.MAX_LIGHTS + index;
+        if (tex instanceof TextureCubeMap) {
           Lwjgl3TextureStateUtil.doTextureBind(tex, unit, false);
         }
         return stack.mallocInt(1).put(unit).flip();

--- a/ardor3d-lwjgl3/src/test/java/com/ardor3d/renderer/lwjgl3/GlLitRenderSmokeTest.java
+++ b/ardor3d-lwjgl3/src/test/java/com/ardor3d/renderer/lwjgl3/GlLitRenderSmokeTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.renderer.lwjgl3;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import com.ardor3d.bounding.BoundingBox;
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.framework.DisplaySettings;
+import com.ardor3d.framework.Scene;
+import com.ardor3d.framework.lwjgl3.GLFWCanvas;
+import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer;
+import com.ardor3d.image.ImageDataFormat;
+import com.ardor3d.intersection.PickResults;
+import com.ardor3d.light.PointLight;
+import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Ray3;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.Renderer;
+import com.ardor3d.renderer.material.MaterialManager;
+import com.ardor3d.scenegraph.Line;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.SceneIndexer;
+import com.ardor3d.scenegraph.shape.Box;
+import com.ardor3d.util.MaterialUtil;
+import com.ardor3d.util.resource.ResourceLocatorTool;
+import com.ardor3d.util.resource.SimpleResourceLocator;
+
+/**
+ * GL smoke test: renders a lit box, an unlit box and a line into a real GL context and asserts
+ * that each path actually produces pixels. This guards against the class of bug where a strict
+ * driver (all of Mesa - llvmpipe, WSLg's D3D12, Linux Intel/AMD) rejects draws that lenient
+ * drivers accept - e.g. two sampler uniforms of different types sharing a texture unit, which
+ * silently blanked the entire lit pipeline while NVIDIA rendered it fine.
+ *
+ * The test SKIPS when no usable GL context or framebuffer readback is available (headless CI
+ * without Xvfb, WSLg's D3D12 readback), so it cannot break builds over infrastructure. Set
+ * ARDOR3D_REQUIRE_GL_SMOKE=1 (as CI does, under Xvfb + llvmpipe) to turn those skips into
+ * failures so the net cannot silently rot.
+ */
+public class GlLitRenderSmokeTest {
+
+  private static final int SIZE = 256;
+  private static final ColorRGBA CLEAR_COLOR = new ColorRGBA(0.1f, 0.15f, 0.3f, 1f);
+  private static final int GRAB_FRAME = 12;
+
+  /** Renders the probe scene and counts classified pixels at frame {@link #GRAB_FRAME}. */
+  private static class ProbeScene implements Scene {
+    private final Node _root = new Node("root");
+    private boolean _initialized = false;
+    private int _frames = 0;
+
+    boolean done = false;
+    int bgPixels, litPixels, unlitPixels, linePixels;
+    String glRenderer;
+
+    @Override
+    public boolean render(final Renderer renderer) {
+      final var canvasRenderer = com.ardor3d.renderer.ContextManager.getCurrentContext();
+      final Camera cam = Camera.getCurrentCamera();
+
+      if (!_initialized) {
+        _initialized = true;
+        renderer.setBackgroundColor(CLEAR_COLOR);
+        cam.setLocation(new Vector3(0, 0, 22));
+        cam.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+        cam.setFrustumPerspective(45.0, 1.0, 0.1, 100.0);
+        buildScene();
+        SceneIndexer.getCurrent().addSceneRoot(_root);
+        glRenderer = org.lwjgl.opengl.GL11C.glGetString(org.lwjgl.opengl.GL11C.GL_RENDERER);
+      }
+
+      _root.updateGeometricState(0.05, true);
+      SceneIndexer.getCurrent().onRender(renderer);
+
+      cam.apply(renderer);
+      _root.onDraw(renderer);
+      renderer.renderBuckets();
+
+      if (++_frames == GRAB_FRAME) {
+        classifyPixels(renderer);
+        done = true;
+      }
+      return canvasRenderer != null;
+    }
+
+    private void buildScene() {
+      // Right half: lit box (the path strict drivers rejected)
+      final Box litBox = new Box("LitBox", Vector3.ZERO, 2.5, 2.5, 2.5);
+      litBox.setModelBound(new BoundingBox());
+      litBox.setTranslation(4.5, 1.0, 0.0);
+      _root.attachChild(litBox);
+
+      // Left half: unlit box
+      final Box unlitBox = new Box("UnlitBox", Vector3.ZERO, 2.5, 2.5, 2.5);
+      unlitBox.setModelBound(new BoundingBox());
+      unlitBox.setTranslation(-4.5, 1.0, 0.0);
+      unlitBox.setRenderMaterial("basic_white.yaml");
+      _root.attachChild(unlitBox);
+
+      // Bottom band: green line
+      final Line line = new Line("ControlLine",
+          new Vector3[] {new Vector3(-4, -6.5, 0), new Vector3(4, -6.5, 0)}, null, null, null);
+      line.setDefaultColor(new ColorRGBA(0f, 1f, 0f, 1f));
+      line.setLineWidth(3f);
+      _root.attachChild(line);
+
+      final PointLight light = new PointLight();
+      light.setColor(ColorRGBA.WHITE);
+      light.setIntensity(0.75f);
+      light.setTranslation(10, 10, 10);
+      light.setEnabled(true);
+      _root.attachChild(light);
+
+      MaterialUtil.autoMaterials(_root);
+    }
+
+    private void classifyPixels(final Renderer renderer) {
+      final ByteBuffer buff = BufferUtils.createByteBuffer(SIZE * SIZE * 3);
+      renderer.grabScreenContents(buff, ImageDataFormat.RGB, 0, 0, SIZE, SIZE);
+
+      final int bottomBand = (int) (SIZE * 0.30); // buffer rows are bottom-up
+      for (int y = 0; y < SIZE; y++) {
+        for (int x = 0; x < SIZE; x++) {
+          final int i = (y * SIZE + x) * 3;
+          final int r = buff.get(i) & 0xFF;
+          final int g = buff.get(i + 1) & 0xFF;
+          final int b = buff.get(i + 2) & 0xFF;
+          if (Math.abs(r - 26) < 20 && Math.abs(g - 38) < 20 && Math.abs(b - 77) < 20) {
+            bgPixels++;
+          } else if (y < bottomBand) {
+            if (g > 96 && g > 2 * r && g > 2 * b) {
+              linePixels++;
+            }
+          } else if (x < SIZE / 2) {
+            unlitPixels++;
+          } else {
+            litPixels++;
+          }
+        }
+      }
+    }
+
+    @Override
+    public PickResults doPick(final Ray3 pickRay) {
+      return null;
+    }
+  }
+
+  private static void skipOrFail(final String reason) {
+    if ("1".equals(System.getenv("ARDOR3D_REQUIRE_GL_SMOKE"))) {
+      fail(reason + " - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run");
+    }
+    Assume.assumeTrue(reason, false);
+  }
+
+  private static void setupResourceLocators() throws Exception {
+    ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, new SimpleResourceLocator(
+        ResourceLocatorTool.getClassPathResource(MaterialManager.class, "com/ardor3d/renderer/material")));
+    ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, new SimpleResourceLocator(
+        ResourceLocatorTool.getClassPathResource(MaterialManager.class, "com/ardor3d/renderer/shader")));
+  }
+
+  @Test
+  public void litUnlitAndLineGeometryAllRender() throws Exception {
+    final ProbeScene scene = new ProbeScene();
+    GLFWCanvas canvas = null;
+    try {
+      setupResourceLocators();
+      canvas = new GLFWCanvas(new DisplaySettings(SIZE, SIZE, 24, 0), new Lwjgl3CanvasRenderer(scene));
+      canvas.init();
+    } catch (final Throwable t) {
+      skipOrFail("Could not create a GL context here: " + t);
+      return;
+    }
+
+    try {
+      for (int i = 0; i < GRAB_FRAME + 2 && !scene.done; i++) {
+        canvas.draw(null);
+      }
+
+      assertTrue("scene never reached the readback frame", scene.done);
+
+      final int total = SIZE * SIZE;
+      if (scene.bgPixels < total / 2) {
+        // e.g. WSLg's D3D12 driver returns zeros from default-framebuffer readback
+        skipOrFail("Framebuffer readback unusable on '" + scene.glRenderer + "' (clear color not visible: "
+            + scene.bgPixels + "/" + total + " bg pixels)");
+      }
+
+      final String on = " on '" + scene.glRenderer + "'";
+      assertTrue("unlit triangles did not render" + on, scene.unlitPixels > 500);
+      assertTrue("lines did not render" + on, scene.linePixels > 30);
+      assertTrue("LIT triangles did not render" + on
+          + " - was the draw rejected (e.g. GL_INVALID_OPERATION from conflicting sampler units)?",
+          scene.litPixels > 500);
+    } finally {
+      canvas.close();
+    }
+  }
+}


### PR DESCRIPTION
## The headline bug

`LightManager` assigned `spotShadowMaps[i]` (`sampler2DShadow`) and `pointShadowMaps[i]` (`samplerCubeShadow`) the **same texture unit** (`FIRST_SHADOW_INDEX + i`). Core GL forbids two sampler uniforms of different types referencing one texture unit, and the check runs at draw time: Mesa's GL frontend rejects the call with `GL_INVALID_OPERATION in glDrawElements` and the mesh is silently dropped. The result was that **every mesh using a lit material was invisible on all Mesa drivers** — llvmpipe, WSLg's D3D12 layer, and Linux Intel/AMD — while NVIDIA's driver, which does not enforce the rule, rendered everything fine. The bug masqueraded as a "WSLg can't render triangles" platform quirk for exactly that reason.

**Fix:** point-light cube maps move to a disjoint unit range (`FIRST_SHADOW_INDEX + MAX_LIGHTS + i`), with new `SpotShadowTexture` / `PointShadowTexture` state properties so each sampler array binds only its own texture kind. Directional CSM binding is unchanged.

## Second fix: `Light.makeCopy`

`Spatial.makeCopy` copies only base spatial state, and no `Light` class overrode it — so a copied light reverted to defaults (white, intensity 1, enabled), losing color, intensity, enabled/shadow flags, point attenuation and spot cone angles. `Light`, `PointLight` and `SpotLight` now extend the copy following the `Mesh.makeCopy` pattern. Red→green coverage for all three light types in `TestLightMakeCopy`.

## The regression net

- **`GlLitRenderSmokeTest`** (first test in `ardor3d-lwjgl3`): spins up a real GLFW context, renders a lit box, an unlit box and a line, reads the framebuffer back and asserts each path produced pixels. Skips cleanly when no usable GL context/readback exists; `ARDOR3D_REQUIRE_GL_SMOKE=1` turns skips into failures so the net can't silently rot.
- **CI** now installs Xvfb + Mesa and runs the build under `xvfb-run` with `LIBGL_ALWAYS_SOFTWARE=1` and the require flag — every push gets its lit pipeline validated by a strict software driver. This configuration fails on master today and would have caught the sampler conflict when it was introduced.
- **`WslgTriangleProbe`** (examples): the self-measuring diagnostic that isolated the bug — renders lit-vs-unlit geometry beside a line control, prints classified pixel counts and the GL renderer string, optionally writes a PNG.

## Verification

- Smoke test validated red→green: temporarily reintroducing the sampler conflict fails it under llvmpipe with the intended message; the fix restores green.
- Probe pixel counts under llvmpipe: lit box 0 pixels before → ~55k after; unlit box and line unchanged.
- Mesa draw-time errors (visible with `MESA_DEBUG=1`) gone on both llvmpipe and WSLg's D3D12; lighting examples and the editor confirmed rendering under WSLg by eye.
- Full `ardor3d-core` and `ardor3d-lwjgl3` suites green, including under the CI-equivalent environment (`LIBGL_ALWAYS_SOFTWARE=1 ARDOR3D_REQUIRE_GL_SMOKE=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new WSLG self-measuring graphics probe that renders, validates pixels, and can save a PNG output.
  * Enhanced light copying so duplicated lights preserve light-specific state (color/intensity, angles, attenuation, and shadow-caster settings).

* **Bug Fixes**
  * Improved shadow sampler compatibility on stricter graphics drivers by separating spot vs point shadow texture uniform handling.
  * Updated CI to run OpenGL smoke tests in a virtual framebuffer and fail fast when GL smoke is unavailable.

* **Tests**
  * Added JUnit coverage for light `makeCopy` behavior.
  * Added an LWJGL3 rendering smoke test that validates basic lit/unlit/line output via framebuffer readback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->