### PR TITLE
Add v2 interact gizmos: translate, rotate, scale with modern interaction

### DIFF
--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -13,6 +13,8 @@ package com.ardor3d.example.interact;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.util.EnumMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.imageio.ImageIO;
 
@@ -24,18 +26,28 @@ import com.ardor3d.example.PropertiesGameSettings;
 import com.ardor3d.example.Purpose;
 import com.ardor3d.extension.interact.InteractManager;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
+import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.TranslateGizmo;
 import com.ardor3d.image.ImageDataFormat;
 import com.ardor3d.image.Texture;
+import com.ardor3d.input.InputState;
+import com.ardor3d.input.character.CharacterInputState;
+import com.ardor3d.input.controller.ControllerState;
+import com.ardor3d.input.gesture.GestureState;
 import com.ardor3d.input.keyboard.Key;
+import com.ardor3d.input.keyboard.KeyboardState;
 import com.ardor3d.input.logical.InputTrigger;
 import com.ardor3d.input.logical.KeyPressedCondition;
+import com.ardor3d.input.logical.TwoInputStates;
+import com.ardor3d.input.mouse.ButtonState;
+import com.ardor3d.input.mouse.MouseButton;
 import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.intersection.PickData;
 import com.ardor3d.intersection.Pickable;
 import com.ardor3d.intersection.PrimitivePickResults;
 import com.ardor3d.math.ColorRGBA;
 import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyVector3;
 import com.ardor3d.renderer.Camera;
 import com.ardor3d.renderer.Renderer;
 import com.ardor3d.renderer.state.TextureState;
@@ -50,13 +62,15 @@ import com.ardor3d.util.TextureManager;
 
 /**
  * Showcases the v2 interact gizmos. Hover a handle to highlight it, drag to manipulate the
- * target. Click objects to change the interact target. Press R to toggle between world and local
- * interact frames.
+ * target. Click objects to change the interact target. Press 1 for the translate gizmo, 2 for
+ * rotate, and R to toggle between world and local interact frames.
  *
  * For unattended verification, -Dgizmo.shot=path skips the settings dialog, grabs a frame to the
  * given PNG once the scene has settled, prints a summary of gizmo-colored pixels and exits.
  * -Dgizmo.camera=far|xaxis overrides the start camera (to check constant screen sizing and axis
- * fading); -Dgizmo.hover=x simulates the mouse resting on the +X arrow (to check highlighting).
+ * fading); -Dgizmo.hover=x simulates the mouse resting on the +X arrow (to check highlighting);
+ * -Dgizmo.widget=rotate starts with the rotate gizmo active; -Dgizmo.drag=ringx simulates a slow
+ * drag around the X ring (to check the pie wedge and angle readout).
  */
 @Purpose(
     htmlDescriptionKey = "com.ardor3d.example.interact.InteractGizmoExample", //
@@ -66,6 +80,7 @@ public class InteractGizmoExample extends ExampleBase {
 
   private InteractManager manager;
   private TranslateGizmo translateGizmo;
+  private RotateGizmo rotateGizmo;
 
   private int _frames = 0;
 
@@ -102,6 +117,9 @@ public class InteractGizmoExample extends ExampleBase {
       // (absent) mouse each update.
       simulateHoverOnXArrow();
     }
+    if (shot != null && _frames >= 20 && "ringx".equals(System.getProperty("gizmo.drag"))) {
+      simulateDragOnXRing();
+    }
 
     manager.render(renderer);
 
@@ -124,6 +142,46 @@ public class InteractGizmoExample extends ExampleBase {
     final MouseState hover =
         new MouseState((int) screen.getX(), (int) screen.getY(), 0, 0, 0, null, null);
     translateGizmo.checkMouseOver(_canvas, hover, manager);
+  }
+
+  private MouseState _lastDragMouse = null;
+
+  /**
+   * Feed the rotate gizmo a synthetic left-button drag that walks around the X ring, driving the
+   * full processInput path so a screenshot run can verify the pie wedge and angle readout.
+   */
+  private void simulateDragOnXRing() {
+    final Camera cam = _canvas.getCanvasRenderer().getCamera();
+    final Spatial target = manager.getSpatialTarget();
+    final ReadOnlyVector3 origin = target.getWorldTranslation();
+    final double scale = rotateGizmo.getHandle().getScale().getX();
+
+    // The point on the X ring facing the camera, swung around the ring a bit more each frame.
+    final Vector3 toCam = new Vector3(cam.getDirection()).negateLocal();
+    final Vector3 e1 = toCam.subtract(Vector3.UNIT_X.multiply(toCam.dot(Vector3.UNIT_X), null), null).normalizeLocal();
+    final Vector3 e2 = Vector3.UNIT_X.cross(e1, null);
+    final double angle = (_frames - 20) * 0.04;
+    final Vector3 onRing = new Vector3(e1).multiplyLocal(Math.cos(angle) * RotateGizmo.RING_RADIUS * scale)
+        .addLocal(e2.multiply(Math.sin(angle) * RotateGizmo.RING_RADIUS * scale, null)).addLocal(origin);
+    final Vector3 screen = cam.getScreenCoordinates(onRing);
+
+    final EnumMap<MouseButton, ButtonState> buttons = new EnumMap<>(MouseButton.class);
+    buttons.put(MouseButton.LEFT, ButtonState.DOWN);
+    // First frame: previous state has the button up at the same spot, starting the drag there.
+    final MouseState previous = _lastDragMouse != null ? _lastDragMouse
+        : new MouseState((int) screen.getX(), (int) screen.getY(), 0, 0, 0, null, null);
+    final MouseState current = new MouseState((int) screen.getX(), (int) screen.getY(),
+        (int) screen.getX() - previous.getX(), (int) screen.getY() - previous.getY(), 0, buttons, null);
+    _lastDragMouse = current;
+
+    final InputState previousState = new InputState(KeyboardState.NOTHING, previous, ControllerState.NOTHING,
+        GestureState.NOTHING, CharacterInputState.NOTHING);
+    final InputState currentState = new InputState(KeyboardState.NOTHING, current, ControllerState.NOTHING,
+        GestureState.NOTHING, CharacterInputState.NOTHING);
+
+    rotateGizmo.processInput(_canvas, new TwoInputStates(previousState, currentState), new AtomicBoolean(false),
+        manager);
+    manager.getSpatialState().applyState(target);
   }
 
   @Override
@@ -152,7 +210,19 @@ public class InteractGizmoExample extends ExampleBase {
     translateGizmo = new TranslateGizmo().withAllHandles();
     manager.addWidget(translateGizmo);
 
-    manager.setActiveWidget(translateGizmo);
+    rotateGizmo = new RotateGizmo().withAllHandles();
+    manager.addWidget(rotateGizmo);
+    // the angle readout is screen-space ui - it renders with the ortho pass
+    _orthoRoot.attachChild(rotateGizmo.getAngleReadout());
+
+    manager.setActiveWidget(
+        "rotate".equals(System.getProperty("gizmo.widget")) ? rotateGizmo : translateGizmo);
+
+    // switch widgets
+    manager.getLogicalLayer().registerTrigger(new InputTrigger(new KeyPressedCondition(Key.ONE),
+        (source, inputStates, tpf) -> manager.setActiveWidget(translateGizmo)));
+    manager.getLogicalLayer().registerTrigger(new InputTrigger(new KeyPressedCondition(Key.TWO),
+        (source, inputStates, tpf) -> manager.setActiveWidget(rotateGizmo)));
 
     // toggle world/local interact frame
     manager.getLogicalLayer()
@@ -160,7 +230,8 @@ public class InteractGizmoExample extends ExampleBase {
           final InteractMatrix next =
               translateGizmo.getInteractMatrix() == InteractMatrix.World ? InteractMatrix.Local : InteractMatrix.World;
           translateGizmo.setInteractMatrix(next);
-          translateGizmo.targetDataUpdated(manager);
+          rotateGizmo.setInteractMatrix(next);
+          manager.fireTargetDataUpdated();
         }));
   }
 
@@ -206,6 +277,10 @@ public class InteractGizmoExample extends ExampleBase {
 
   @Override
   protected void updateLogicalLayer(final ReadOnlyTimer timer) {
+    if (System.getProperty("gizmo.shot") != null && System.getProperty("gizmo.drag") != null) {
+      // A simulated drag is driving the widgets; real (idle) input would end it every frame.
+      return;
+    }
     manager.getLogicalLayer().checkTriggers(timer.getTimePerFrame());
   }
 
@@ -266,6 +341,11 @@ public class InteractGizmoExample extends ExampleBase {
     System.out.println("GIZMO size=" + width + "x" + height + " redPixels=" + red + " greenPixels=" + green
         + " bluePixels=" + blue + " highlightPixels=" + highlight
         + (maxX < 0 ? " bbox=none" : " bbox=" + (maxX - minX + 1) + "x" + (maxY - minY + 1)));
+    if (System.getProperty("gizmo.drag") != null) {
+      System.out.println("GIZMO dragAngle=" + rotateGizmo.getDragAngle() + " text='"
+          + rotateGizmo.getAngleReadout().getText() + "' textScreen="
+          + rotateGizmo.getAngleReadout().getTranslation());
+    }
 
     try {
       final BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -27,6 +27,7 @@ import com.ardor3d.example.Purpose;
 import com.ardor3d.extension.interact.InteractManager;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
 import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo;
+import com.ardor3d.extension.interact.widget.gizmo.ScaleGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.TranslateGizmo;
 import com.ardor3d.image.ImageDataFormat;
 import com.ardor3d.image.Texture;
@@ -81,6 +82,7 @@ public class InteractGizmoExample extends ExampleBase {
   private InteractManager manager;
   private TranslateGizmo translateGizmo;
   private RotateGizmo rotateGizmo;
+  private ScaleGizmo scaleGizmo;
 
   private int _frames = 0;
 
@@ -215,16 +217,24 @@ public class InteractGizmoExample extends ExampleBase {
     // the angle readout is screen-space ui - it renders with the ortho pass
     _orthoRoot.attachChild(rotateGizmo.getAngleReadout());
 
-    manager.setActiveWidget(
-        "rotate".equals(System.getProperty("gizmo.widget")) ? rotateGizmo : translateGizmo);
+    scaleGizmo = new ScaleGizmo().withAllHandles();
+    manager.addWidget(scaleGizmo);
+
+    manager.setActiveWidget(switch (System.getProperty("gizmo.widget", "translate")) {
+      case "rotate" -> rotateGizmo;
+      case "scale" -> scaleGizmo;
+      default -> translateGizmo;
+    });
 
     // switch widgets
     manager.getLogicalLayer().registerTrigger(new InputTrigger(new KeyPressedCondition(Key.ONE),
         (source, inputStates, tpf) -> manager.setActiveWidget(translateGizmo)));
     manager.getLogicalLayer().registerTrigger(new InputTrigger(new KeyPressedCondition(Key.TWO),
         (source, inputStates, tpf) -> manager.setActiveWidget(rotateGizmo)));
+    manager.getLogicalLayer().registerTrigger(new InputTrigger(new KeyPressedCondition(Key.THREE),
+        (source, inputStates, tpf) -> manager.setActiveWidget(scaleGizmo)));
 
-    // toggle world/local interact frame
+    // toggle world/local interact frame (the scale gizmo is always local)
     manager.getLogicalLayer()
         .registerTrigger(new InputTrigger(new KeyPressedCondition(Key.R), (source, inputStates, tpf) -> {
           final InteractMatrix next =

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.example.interact;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.ByteBuffer;
+
+import javax.imageio.ImageIO;
+
+import com.ardor3d.bounding.BoundingBox;
+import com.ardor3d.bounding.BoundingSphere;
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.example.ExampleBase;
+import com.ardor3d.example.PropertiesGameSettings;
+import com.ardor3d.example.Purpose;
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.InteractMatrix;
+import com.ardor3d.extension.interact.widget.gizmo.TranslateGizmo;
+import com.ardor3d.image.ImageDataFormat;
+import com.ardor3d.image.Texture;
+import com.ardor3d.input.keyboard.Key;
+import com.ardor3d.input.logical.InputTrigger;
+import com.ardor3d.input.logical.KeyPressedCondition;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.intersection.PickData;
+import com.ardor3d.intersection.Pickable;
+import com.ardor3d.intersection.PrimitivePickResults;
+import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.Renderer;
+import com.ardor3d.renderer.state.TextureState;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.Spatial;
+import com.ardor3d.scenegraph.hint.PickingHint;
+import com.ardor3d.scenegraph.shape.Box;
+import com.ardor3d.scenegraph.shape.Sphere;
+import com.ardor3d.util.MaterialUtil;
+import com.ardor3d.util.ReadOnlyTimer;
+import com.ardor3d.util.TextureManager;
+
+/**
+ * Showcases the v2 interact gizmos. Hover a handle to highlight it, drag to manipulate the
+ * target. Click objects to change the interact target. Press R to toggle between world and local
+ * interact frames.
+ *
+ * For unattended verification, -Dgizmo.shot=path skips the settings dialog, grabs a frame to the
+ * given PNG once the scene has settled, prints a summary of gizmo-colored pixels and exits.
+ * -Dgizmo.camera=far|xaxis overrides the start camera (to check constant screen sizing and axis
+ * fading); -Dgizmo.hover=x simulates the mouse resting on the +X arrow (to check highlighting).
+ */
+@Purpose(
+    htmlDescriptionKey = "com.ardor3d.example.interact.InteractGizmoExample", //
+    thumbnailPath = "com/ardor3d/example/media/thumbnails/interact_InteractExample.jpg", //
+    maxHeapMemory = 64)
+public class InteractGizmoExample extends ExampleBase {
+
+  private InteractManager manager;
+  private TranslateGizmo translateGizmo;
+
+  private int _frames = 0;
+
+  public static void main(final String[] args) {
+    start(InteractGizmoExample.class);
+  }
+
+  @Override
+  protected PropertiesGameSettings getAttributes(final PropertiesGameSettings settings) {
+    if (System.getProperty("gizmo.shot") != null) {
+      // Unattended screenshot run - never show the settings dialog.
+      return settings;
+    }
+    return super.getAttributes(settings);
+  }
+
+  @Override
+  protected void updateExample(final ReadOnlyTimer timer) {
+    manager.update(timer);
+  }
+
+  @Override
+  protected void renderExample(final Renderer renderer) {
+    if (_frames == 0) {
+      renderer.setBackgroundColor(new ColorRGBA(0.13f, 0.14f, 0.16f, 1f));
+    }
+
+    super.renderExample(renderer);
+
+    _frames++;
+    final String shot = System.getProperty("gizmo.shot");
+    if (shot != null && _frames >= 20 && "x".equals(System.getProperty("gizmo.hover"))) {
+      // Re-applied every frame: the manager's own input processing resets hover to the real
+      // (absent) mouse each update.
+      simulateHoverOnXArrow();
+    }
+
+    manager.render(renderer);
+
+    if (shot != null && _frames == 40) {
+      grabShot(renderer, shot);
+      _exit = true;
+    }
+  }
+
+  /**
+   * Pretend the mouse is resting mid-shaft on the +X arrow, so a screenshot run can verify the
+   * hover highlight without real input.
+   */
+  private void simulateHoverOnXArrow() {
+    final Camera cam = _canvas.getCanvasRenderer().getCamera();
+    final Spatial target = manager.getSpatialTarget();
+    final double scale = translateGizmo.getHandle().getScale().getX();
+    final Vector3 onArrow = new Vector3(0.6 * scale, 0, 0).addLocal(target.getWorldTranslation());
+    final Vector3 screen = cam.getScreenCoordinates(onArrow);
+    final MouseState hover =
+        new MouseState((int) screen.getX(), (int) screen.getY(), 0, 0, 0, null, null);
+    translateGizmo.checkMouseOver(_canvas, hover, manager);
+  }
+
+  @Override
+  protected void initExample() {
+    _canvas.setTitle("Interact Gizmo Example");
+
+    final Camera camera = _canvas.getCanvasRenderer().getCamera();
+    final String cameraMode = System.getProperty("gizmo.camera", "default");
+    switch (cameraMode) {
+      case "far" -> camera.setLocation(36, 30, 48);
+      case "xaxis" -> camera.setLocation(24, 3, 0);
+      default -> camera.setLocation(12, 10, 16);
+    }
+    camera.lookAt(0, cameraMode.equals("xaxis") ? 3 : 2, 0, Vector3.UNIT_Y);
+
+    addControls();
+    addObjects();
+
+    MaterialUtil.autoMaterials(_root);
+  }
+
+  private void addControls() {
+    manager = new InteractManager();
+    manager.setupInput(_canvas, _physicalLayer, _logicalLayer);
+
+    translateGizmo = new TranslateGizmo().withAllHandles();
+    manager.addWidget(translateGizmo);
+
+    manager.setActiveWidget(translateGizmo);
+
+    // toggle world/local interact frame
+    manager.getLogicalLayer()
+        .registerTrigger(new InputTrigger(new KeyPressedCondition(Key.R), (source, inputStates, tpf) -> {
+          final InteractMatrix next =
+              translateGizmo.getInteractMatrix() == InteractMatrix.World ? InteractMatrix.Local : InteractMatrix.World;
+          translateGizmo.setInteractMatrix(next);
+          translateGizmo.targetDataUpdated(manager);
+        }));
+  }
+
+  private void addObjects() {
+    final Box floor = new Box("floor", Vector3.ZERO, 20, 0.5, 20);
+    floor.setTranslation(0, -0.5, 0);
+    final TextureState ts = new TextureState();
+    ts.setTexture(TextureManager.load("models/obj/pitcher.jpg", Texture.MinificationFilter.Trilinear, true));
+    floor.setRenderState(ts);
+    floor.getSceneHints().setPickingHint(PickingHint.Pickable, false);
+    floor.setModelBound(new BoundingBox());
+    _root.attachChild(floor);
+
+    final Box box = new Box("box", Vector3.ZERO, 3, 3, 3);
+    box.setTranslation(0, 3, 0);
+    TextureState boxTs = new TextureState();
+    boxTs.setTexture(TextureManager.load("images/skybox/1.jpg", Texture.MinificationFilter.Trilinear, true));
+    box.setRenderState(boxTs);
+    box.getSceneHints().setPickingHint(PickingHint.Pickable, true);
+    box.setModelBound(new BoundingBox());
+
+    final Node boxBase = new Node("boxBase");
+    boxBase.attachChild(box);
+    _root.attachChild(boxBase);
+
+    final Sphere sphere = new Sphere("sphere", Vector3.ZERO, 16, 16, 2);
+    sphere.setTranslation(0, 2, 0);
+    boxTs = new TextureState();
+    boxTs.setTexture(TextureManager.load("images/water/dudvmap.png", Texture.MinificationFilter.Trilinear, true));
+    sphere.setRenderState(boxTs);
+    sphere.getSceneHints().setPickingHint(PickingHint.Pickable, true);
+    sphere.setModelBound(new BoundingSphere());
+
+    final Node sphereBase = new Node("sphereBase");
+    sphereBase.setTranslation(7, 0, -4);
+    sphereBase.attachChild(sphere);
+    _root.attachChild(sphereBase);
+
+    // auto select the box
+    _root.updateGeometricState(0);
+    manager.setSpatialTarget(boxBase);
+  }
+
+  @Override
+  protected void updateLogicalLayer(final ReadOnlyTimer timer) {
+    manager.getLogicalLayer().checkTriggers(timer.getTimePerFrame());
+  }
+
+  @Override
+  protected void processPicks(final PrimitivePickResults pickResults) {
+    final PickData pick = pickResults.findFirstIntersectingPickData();
+    if (pick != null) {
+      final Pickable target = pick.getTarget();
+      if (target instanceof Spatial) {
+        manager.setSpatialTarget(((Spatial) target).getParent());
+        return;
+      }
+    }
+    manager.setSpatialTarget(null);
+  }
+
+  /**
+   * Grab the framebuffer, save it as a PNG and print counts plus the bounding box of pixels
+   * matching the gizmo's saturated axis colors - enough to verify the gizmo drew, and at what
+   * on-screen size.
+   */
+  private void grabShot(final Renderer renderer, final String path) {
+    final Camera cam = _canvas.getCanvasRenderer().getCamera();
+    final int width = cam.getWidth();
+    final int height = cam.getHeight();
+    final ByteBuffer buff = BufferUtils.createByteBuffer(width * height * 3);
+    renderer.grabScreenContents(buff, ImageDataFormat.RGB, 0, 0, width, height);
+
+    int red = 0, green = 0, blue = 0, highlight = 0;
+    int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE, maxX = -1, maxY = -1;
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        final int i = (y * width + x) * 3;
+        final int r = buff.get(i) & 0xFF;
+        final int g = buff.get(i + 1) & 0xFF;
+        final int b = buff.get(i + 2) & 0xFF;
+        boolean gizmo = true;
+        if (r > 170 && g < 110 && b < 130) {
+          red++;
+        } else if (g > 150 && r < 160 && b < 100) {
+          green++;
+        } else if (b > 170 && r < 110 && g < 180) {
+          blue++;
+        } else if (r > 200 && g > 170 && b < 110) {
+          highlight++;
+        } else {
+          gizmo = false;
+        }
+        if (gizmo) {
+          minX = Math.min(minX, x);
+          minY = Math.min(minY, y);
+          maxX = Math.max(maxX, x);
+          maxY = Math.max(maxY, y);
+        }
+      }
+    }
+
+    System.out.println("GIZMO size=" + width + "x" + height + " redPixels=" + red + " greenPixels=" + green
+        + " bluePixels=" + blue + " highlightPixels=" + highlight
+        + (maxX < 0 ? " bbox=none" : " bbox=" + (maxX - minX + 1) + "x" + (maxY - minY + 1)));
+
+    try {
+      final BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+      for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+          final int i = (y * width + x) * 3;
+          final int rgb = ((buff.get(i) & 0xFF) << 16) | ((buff.get(i + 1) & 0xFF) << 8) | (buff.get(i + 2) & 0xFF);
+          img.setRGB(x, height - 1 - y, rgb); // GL rows are bottom-up
+        }
+      }
+      ImageIO.write(img, "png", new File(path));
+      System.out.println("GIZMO png=" + path);
+    } catch (final Exception ex) {
+      System.out.println("GIZMO png write failed: " + ex);
+    }
+  }
+}

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -51,6 +51,7 @@ import com.ardor3d.intersection.PickData;
 import com.ardor3d.intersection.Pickable;
 import com.ardor3d.intersection.PrimitivePickResults;
 import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Quaternion;
 import com.ardor3d.math.Vector3;
 import com.ardor3d.math.type.ReadOnlyVector3;
 import com.ardor3d.math.util.MathUtils;
@@ -267,6 +268,11 @@ public class InteractGizmoExample extends ExampleBase {
           gridSnap.setEnabled(false);
           angleSnap.setEnabled(false);
         }));
+    if (System.getProperty("gizmo.snap") != null) {
+      // Simulated-drag screenshot runs mute real input, so Ctrl can't reach the triggers.
+      gridSnap.setEnabled(true);
+      angleSnap.setEnabled(true);
+    }
   }
 
   private void addObjects() {
@@ -376,9 +382,10 @@ public class InteractGizmoExample extends ExampleBase {
         + " bluePixels=" + blue + " highlightPixels=" + highlight
         + (maxX < 0 ? " bbox=none" : " bbox=" + (maxX - minX + 1) + "x" + (maxY - minY + 1)));
     if (System.getProperty("gizmo.drag") != null) {
+      final double targetAngle =
+          new Quaternion().fromRotationMatrix(manager.getSpatialTarget().getRotation()).toAngleAxis(new Vector3());
       System.out.println("GIZMO dragAngle=" + rotateGizmo.getDragAngle() + " text='"
-          + rotateGizmo.getAngleReadout().getText() + "' textScreen="
-          + rotateGizmo.getAngleReadout().getTranslation());
+          + rotateGizmo.getAngleReadout().getText() + "' targetAngleDeg=" + targetAngle * MathUtils.RAD_TO_DEG);
     }
 
     try {

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -25,6 +25,8 @@ import com.ardor3d.example.ExampleBase;
 import com.ardor3d.example.PropertiesGameSettings;
 import com.ardor3d.example.Purpose;
 import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.filter.AngleSnapFilter;
+import com.ardor3d.extension.interact.filter.GridSnapFilter;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
 import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.ScaleGizmo;
@@ -38,7 +40,9 @@ import com.ardor3d.input.gesture.GestureState;
 import com.ardor3d.input.keyboard.Key;
 import com.ardor3d.input.keyboard.KeyboardState;
 import com.ardor3d.input.logical.InputTrigger;
+import com.ardor3d.input.logical.KeyHeldCondition;
 import com.ardor3d.input.logical.KeyPressedCondition;
+import com.ardor3d.input.logical.KeyReleasedCondition;
 import com.ardor3d.input.logical.TwoInputStates;
 import com.ardor3d.input.mouse.ButtonState;
 import com.ardor3d.input.mouse.MouseButton;
@@ -49,6 +53,7 @@ import com.ardor3d.intersection.PrimitivePickResults;
 import com.ardor3d.math.ColorRGBA;
 import com.ardor3d.math.Vector3;
 import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.renderer.Camera;
 import com.ardor3d.renderer.Renderer;
 import com.ardor3d.renderer.state.TextureState;
@@ -64,7 +69,8 @@ import com.ardor3d.util.TextureManager;
 /**
  * Showcases the v2 interact gizmos. Hover a handle to highlight it, drag to manipulate the
  * target. Click objects to change the interact target. Press 1 for the translate gizmo, 2 for
- * rotate, and R to toggle between world and local interact frames.
+ * rotate, 3 for scale, and R to toggle between world and local interact frames. Hold Ctrl while
+ * dragging to snap: translation to a 1-unit grid, rotation to 15 degree steps.
  *
  * For unattended verification, -Dgizmo.shot=path skips the settings dialog, grabs a frame to the
  * given PNG once the scene has settled, prints a summary of gizmo-colored pixels and exits.
@@ -242,6 +248,24 @@ public class InteractGizmoExample extends ExampleBase {
           translateGizmo.setInteractMatrix(next);
           rotateGizmo.setInteractMatrix(next);
           manager.fireTargetDataUpdated();
+        }));
+
+    // hold Ctrl to snap: translate to a 1-unit grid, rotate to 15 degree steps
+    final GridSnapFilter gridSnap = new GridSnapFilter(1.0);
+    gridSnap.setEnabled(false);
+    translateGizmo.addFilter(gridSnap);
+    final AngleSnapFilter angleSnap = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    angleSnap.setEnabled(false);
+    rotateGizmo.addFilter(angleSnap);
+    manager.getLogicalLayer()
+        .registerTrigger(new InputTrigger(new KeyHeldCondition(Key.LEFT_CONTROL), (source, inputStates, tpf) -> {
+          gridSnap.setEnabled(true);
+          angleSnap.setEnabled(true);
+        }));
+    manager.getLogicalLayer()
+        .registerTrigger(new InputTrigger(new KeyReleasedCondition(Key.LEFT_CONTROL), (source, inputStates, tpf) -> {
+          gridSnap.setEnabled(false);
+          angleSnap.setEnabled(false);
         }));
   }
 

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -227,11 +227,15 @@ public class InteractGizmoExample extends ExampleBase {
     scaleGizmo = new ScaleGizmo().withAllHandles();
     manager.addWidget(scaleGizmo);
 
-    manager.setActiveWidget(switch (System.getProperty("gizmo.widget", "translate")) {
-      case "rotate" -> rotateGizmo;
-      case "scale" -> scaleGizmo;
-      default -> translateGizmo;
-    });
+    // The ring-drag simulation drives the rotate gizmo directly; it must also be the active
+    // widget or the manager would render a different gizmo than the one being dragged.
+    final boolean simulatedRingDrag = "ringx".equals(System.getProperty("gizmo.drag"));
+    manager.setActiveWidget(simulatedRingDrag ? rotateGizmo
+        : switch (System.getProperty("gizmo.widget", "translate")) {
+          case "rotate" -> rotateGizmo;
+          case "scale" -> scaleGizmo;
+          default -> translateGizmo;
+        });
 
     // switch widgets
     manager.getLogicalLayer().registerTrigger(new InputTrigger(new KeyPressedCondition(Key.ONE),

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/AngleSnapFilter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/AngleSnapFilter.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.filter;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.data.SpatialState;
+import com.ardor3d.extension.interact.widget.AbstractInteractWidget;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Quaternion;
+import com.ardor3d.math.Vector3;
+
+/**
+ * Filter that snaps the rotation accumulated over the course of a drag to fixed angle increments,
+ * e.g. 15 degree steps. The rotation at drag start is captured and the delta applied since is
+ * quantized as a single axis-angle rotation, so it works with any widget that rotates the state
+ * (RotateWidget, RotateGizmo). Toggle with {@link #setEnabled(boolean)} to make snapping a
+ * modifier-key behavior (e.g. while Ctrl is held).
+ */
+public class AngleSnapFilter extends UpdateFilterAdapter {
+
+  protected final Matrix3 _calcMat3A = new Matrix3();
+  protected final Matrix3 _calcMat3B = new Matrix3();
+  protected final Quaternion _calcQuat = new Quaternion();
+  protected final Vector3 _calcVec = new Vector3();
+
+  protected double _snapAngle;
+  protected boolean _enabled = true;
+
+  protected Matrix3 _startRotation = null;
+
+  /**
+   * @param snapAngle
+   *          the rotation increment to snap to, in radians.
+   */
+  public AngleSnapFilter(final double snapAngle) {
+    _snapAngle = snapAngle;
+  }
+
+  @Override
+  public void beginDrag(final InteractManager manager, final AbstractInteractWidget widget, final MouseState state) {
+    if (manager.getSpatialTarget() != null) {
+      _startRotation = new Matrix3(manager.getSpatialTarget().getTransform().getMatrix());
+    }
+  }
+
+  @Override
+  public void endDrag(final InteractManager manager, final AbstractInteractWidget widget, final MouseState state) {
+    _startRotation = null;
+  }
+
+  @Override
+  public void applyFilter(final InteractManager manager, final AbstractInteractWidget widget) {
+    if (!_enabled || _snapAngle <= 0 || _startRotation == null) {
+      return;
+    }
+    final SpatialState state = manager.getSpatialState();
+
+    // The rotation applied since drag start, as a single axis-angle.
+    _calcMat3A.set(_startRotation).transposeLocal();
+    state.getTransform().getMatrix().multiply(_calcMat3A, _calcMat3B);
+    final double angle = _calcQuat.fromRotationMatrix(_calcMat3B).toAngleAxis(_calcVec);
+
+    final double snapped = Math.round(angle / _snapAngle) * _snapAngle;
+    if (snapped == 0 || _calcVec.lengthSquared() < 1e-12) {
+      state.getTransform().setRotation(_startRotation);
+      return;
+    }
+
+    // Rebuild: quantized delta on top of the start rotation.
+    _calcMat3A.fromAngleNormalAxis(snapped, _calcVec.normalizeLocal());
+    state.getTransform().setRotation(_calcMat3A.multiply(_startRotation, _calcMat3B));
+  }
+
+  public double getSnapAngle() { return _snapAngle; }
+
+  /** Set the rotation increment to snap to, in radians. */
+  public void setSnapAngle(final double snapAngle) { _snapAngle = snapAngle; }
+
+  public boolean isEnabled() { return _enabled; }
+
+  public void setEnabled(final boolean enabled) { _enabled = enabled; }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/AngleSnapFilter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/AngleSnapFilter.java
@@ -20,10 +20,14 @@ import com.ardor3d.math.Vector3;
 
 /**
  * Filter that snaps the rotation accumulated over the course of a drag to fixed angle increments,
- * e.g. 15 degree steps. The rotation at drag start is captured and the delta applied since is
- * quantized as a single axis-angle rotation, so it works with any widget that rotates the state
- * (RotateWidget, RotateGizmo). Toggle with {@link #setEnabled(boolean)} to make snapping a
- * modifier-key behavior (e.g. while Ctrl is held).
+ * e.g. 15 degree steps. The rotation at drag start is captured, the raw per-event rotations the
+ * widget applies are accumulated (the manager resets the state from the target every input event,
+ * and the target only ever receives snapped values - the filter must keep the running total
+ * itself), and the accumulated delta is quantized as a single axis-angle rotation. Works with any
+ * widget that rotates the state (RotateWidget, RotateGizmo). Toggle with
+ * {@link #setEnabled(boolean)} to make snapping a modifier-key behavior (e.g. while Ctrl is
+ * held); the raw total keeps accumulating while disabled, so mid-drag toggles snap relative to
+ * the whole drag.
  */
 public class AngleSnapFilter extends UpdateFilterAdapter {
 
@@ -35,7 +39,10 @@ public class AngleSnapFilter extends UpdateFilterAdapter {
   protected double _snapAngle;
   protected boolean _enabled = true;
 
+  /** Target rotation captured at drag start; null when no drag is active. */
   protected Matrix3 _startRotation = null;
+  /** Raw (unsnapped) rotation the drag has applied since it started. */
+  protected final Matrix3 _accumulated = new Matrix3();
 
   /**
    * @param snapAngle
@@ -49,6 +56,7 @@ public class AngleSnapFilter extends UpdateFilterAdapter {
   public void beginDrag(final InteractManager manager, final AbstractInteractWidget widget, final MouseState state) {
     if (manager.getSpatialTarget() != null) {
       _startRotation = new Matrix3(manager.getSpatialTarget().getTransform().getMatrix());
+      _accumulated.setIdentity();
     }
   }
 
@@ -59,16 +67,24 @@ public class AngleSnapFilter extends UpdateFilterAdapter {
 
   @Override
   public void applyFilter(final InteractManager manager, final AbstractInteractWidget widget) {
-    if (!_enabled || _snapAngle <= 0 || _startRotation == null) {
+    if (_startRotation == null || manager.getSpatialTarget() == null) {
       return;
     }
     final SpatialState state = manager.getSpatialState();
 
-    // The rotation applied since drag start, as a single axis-angle.
-    _calcMat3A.set(_startRotation).transposeLocal();
+    // This event's raw widget rotation is the state's divergence from the target, which the
+    // manager has not yet updated this cycle. Fold it into the running total.
+    _calcMat3A.set(manager.getSpatialTarget().getTransform().getMatrix()).transposeLocal();
     state.getTransform().getMatrix().multiply(_calcMat3A, _calcMat3B);
-    final double angle = _calcQuat.fromRotationMatrix(_calcMat3B).toAngleAxis(_calcVec);
+    _calcMat3B.multiplyLocal(_accumulated);
+    _accumulated.set(_calcMat3B);
 
+    if (!_enabled || _snapAngle <= 0) {
+      return;
+    }
+
+    // Quantize the accumulated delta as a single axis-angle.
+    final double angle = _calcQuat.fromRotationMatrix(_accumulated).toAngleAxis(_calcVec);
     final double snapped = Math.round(angle / _snapAngle) * _snapAngle;
     if (snapped == 0 || _calcVec.lengthSquared() < 1e-12) {
       state.getTransform().setRotation(_startRotation);

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/GridSnapFilter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/GridSnapFilter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.filter;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.data.SpatialState;
+import com.ardor3d.extension.interact.widget.AbstractInteractWidget;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyVector3;
+
+/**
+ * Filter that snaps the state's translation to a regular grid, in the target's parent coordinate
+ * space. Attach to translation widgets; toggle with {@link #setEnabled(boolean)} to make snapping
+ * a modifier-key behavior (e.g. while Ctrl is held).
+ */
+public class GridSnapFilter extends UpdateFilterAdapter {
+
+  protected final Vector3 _calcVec = new Vector3();
+
+  protected double _gridSize;
+  protected boolean _enabled = true;
+
+  public GridSnapFilter(final double gridSize) {
+    _gridSize = gridSize;
+  }
+
+  @Override
+  public void applyFilter(final InteractManager manager, final AbstractInteractWidget widget) {
+    if (!_enabled || _gridSize <= 0) {
+      return;
+    }
+    final SpatialState state = manager.getSpatialState();
+    final ReadOnlyVector3 translation = state.getTransform().getTranslation();
+    _calcVec.set( //
+        Math.round(translation.getX() / _gridSize) * _gridSize,
+        Math.round(translation.getY() / _gridSize) * _gridSize,
+        Math.round(translation.getZ() / _gridSize) * _gridSize);
+    state.getTransform().setTranslation(_calcVec);
+  }
+
+  public double getGridSize() { return _gridSize; }
+
+  public void setGridSize(final double gridSize) { _gridSize = gridSize; }
+
+  public boolean isEnabled() { return _enabled; }
+
+  public void setEnabled(final boolean enabled) { _enabled = enabled; }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/GridSnapFilter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/GridSnapFilter.java
@@ -13,13 +13,18 @@ package com.ardor3d.extension.interact.filter;
 import com.ardor3d.extension.interact.InteractManager;
 import com.ardor3d.extension.interact.data.SpatialState;
 import com.ardor3d.extension.interact.widget.AbstractInteractWidget;
+import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.math.Vector3;
-import com.ardor3d.math.type.ReadOnlyVector3;
 
 /**
- * Filter that snaps the state's translation to a regular grid, in the target's parent coordinate
- * space. Attach to translation widgets; toggle with {@link #setEnabled(boolean)} to make snapping
- * a modifier-key behavior (e.g. while Ctrl is held).
+ * Filter that snaps the translation accumulated over the course of a drag to grid increments, in
+ * the target's parent coordinate space. The translation at drag start is captured, the raw
+ * per-event offsets the widget applies are accumulated (the manager resets the state from the
+ * target every input event, and the target only ever receives snapped values - the filter must
+ * keep the running total itself), and the target moves in whole grid steps from where the drag
+ * began. Toggle with {@link #setEnabled(boolean)} to make snapping a modifier-key behavior (e.g.
+ * while Ctrl is held); the raw total keeps accumulating while disabled, so mid-drag toggles snap
+ * relative to the whole drag.
  */
 public class GridSnapFilter extends UpdateFilterAdapter {
 
@@ -28,22 +33,51 @@ public class GridSnapFilter extends UpdateFilterAdapter {
   protected double _gridSize;
   protected boolean _enabled = true;
 
+  /** Target translation captured at drag start; null when no drag is active. */
+  protected Vector3 _startTranslation = null;
+  /** Raw (unsnapped) offset the drag has applied since it started. */
+  protected final Vector3 _accumulated = new Vector3();
+
   public GridSnapFilter(final double gridSize) {
     _gridSize = gridSize;
   }
 
   @Override
+  public void beginDrag(final InteractManager manager, final AbstractInteractWidget widget, final MouseState state) {
+    if (manager.getSpatialTarget() != null) {
+      _startTranslation = new Vector3(manager.getSpatialTarget().getTransform().getTranslation());
+      _accumulated.zero();
+    }
+  }
+
+  @Override
+  public void endDrag(final InteractManager manager, final AbstractInteractWidget widget, final MouseState state) {
+    _startTranslation = null;
+  }
+
+  @Override
   public void applyFilter(final InteractManager manager, final AbstractInteractWidget widget) {
-    if (!_enabled || _gridSize <= 0) {
+    if (_startTranslation == null || manager.getSpatialTarget() == null) {
       return;
     }
     final SpatialState state = manager.getSpatialState();
-    final ReadOnlyVector3 translation = state.getTransform().getTranslation();
+
+    // This event's raw widget offset is the state's divergence from the target, which the
+    // manager has not yet updated this cycle. Fold it into the running total.
+    _calcVec.set(state.getTransform().getTranslation())
+        .subtractLocal(manager.getSpatialTarget().getTransform().getTranslation());
+    _accumulated.addLocal(_calcVec);
+
+    if (!_enabled || _gridSize <= 0) {
+      return;
+    }
+
+    // Move in whole grid steps from the drag start.
     _calcVec.set( //
-        Math.round(translation.getX() / _gridSize) * _gridSize,
-        Math.round(translation.getY() / _gridSize) * _gridSize,
-        Math.round(translation.getZ() / _gridSize) * _gridSize);
-    state.getTransform().setTranslation(_calcVec);
+        Math.round(_accumulated.getX() / _gridSize) * _gridSize,
+        Math.round(_accumulated.getY() / _gridSize) * _gridSize,
+        Math.round(_accumulated.getZ() / _gridSize) * _gridSize);
+    state.getTransform().setTranslation(_calcVec.addLocal(_startTranslation));
   }
 
   public double getGridSize() { return _gridSize; }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -86,6 +86,12 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
 
   protected final ZBufferState _ghostZState = new ZBufferState();
 
+  // scratch objects for the drag hot path, complementing the _calcVec3* pool in the base class
+  protected final Vector2 _calcVec2A = new Vector2();
+  protected final Vector2 _calcVec2B = new Vector2();
+  protected final Vector2 _calcVec2C = new Vector2();
+  protected final Plane _calcPlane = new Plane();
+
   public AbstractGizmo(final String name) {
     _handle = new Node(name);
     LightProperties.setLightReceiver(_handle, false);
@@ -266,14 +272,15 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
       return false;
     }
     normal.normalizeLocal();
-    final Plane pickPlane = new Plane(normal, normal.dot(origin));
+    _calcPlane.setNormal(normal);
+    _calcPlane.setConstant(normal.dot(origin));
 
     getPickRay(oldMouse, camera);
-    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3A)) {
+    if (!_calcRay.intersectsPlane(_calcPlane, _calcVec3A)) {
       return false;
     }
     getPickRay(newMouse, camera);
-    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3B)) {
+    if (!_calcRay.intersectsPlane(_calcPlane, _calcVec3B)) {
       return false;
     }
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.AbstractInteractWidget;
+import com.ardor3d.extension.interact.widget.DragState;
+import com.ardor3d.extension.interact.widget.InteractMatrix;
+import com.ardor3d.intersection.PickingUtil;
+import com.ardor3d.light.LightProperties;
+import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Vector2;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyColorRGBA;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.ContextManager;
+import com.ardor3d.renderer.RenderContext;
+import com.ardor3d.renderer.Renderer;
+import com.ardor3d.renderer.queue.RenderBucketType;
+import com.ardor3d.renderer.state.BlendState;
+import com.ardor3d.renderer.state.RenderState;
+import com.ardor3d.renderer.state.RenderState.StateType;
+import com.ardor3d.renderer.state.ZBufferState;
+import com.ardor3d.renderer.state.ZBufferState.TestFunction;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.Spatial;
+import com.ardor3d.scenegraph.hint.PickingHint;
+
+/**
+ * Base class for the v2 interact gizmos. Compared to the older widgets in the parent package,
+ * gizmos:
+ * <ul>
+ * <li>hold a constant on-screen size regardless of target size or camera distance,</li>
+ * <li>highlight the individual handle under the mouse rather than scaling the whole widget,</li>
+ * <li>draw on top of the scene in two passes: a dimmed "x-ray" pass where the gizmo is occluded
+ * and a full-strength pass where it is visible, and</li>
+ * <li>fade out handles whose drag math is ill-conditioned at the current view angle.</li>
+ * </ul>
+ * Gizmos render immediately (their scenegraph uses the Skip bucket), so
+ * {@link InteractManager#render(Renderer)} must be called after the main scene has been drawn and
+ * its render buckets flushed - which is the usual place to call it.
+ */
+public abstract class AbstractGizmo extends AbstractInteractWidget {
+
+  public static final ReadOnlyColorRGBA DEFAULT_X_COLOR = new ColorRGBA(0.91f, 0.23f, 0.29f, 1.0f);
+  public static final ReadOnlyColorRGBA DEFAULT_Y_COLOR = new ColorRGBA(0.44f, 0.79f, 0.16f, 1.0f);
+  public static final ReadOnlyColorRGBA DEFAULT_Z_COLOR = new ColorRGBA(0.20f, 0.51f, 0.92f, 1.0f);
+  public static final ReadOnlyColorRGBA DEFAULT_CENTER_COLOR = new ColorRGBA(0.85f, 0.85f, 0.85f, 0.8f);
+  public static final ReadOnlyColorRGBA DEFAULT_HIGHLIGHT_COLOR = new ColorRGBA(1.0f, 0.86f, 0.18f, 1.0f);
+
+  /** Default on-screen footprint of a gizmo, in pixels. */
+  public static final double DEFAULT_PIXEL_SIZE = 90;
+
+  /** Alpha multiplier for the occluded (x-ray) render pass. */
+  public static final float DEFAULT_GHOST_ALPHA = 0.28f;
+
+  /** Handles are not pickable once faded below this alpha. */
+  public static final double PICK_ALPHA_FLOOR = 0.2;
+
+  protected double _pixelSize = AbstractGizmo.DEFAULT_PIXEL_SIZE;
+  protected final ColorRGBA _highlightColor = new ColorRGBA(AbstractGizmo.DEFAULT_HIGHLIGHT_COLOR);
+  protected float _ghostAlpha = AbstractGizmo.DEFAULT_GHOST_ALPHA;
+  protected boolean _xray = true;
+
+  /** View angle at or below which fading handles are fully hidden, in radians. */
+  protected double _fadeHideAngle = 10 * MathUtils.DEG_TO_RAD;
+  /** View angle at or above which fading handles are fully visible, in radians. */
+  protected double _fadeFullAngle = 20 * MathUtils.DEG_TO_RAD;
+
+  protected final List<GizmoHandle> _gizmoHandles = new ArrayList<>();
+
+  protected final ZBufferState _ghostZState = new ZBufferState();
+
+  public AbstractGizmo(final String name) {
+    _handle = new Node(name);
+    LightProperties.setLightReceiver(_handle, false);
+
+    final BlendState blend = new BlendState();
+    blend.setBlendEnabled(true);
+    _handle.setRenderState(blend);
+
+    final ZBufferState zstate = new ZBufferState();
+    zstate.setFunction(TestFunction.LessThanOrEqualTo);
+    _handle.setRenderState(zstate);
+
+    // Render immediately when drawn rather than queueing - the gizmo is drawn once per pass by
+    // render(), after the scene buckets have flushed.
+    _handle.getSceneHints().setRenderBucketType(RenderBucketType.Skip);
+    _handle.updateGeometricState(0);
+
+    _ghostZState.setFunction(TestFunction.GreaterThan);
+    _ghostZState.setWritable(false);
+  }
+
+  protected void addGizmoHandle(final GizmoHandle handle) {
+    _gizmoHandles.add(handle);
+    _handle.attachChild(handle.getRoot());
+  }
+
+  protected GizmoHandle findGizmoHandle(final Spatial spatial) {
+    if (spatial == null) {
+      return null;
+    }
+    for (int i = _gizmoHandles.size(); --i >= 0;) {
+      final GizmoHandle handle = _gizmoHandles.get(i);
+      if (handle.contains(spatial)) {
+        return handle;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @return the handle currently being dragged, or hovered if no drag is active, or null.
+   */
+  public GizmoHandle getActiveHandle() {
+    if (_dragState != DragState.NONE && _lastDragSpatial != null) {
+      return findGizmoHandle(_lastDragSpatial);
+    }
+    if (_mouseOver && _lastMouseOverSpatial != null) {
+      return findGizmoHandle(_lastMouseOverSpatial);
+    }
+    return null;
+  }
+
+  @Override
+  public void targetDataUpdated(final InteractManager manager) {
+    final Spatial target = manager.getSpatialTarget();
+    if (target == null) {
+      _handle.setRotation(Matrix3.IDENTITY);
+    } else {
+      target.updateGeometricState(0);
+
+      if (_interactMatrix == InteractMatrix.Local) {
+        _handle.setRotation(target.getWorldRotation());
+      } else {
+        _handle.setRotation(Matrix3.IDENTITY);
+      }
+    }
+    // Note: scale is not set here. Gizmos are sized per-frame in render() to hold a constant
+    // screen footprint.
+  }
+
+  @Override
+  public void render(final Renderer renderer, final InteractManager manager) {
+    final Spatial target = manager.getSpatialTarget();
+    if (target == null) {
+      return;
+    }
+
+    final Camera camera = Camera.getCurrentCamera();
+
+    _handle.setTranslation(target.getWorldTranslation());
+    _handle.setScale(Math.max(AbstractInteractWidget.MIN_SCALE,
+        GizmoMath.calculateFixedScreenScale(camera, _handle.getTranslation(), _pixelSize)));
+
+    updateCameraFacingHandles(camera);
+    updateHandleFades(camera);
+    _handle.updateGeometricState(0);
+
+    final GizmoHandle active = getActiveHandle();
+    final RenderContext context = ContextManager.getCurrentContext();
+
+    if (_xray) {
+      // Occluded pass: only draw where the gizmo is behind scene geometry, dimmed.
+      applyHandleColors(active, _ghostAlpha);
+      final RenderState previousZ = context.getEnforcedState(StateType.ZBuffer);
+      context.enforceState(_ghostZState);
+      renderer.draw(_handle);
+      if (previousZ != null) {
+        context.enforceState(previousZ);
+      } else {
+        context.clearEnforcedState(StateType.ZBuffer);
+      }
+    }
+
+    // Visible pass: full strength wherever the gizmo passes the normal depth test.
+    applyHandleColors(active, 1.0f);
+    renderer.draw(_handle);
+  }
+
+  /**
+   * Hook for orienting camera-facing handles (view-plane disks, screen-space rings) each frame.
+   * Called before fades are updated and world transforms refreshed.
+   */
+  protected void updateCameraFacingHandles(final Camera camera) {
+    /**/}
+
+  protected void updateHandleFades(final Camera camera) {
+    for (int i = _gizmoHandles.size(); --i >= 0;) {
+      final GizmoHandle handle = _gizmoHandles.get(i);
+      double alpha = 1.0;
+      switch (handle.getFadeMode()) {
+        case Axis: {
+          _handle.getRotation().applyPost(handle.getAxis(), _calcVec3A);
+          final double angle = GizmoMath.axisViewAngle(_calcVec3A, camera.getDirection());
+          alpha = GizmoMath.fadeAlpha(angle, _fadeHideAngle, _fadeFullAngle);
+          break;
+        }
+        case Plane: {
+          _handle.getRotation().applyPost(handle.getAxis(), _calcVec3A);
+          final double angle = GizmoMath.planeViewAngle(_calcVec3A, camera.getDirection());
+          alpha = GizmoMath.fadeAlpha(angle, _fadeHideAngle, _fadeFullAngle);
+          break;
+        }
+        default:
+          break;
+      }
+      handle.setFadeAlpha(alpha);
+      handle.getRoot().getSceneHints().setPickingHint(PickingHint.Pickable,
+          alpha > AbstractGizmo.PICK_ALPHA_FLOOR);
+    }
+  }
+
+  protected void applyHandleColors(final GizmoHandle active, final float alphaMultiplier) {
+    for (int i = _gizmoHandles.size(); --i >= 0;) {
+      final GizmoHandle handle = _gizmoHandles.get(i);
+      final ReadOnlyColorRGBA rgb = handle == active ? _highlightColor : handle.getBaseColor();
+      final float alpha = handle.getBaseColor().getAlpha() * (float) handle.getFadeAlpha() * alphaMultiplier;
+      handle.applyColor(rgb, alpha);
+    }
+  }
+
+  @Override
+  protected void findPick(final Vector2 mouseLoc, final Camera camera) {
+    getPickRay(mouseLoc, camera);
+    _results.clear();
+    // Unlike the base widget, pick against culled spatials too: thin handles carry invisible,
+    // fatter pick-proxy meshes hidden with CullHint.Always.
+    PickingUtil.findPick(_handle, _calcRay, _results, false);
+  }
+
+  public double getPixelSize() { return _pixelSize; }
+
+  /** Set the on-screen footprint the gizmo is scaled to hold, in pixels. */
+  public void setPixelSize(final double pixels) { _pixelSize = pixels; }
+
+  public ReadOnlyColorRGBA getHighlightColor() { return _highlightColor; }
+
+  public void setHighlightColor(final ReadOnlyColorRGBA color) { _highlightColor.set(color); }
+
+  public boolean isXRay() { return _xray; }
+
+  /** Enable or disable the dimmed render pass showing the gizmo where it is occluded. */
+  public void setXRay(final boolean xray) { _xray = xray; }
+
+  public float getGhostAlpha() { return _ghostAlpha; }
+
+  public void setGhostAlpha(final float alpha) { _ghostAlpha = alpha; }
+
+  public double getFadeHideAngle() { return _fadeHideAngle; }
+
+  public double getFadeFullAngle() { return _fadeFullAngle; }
+
+  /** Set the view-angle band over which ill-conditioned handles fade out, in radians. */
+  public void setFadeAngles(final double hideBelow, final double fullAbove) {
+    _fadeHideAngle = hideBelow;
+    _fadeFullAngle = fullAbove;
+  }
+
+  public List<GizmoHandle> getGizmoHandles() { return _gizmoHandles; }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -21,9 +21,11 @@ import com.ardor3d.intersection.PickingUtil;
 import com.ardor3d.light.LightProperties;
 import com.ardor3d.math.ColorRGBA;
 import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Plane;
 import com.ardor3d.math.Vector2;
 import com.ardor3d.math.Vector3;
 import com.ardor3d.math.type.ReadOnlyColorRGBA;
+import com.ardor3d.math.type.ReadOnlyVector3;
 import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.renderer.Camera;
 import com.ardor3d.renderer.ContextManager;
@@ -232,6 +234,51 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
       final float alpha = handle.getBaseColor().getAlpha() * (float) handle.getFadeAlpha() * alphaMultiplier;
       handle.applyColor(rgb, alpha);
     }
+  }
+
+  /**
+   * Project the pick-ray hits for two mouse positions onto a world-space axis line through the
+   * gizmo origin. The hits are taken against the plane containing the axis that most directly
+   * faces the camera - the standard construction for single-axis drags.
+   *
+   * @param axis
+   *          unit direction of the axis, in world space.
+   * @param oldMouse
+   *          previous mouse position.
+   * @param newMouse
+   *          current mouse position.
+   * @param camera
+   *          the viewing camera.
+   * @param store
+   *          on success, x holds the old hit's signed distance along the axis from the gizmo
+   *          origin and y the new hit's.
+   * @return false if the axis is aligned with the view direction (ill-conditioned) or a pick ray
+   *         missed the plane.
+   */
+  protected boolean projectOnAxis(final ReadOnlyVector3 axis, final Vector2 oldMouse, final Vector2 newMouse,
+      final Camera camera, final Vector2 store) {
+    final ReadOnlyVector3 origin = _handle.getWorldTranslation();
+
+    // The plane's normal is the component of the view direction perpendicular to the axis.
+    final Vector3 normal = _calcVec3C.set(camera.getDirection())
+        .subtractLocal(axis.multiply(camera.getDirection().dot(axis), _calcVec3A));
+    if (normal.lengthSquared() < 1e-10) {
+      return false;
+    }
+    normal.normalizeLocal();
+    final Plane pickPlane = new Plane(normal, normal.dot(origin));
+
+    getPickRay(oldMouse, camera);
+    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3A)) {
+      return false;
+    }
+    getPickRay(newMouse, camera);
+    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3B)) {
+      return false;
+    }
+
+    store.set(_calcVec3A.subtractLocal(origin).dot(axis), _calcVec3B.subtractLocal(origin).dot(axis));
+    return true;
   }
 
   @Override

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoGeometry.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoGeometry.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import java.nio.FloatBuffer;
+
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.buffer.IndexBufferData;
+import com.ardor3d.scenegraph.Mesh;
+import com.ardor3d.scenegraph.MeshData;
+
+/**
+ * Mesh builders for gizmo handle geometry that the stock shapes do not cover.
+ */
+public final class GizmoGeometry {
+
+  private GizmoGeometry() {}
+
+  /**
+   * Build a tube following a circular arc in the XY plane, centered on the origin, sweeping
+   * counter-clockwise from startAngle to endAngle (radians, measured from +X). Pass a full 2*pi
+   * sweep to build a closed ring. No texture coordinates are generated.
+   *
+   * @param name
+   *          name for the mesh.
+   * @param arcRadius
+   *          radius of the arc the tube follows.
+   * @param tubeRadius
+   *          radius of the tube itself.
+   * @param startAngle
+   *          arc start angle, in radians.
+   * @param endAngle
+   *          arc end angle, in radians. Must be greater than startAngle.
+   * @param arcSamples
+   *          segments along the arc.
+   * @param tubeSamples
+   *          segments around the tube.
+   * @return the new mesh. The caller is responsible for updateModelBound().
+   */
+  public static Mesh arcTube(final String name, final double arcRadius, final double tubeRadius,
+      final double startAngle, final double endAngle, final int arcSamples, final int tubeSamples) {
+    final boolean closed = endAngle - startAngle > 2 * Math.PI - 1e-6;
+    // Open arcs need a final ring of vertices at endAngle; closed ones wrap back to the first.
+    final int rings = closed ? arcSamples : arcSamples + 1;
+
+    final Mesh mesh = new Mesh(name);
+    final MeshData meshData = mesh.getMeshData();
+
+    final int verts = rings * tubeSamples;
+    final FloatBuffer vertexBuffer = BufferUtils.createVector3Buffer(verts);
+    final FloatBuffer normalBuffer = BufferUtils.createVector3Buffer(verts);
+
+    for (int i = 0; i < rings; i++) {
+      final double theta = startAngle + (endAngle - startAngle) * i / arcSamples;
+      final double cosTheta = Math.cos(theta);
+      final double sinTheta = Math.sin(theta);
+      for (int j = 0; j < tubeSamples; j++) {
+        final double phi = 2 * Math.PI * j / tubeSamples;
+        final double cosPhi = Math.cos(phi);
+        final double sinPhi = Math.sin(phi);
+        // normal = radial component in the arc plane + tube's out-of-plane component
+        final double nx = cosPhi * cosTheta;
+        final double ny = cosPhi * sinTheta;
+        final double nz = sinPhi;
+        normalBuffer.put((float) nx).put((float) ny).put((float) nz);
+        vertexBuffer.put((float) (cosTheta * arcRadius + nx * tubeRadius))
+            .put((float) (sinTheta * arcRadius + ny * tubeRadius)) //
+            .put((float) (nz * tubeRadius));
+      }
+    }
+    meshData.setVertexBuffer(vertexBuffer);
+    meshData.setNormalBuffer(normalBuffer);
+
+    final int quadRows = closed ? rings : rings - 1;
+    final IndexBufferData<?> indices = BufferUtils.createIndexBufferData(quadRows * tubeSamples * 6, verts - 1);
+    for (int i = 0; i < quadRows; i++) {
+      final int rowA = i * tubeSamples;
+      final int rowB = (i + 1) % rings * tubeSamples;
+      for (int j = 0; j < tubeSamples; j++) {
+        final int j2 = (j + 1) % tubeSamples;
+        indices.put(rowA + j).put(rowB + j).put(rowB + j2);
+        indices.put(rowA + j).put(rowB + j2).put(rowA + j2);
+      }
+    }
+    meshData.setIndices(indices);
+
+    return mesh;
+  }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoHandle.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoHandle.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyColorRGBA;
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.scenegraph.Mesh;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.Spatial;
+
+/**
+ * One interactive part of a gizmo: a subtree of meshes with a shared identity, base color, drag
+ * axis and fade rule. The owning gizmo colors the whole part as a unit for hover highlighting and
+ * view-angle fading.
+ */
+public class GizmoHandle {
+
+  /** How this handle fades as the camera's view direction changes. */
+  public enum FadeMode {
+    /** Never fades. */
+    None,
+    /** Fades out as its axis approaches the view direction (axis drag is ill-conditioned there). */
+    Axis,
+    /** Fades out as its plane approaches edge-on to the camera (its axis is the plane normal). */
+    Plane
+  }
+
+  protected final GizmoPart _part;
+  protected final Node _root;
+  protected final ColorRGBA _baseColor = new ColorRGBA();
+  protected final Vector3 _axis = new Vector3();
+  protected final FadeMode _fadeMode;
+  protected final List<Mesh> _meshes = new ArrayList<>();
+
+  /** Most recently calculated view-angle fade, applied as an alpha multiplier. */
+  protected double _fadeAlpha = 1.0;
+
+  /**
+   * @param part
+   *          identity of this handle within its gizmo.
+   * @param root
+   *          subtree holding the handle's meshes (visuals and any invisible pick proxies).
+   * @param baseColor
+   *          un-highlighted color; its alpha is the handle's base opacity.
+   * @param axis
+   *          the axis this handle drags along (or plane normal, or zero if unused) in the gizmo's
+   *          local space.
+   * @param fadeMode
+   *          how this handle fades with the view angle.
+   */
+  public GizmoHandle(final GizmoPart part, final Node root, final ReadOnlyColorRGBA baseColor,
+      final ReadOnlyVector3 axis, final FadeMode fadeMode) {
+    _part = part;
+    _root = root;
+    _baseColor.set(baseColor);
+    _axis.set(axis);
+    _fadeMode = fadeMode;
+
+    collectMeshes(root);
+  }
+
+  protected void collectMeshes(final Spatial spatial) {
+    if (spatial instanceof Mesh mesh) {
+      _meshes.add(mesh);
+    } else if (spatial instanceof Node node) {
+      for (int i = 0; i < node.getNumberOfChildren(); i++) {
+        collectMeshes(node.getChild(i));
+      }
+    }
+  }
+
+  /**
+   * Set the given color on all of this handle's meshes, replacing the alpha with the given value.
+   */
+  public void applyColor(final ReadOnlyColorRGBA rgb, final float alpha) {
+    for (int i = _meshes.size(); --i >= 0;) {
+      final Mesh mesh = _meshes.get(i);
+      mesh.setDefaultColor(rgb.getRed(), rgb.getGreen(), rgb.getBlue(), alpha);
+    }
+  }
+
+  public boolean contains(final Spatial spatial) {
+    return spatial instanceof Mesh && _meshes.contains(spatial);
+  }
+
+  public GizmoPart getPart() { return _part; }
+
+  public Node getRoot() { return _root; }
+
+  public ColorRGBA getBaseColor() { return _baseColor; }
+
+  public ReadOnlyVector3 getAxis() { return _axis; }
+
+  public FadeMode getFadeMode() { return _fadeMode; }
+
+  public double getFadeAlpha() { return _fadeAlpha; }
+
+  public void setFadeAlpha(final double alpha) { _fadeAlpha = alpha; }
+
+  public List<Mesh> getMeshes() { return _meshes; }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMath.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMath.java
@@ -123,6 +123,27 @@ public final class GizmoMath {
   }
 
   /**
+   * The signed angle that rotates one direction onto another about an axis, in radians. Positive
+   * angles are counter-clockwise looking down the axis (right-hand rule). The inputs are expected
+   * to be unit length and reasonably close to the plane perpendicular to the axis.
+   *
+   * @param from
+   *          unit start direction.
+   * @param to
+   *          unit end direction.
+   * @param axis
+   *          unit rotation axis.
+   * @return the signed angle, in radians, in (-pi, pi].
+   */
+  public static double signedAngle(final ReadOnlyVector3 from, final ReadOnlyVector3 to,
+      final ReadOnlyVector3 axis) {
+    final double crossDot = axis.getX() * (from.getY() * to.getZ() - from.getZ() * to.getY())
+        + axis.getY() * (from.getZ() * to.getX() - from.getX() * to.getZ())
+        + axis.getZ() * (from.getX() * to.getY() - from.getY() * to.getX());
+    return Math.atan2(crossDot, from.dot(to));
+  }
+
+  /**
    * Map a view angle to a fade alpha: 0 at or below hideBelow, 1 at or above fullAbove, linear in
    * between. Used to fade out handles whose drag direction is ill-conditioned at the current view
    * angle.

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMath.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMath.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.Camera.ProjectionMode;
+
+/**
+ * Pure math used by the v2 interact gizmos: constant screen-size scaling and view-angle based
+ * handle fades. Kept free of scenegraph and GL types (save read-only Camera access) so it can be
+ * unit tested directly.
+ */
+public final class GizmoMath {
+
+  private GizmoMath() {}
+
+  /**
+   * Calculate the world-space size that covers a desired number of vertical pixels at a given view
+   * depth, under a perspective frustum.
+   *
+   * @param pixels
+   *          desired on-screen size, in pixels.
+   * @param camDepth
+   *          distance from the camera along the view direction (camera-space z depth). Must be
+   *          positive for a sensible result.
+   * @param frustumTop
+   *          the camera's frustum top value (half the frustum height at the near plane).
+   * @param frustumNear
+   *          the camera's near plane distance.
+   * @param viewportHeightPixels
+   *          the viewport height, in pixels.
+   * @return the world-space size at the given depth that projects to the requested pixel size.
+   */
+  public static double worldSizeForPixels(final double pixels, final double camDepth, final double frustumTop,
+      final double frustumNear, final double viewportHeightPixels) {
+    // The frustum spans 2*frustumTop world units of height at the near plane, growing linearly
+    // with depth. Map that against the viewport height to get world units per pixel.
+    final double worldHeightAtDepth = 2.0 * camDepth * frustumTop / frustumNear;
+    return pixels * worldHeightAtDepth / viewportHeightPixels;
+  }
+
+  /**
+   * Calculate the world-space size that covers a desired number of vertical pixels under an
+   * orthographic frustum. Depth does not matter in this projection.
+   *
+   * @param pixels
+   *          desired on-screen size, in pixels.
+   * @param frustumTop
+   *          the camera's frustum top value.
+   * @param frustumBottom
+   *          the camera's frustum bottom value.
+   * @param viewportHeightPixels
+   *          the viewport height, in pixels.
+   * @return the world-space size that projects to the requested pixel size.
+   */
+  public static double worldSizeForPixelsOrtho(final double pixels, final double frustumTop,
+      final double frustumBottom, final double viewportHeightPixels) {
+    return pixels * (frustumTop - frustumBottom) / viewportHeightPixels;
+  }
+
+  /**
+   * Calculate the scale to apply to a unit-sized handle so it covers a desired number of vertical
+   * pixels on screen, regardless of camera distance. Dispatches on the camera's projection mode.
+   * Positions at or behind the near plane are clamped to the near plane, so the returned scale is
+   * always positive.
+   *
+   * @param camera
+   *          the camera viewing the handle.
+   * @param worldPos
+   *          the world position of the handle.
+   * @param pixels
+   *          desired on-screen size, in pixels.
+   * @return scale factor for a handle of world-size 1.0.
+   */
+  public static double calculateFixedScreenScale(final Camera camera, final ReadOnlyVector3 worldPos,
+      final double pixels) {
+    if (camera.getProjectionMode() == ProjectionMode.Perspective) {
+      final double depth = Math.max(camera.getFrustumNear(),
+          worldPos.subtract(camera.getLocation(), null).dot(camera.getDirection()));
+      return worldSizeForPixels(pixels, depth, camera.getFrustumTop(), camera.getFrustumNear(), camera.getHeight());
+    }
+
+    return worldSizeForPixelsOrtho(pixels, camera.getFrustumTop(), camera.getFrustumBottom(), camera.getHeight());
+  }
+
+  /**
+   * The angle between an axis line and the view direction, folded into [0, pi/2]. An axis pointing
+   * directly at (or away from) the camera returns 0; an axis perpendicular to the view direction
+   * returns pi/2.
+   *
+   * @param axisDir
+   *          unit direction of the axis.
+   * @param viewDir
+   *          unit view direction of the camera.
+   * @return the folded angle, in radians.
+   */
+  public static double axisViewAngle(final ReadOnlyVector3 axisDir, final ReadOnlyVector3 viewDir) {
+    return Math.acos(Math.min(1.0, Math.abs(axisDir.dot(viewDir))));
+  }
+
+  /**
+   * The angle between a plane and the view direction, folded into [0, pi/2]. A plane viewed
+   * edge-on returns 0; a plane viewed face-on returns pi/2.
+   *
+   * @param planeNormal
+   *          unit normal of the plane.
+   * @param viewDir
+   *          unit view direction of the camera.
+   * @return the folded angle, in radians.
+   */
+  public static double planeViewAngle(final ReadOnlyVector3 planeNormal, final ReadOnlyVector3 viewDir) {
+    return Math.asin(Math.min(1.0, Math.abs(planeNormal.dot(viewDir))));
+  }
+
+  /**
+   * Map a view angle to a fade alpha: 0 at or below hideBelow, 1 at or above fullAbove, linear in
+   * between. Used to fade out handles whose drag direction is ill-conditioned at the current view
+   * angle.
+   *
+   * @param angle
+   *          the view angle, in radians (see {@link #axisViewAngle(ReadOnlyVector3, ReadOnlyVector3)}
+   *          and {@link #planeViewAngle(ReadOnlyVector3, ReadOnlyVector3)}).
+   * @param hideBelow
+   *          angle at or below which the handle is fully hidden, in radians.
+   * @param fullAbove
+   *          angle at or above which the handle is fully visible, in radians. Must be greater than
+   *          hideBelow.
+   * @return alpha in [0, 1].
+   */
+  public static double fadeAlpha(final double angle, final double hideBelow, final double fullAbove) {
+    return MathUtils.clamp((angle - hideBelow) / (fullAbove - hideBelow), 0.0, 1.0);
+  }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoPart.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoPart.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+/**
+ * Identifies the individual interactive parts a gizmo can be composed of. Which parts are present,
+ * and how a drag on each is interpreted, is up to the owning gizmo.
+ */
+public enum GizmoPart {
+  /** Handle constrained to a single axis. */
+  AxisX, AxisY, AxisZ,
+
+  /** Handle constrained to a plane spanned by two axes. Named by the axes that span it. */
+  PlaneXY, PlaneXZ, PlaneYZ,
+
+  /** Center handle, interpreted against the camera's view plane. */
+  Center,
+
+  /** Ring handle rotating about a single axis. */
+  RingX, RingY, RingZ,
+
+  /** Screen-space ring handle rotating about the view direction. */
+  RingView
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
@@ -1,0 +1,358 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import java.nio.FloatBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.ardor3d.buffer.BufferUtils;
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.DragState;
+import com.ardor3d.extension.interact.widget.gizmo.GizmoHandle.FadeMode;
+import com.ardor3d.framework.Canvas;
+import com.ardor3d.input.logical.TwoInputStates;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.light.LightProperties;
+import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Plane;
+import com.ardor3d.math.Quaternion;
+import com.ardor3d.math.Transform;
+import com.ardor3d.math.Vector2;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyColorRGBA;
+import com.ardor3d.math.type.ReadOnlyQuaternion;
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.IndexMode;
+import com.ardor3d.renderer.Renderer;
+import com.ardor3d.renderer.state.CullState;
+import com.ardor3d.scenegraph.Mesh;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.hint.CullHint;
+import com.ardor3d.ui.text.BasicText;
+import com.ardor3d.util.MaterialUtil;
+
+/**
+ * A v2 rotation gizmo: three axis rings drawn as half-circles kept facing the camera (the back
+ * half of a rotation circle is not usefully draggable), plus an outer ring for rolling about the
+ * view direction. While dragging, a translucent pie wedge sweeps out the accumulated rotation and
+ * a text readout shows the angle in degrees. See {@link AbstractGizmo} for the shared visual
+ * behavior.
+ */
+public class RotateGizmo extends AbstractGizmo {
+
+  // All geometry is built to a gizmo of radius ~1.0, sized on screen by AbstractGizmo.
+  public static final double RING_RADIUS = 1.0;
+  public static final double VIEW_RING_RADIUS = 1.18;
+  public static final double TUBE_RADIUS = 0.011;
+  public static final double PICK_PROXY_TUBE_RADIUS = 0.06;
+  public static final double PIE_RADIUS = 0.95;
+  public static final float PIE_ALPHA = 0.3f;
+  public static final int ARC_SAMPLES = 48;
+  public static final int TUBE_SAMPLES = 8;
+
+  protected GizmoHandle _viewRingHandle;
+
+  protected final Quaternion _calcQuat = new Quaternion();
+  protected final Matrix3 _calcMat3 = new Matrix3();
+
+  /** Accumulated angle of the active drag, in radians. */
+  protected double _dragAngle;
+  /** World-space direction from the gizmo center to the initial drag grab point. */
+  protected Vector3 _dragStartDir = null;
+  /** World-space rotation axis of the active drag. */
+  protected final Vector3 _dragAxis = new Vector3();
+
+  protected final Mesh _pieMesh;
+  protected final BasicText _angleText;
+
+  public RotateGizmo() {
+    super("rotateGizmo");
+
+    // Pie wedge showing the swept angle during a drag. Not a handle: not pickable, recolored
+    // to match the dragged ring.
+    _pieMesh = new Mesh("dragPie");
+    _pieMesh.getMeshData().setIndexMode(IndexMode.TriangleFan);
+    // seed with a degenerate wedge; updatePie() replaces it while dragging
+    _pieMesh.getMeshData().setVertexBuffer(BufferUtils.createVector3Buffer(3));
+    LightProperties.setLightReceiver(_pieMesh, false);
+    final CullState pieCull = new CullState();
+    pieCull.setCullFace(CullState.Face.None);
+    _pieMesh.setRenderState(pieCull);
+    _pieMesh.getSceneHints().setAllPickingHints(false);
+    _pieMesh.getSceneHints().setCullHint(CullHint.Always);
+    _handle.attachChild(_pieMesh);
+    MaterialUtil.autoMaterials(_pieMesh);
+
+    // Screen-space angle readout, living in the ortho render queue. The gizmo shows, hides,
+    // positions and updates it during ring drags; the application decides where it renders by
+    // attaching it to its UI/ortho root (see getAngleReadout()).
+    _angleText = BasicText.createDefaultTextLabel("angleReadout", "", 16);
+    _angleText.setTextColor(ColorRGBA.WHITE);
+    _angleText.getSceneHints().setCullHint(CullHint.Always);
+  }
+
+  /**
+   * @return the screen-space angle readout shown while dragging a ring. Attach it to an
+   *         application node rendered in ortho/screen coordinates (with the ortho origin at the
+   *         bottom left) to enable it; the gizmo takes care of visibility, position and content.
+   */
+  public BasicText getAngleReadout() { return _angleText; }
+
+  /** Add the full set of handles: the three axis rings and the view roll ring. */
+  public RotateGizmo withAllHandles() {
+    return withAxisRings().withViewRing();
+  }
+
+  /** Add the three camera-facing half rings. */
+  public RotateGizmo withAxisRings() {
+    addRingHandle(GizmoPart.RingX, Vector3.UNIT_X, DEFAULT_X_COLOR);
+    addRingHandle(GizmoPart.RingY, Vector3.UNIT_Y, DEFAULT_Y_COLOR);
+    addRingHandle(GizmoPart.RingZ, Vector3.UNIT_Z, DEFAULT_Z_COLOR);
+    return this;
+  }
+
+  /** Add the outer, screen-space roll ring. */
+  public RotateGizmo withViewRing() {
+    final Node root = new Node(GizmoPart.RingView.name());
+    LightProperties.setLightReceiver(root, false);
+
+    final Mesh ring = GizmoGeometry.arcTube("ring", RotateGizmo.VIEW_RING_RADIUS, RotateGizmo.TUBE_RADIUS, 0,
+        MathUtils.TWO_PI, RotateGizmo.ARC_SAMPLES * 2, RotateGizmo.TUBE_SAMPLES);
+    ring.updateModelBound();
+    root.attachChild(ring);
+
+    final Mesh proxy = GizmoGeometry.arcTube("pickProxy", RotateGizmo.VIEW_RING_RADIUS,
+        RotateGizmo.PICK_PROXY_TUBE_RADIUS, 0, MathUtils.TWO_PI, RotateGizmo.ARC_SAMPLES, 6);
+    proxy.updateModelBound();
+    proxy.getSceneHints().setCullHint(CullHint.Always);
+    root.attachChild(proxy);
+
+    _viewRingHandle = new GizmoHandle(GizmoPart.RingView, root, DEFAULT_CENTER_COLOR, Vector3.ZERO, FadeMode.None);
+    addGizmoHandle(_viewRingHandle);
+    MaterialUtil.autoMaterials(root);
+    return this;
+  }
+
+  protected void addRingHandle(final GizmoPart part, final ReadOnlyVector3 axis, final ReadOnlyColorRGBA color) {
+    final Node root = new Node(part.name());
+    LightProperties.setLightReceiver(root, false);
+
+    // A half circle in the XY plane centered on +X; updateCameraFacingHandles turns it so +Z is
+    // the rotation axis and +X faces the camera.
+    final Mesh arc = GizmoGeometry.arcTube("arc", RotateGizmo.RING_RADIUS, RotateGizmo.TUBE_RADIUS, -MathUtils.HALF_PI,
+        MathUtils.HALF_PI, RotateGizmo.ARC_SAMPLES, RotateGizmo.TUBE_SAMPLES);
+    arc.updateModelBound();
+    root.attachChild(arc);
+
+    final Mesh proxy = GizmoGeometry.arcTube("pickProxy", RotateGizmo.RING_RADIUS,
+        RotateGizmo.PICK_PROXY_TUBE_RADIUS, -MathUtils.HALF_PI, MathUtils.HALF_PI, RotateGizmo.ARC_SAMPLES / 2, 6);
+    proxy.updateModelBound();
+    proxy.getSceneHints().setCullHint(CullHint.Always);
+    root.attachChild(proxy);
+
+    addGizmoHandle(new GizmoHandle(part, root, color, axis, FadeMode.None));
+    MaterialUtil.autoMaterials(root);
+  }
+
+  @Override
+  protected void updateCameraFacingHandles(final Camera camera) {
+    // Camera direction in the gizmo's local frame.
+    final Vector3 toCamera = _calcVec3A.set(camera.getDirection()).negateLocal();
+    _handle.getRotation().applyPre(toCamera, toCamera);
+
+    for (int i = _gizmoHandles.size(); --i >= 0;) {
+      final GizmoHandle handle = _gizmoHandles.get(i);
+      switch (handle.getPart()) {
+        case RingX, RingY, RingZ -> {
+          // Face the half ring's center (+X in arc space) at the camera: local +Z maps to the
+          // ring axis and +X to the component of the camera direction perpendicular to it.
+          final ReadOnlyVector3 axis = handle.getAxis();
+          final Vector3 facing = _calcVec3B.set(toCamera)
+              .subtractLocal(_calcVec3C.set(axis).multiplyLocal(toCamera.dot(axis)));
+          if (facing.lengthSquared() > 1e-8) {
+            facing.normalizeLocal();
+            handle.getRoot().setRotation(_calcMat3.fromAxes(facing, _calcVec3C.set(axis).crossLocal(facing), axis));
+          }
+          // Otherwise the ring is face-on and every half is equally good; keep the last one.
+        }
+        case RingView -> {
+          _calcQuat.fromVectorToVector(Vector3.UNIT_Z, toCamera);
+          handle.getRoot().setRotation(_calcQuat);
+        }
+        default -> {
+        }
+      }
+    }
+
+    updatePie();
+  }
+
+  @Override
+  public void render(final Renderer renderer, final InteractManager manager) {
+    super.render(renderer, manager);
+    updateAngleReadout(manager);
+  }
+
+  protected void updateAngleReadout(final InteractManager manager) {
+    if (manager.getSpatialTarget() == null || _dragState == DragState.NONE || _dragStartDir == null) {
+      hideAngleReadout();
+      return;
+    }
+
+    // Show the readout just above the gizmo center, in screen coordinates (ortho space).
+    final Camera camera = Camera.getCurrentCamera();
+    final Vector3 screen = camera.getScreenCoordinates(_handle.getWorldTranslation(), _calcVec3A);
+    _angleText.setText(String.format("%.1f°", _dragAngle * MathUtils.RAD_TO_DEG));
+    _angleText.setTranslation((int) (screen.getX() + 12), (int) (screen.getY() + 12), 0);
+    _angleText.getSceneHints().setCullHint(CullHint.Never);
+  }
+
+  protected void hideAngleReadout() {
+    if (_angleText.getSceneHints().getCullHint() != CullHint.Always) {
+      _angleText.getSceneHints().setCullHint(CullHint.Always);
+    }
+  }
+
+  /**
+   * Rebuild the pie wedge fan for the current drag, or hide it when no ring drag is active.
+   */
+  protected void updatePie() {
+    final GizmoHandle active = _dragState != DragState.NONE ? findGizmoHandle(_lastDragSpatial) : null;
+    if (active == null || _dragStartDir == null) {
+      _pieMesh.getSceneHints().setCullHint(CullHint.Always);
+      return;
+    }
+    _pieMesh.getSceneHints().setCullHint(CullHint.Never);
+    _pieMesh.setDefaultColor(active.getBaseColor().getRed(), active.getBaseColor().getGreen(),
+        active.getBaseColor().getBlue(), RotateGizmo.PIE_ALPHA);
+
+    // Work in the gizmo's local frame: in-plane basis from the grab direction and drag axis.
+    final Vector3 axisLocal = _calcVec3A.set(_dragAxis);
+    _handle.getRotation().applyPre(axisLocal, axisLocal);
+    final Vector3 e1 = _calcVec3B.set(_dragStartDir);
+    _handle.getRotation().applyPre(e1, e1);
+    final Vector3 e2 = axisLocal.cross(e1, _calcVec3C);
+
+    final int segments = Math.max(1, (int) Math.ceil(Math.abs(_dragAngle) / (5 * MathUtils.DEG_TO_RAD)));
+    final FloatBuffer vertexBuffer = BufferUtils.createVector3Buffer(segments + 2);
+    vertexBuffer.put(0).put(0).put(0);
+    for (int i = 0; i <= segments; i++) {
+      final double angle = _dragAngle * i / segments;
+      final double c = Math.cos(angle) * RotateGizmo.PIE_RADIUS;
+      final double s = Math.sin(angle) * RotateGizmo.PIE_RADIUS;
+      vertexBuffer.put((float) (e1.getX() * c + e2.getX() * s)) //
+          .put((float) (e1.getY() * c + e2.getY() * s)) //
+          .put((float) (e1.getZ() * c + e2.getZ() * s));
+    }
+    _pieMesh.getMeshData().setVertexBuffer(vertexBuffer);
+  }
+
+  @Override
+  public void endDrag(final InteractManager manager, final MouseState current) {
+    super.endDrag(manager, current);
+    _dragStartDir = null;
+    _dragAngle = 0;
+    hideAngleReadout();
+  }
+
+  @Override
+  public void processInput(final Canvas source, final TwoInputStates inputStates, final AtomicBoolean inputConsumed,
+      final InteractManager manager) {
+
+    final Camera camera = source.getCanvasRenderer().getCamera();
+    final MouseState current = inputStates.getCurrent().getMouseState();
+    final MouseState previous = inputStates.getPrevious().getMouseState();
+
+    // first process mouse over state
+    checkMouseOver(source, current, manager);
+
+    // Now check drag status
+    if (!checkShouldDrag(camera, current, previous, inputConsumed, manager)) {
+      return;
+    }
+
+    // act on drag
+    final GizmoHandle handle = findGizmoHandle(_lastDragSpatial);
+    if (handle == null) {
+      return;
+    }
+
+    final Vector2 oldMouse = new Vector2(previous.getX(), previous.getY());
+    final ReadOnlyQuaternion rot = getNewRotation(handle, oldMouse, current, camera, manager);
+    final Transform transform = manager.getSpatialState().getTransform();
+    rot.toRotationMatrix(_calcMat3).multiply(transform.getMatrix(), _calcMat3);
+    transform.setRotation(_calcMat3);
+
+    // apply our filters, if any, now that we've made updates.
+    applyFilters(manager);
+  }
+
+  /**
+   * Work out the rotation described by the mouse moving from oldMouse to the current position
+   * while dragging the given ring, expressed in the target's parent coordinate space. Also tracks
+   * the drag's accumulated angle for the pie wedge and readout.
+   */
+  protected ReadOnlyQuaternion getNewRotation(final GizmoHandle handle, final Vector2 oldMouse,
+      final MouseState current, final Camera camera, final InteractManager manager) {
+
+    final ReadOnlyVector3 origin = _handle.getWorldTranslation();
+
+    // The rotation axis, in world space.
+    if (handle.getPart() == GizmoPart.RingView) {
+      _dragAxis.set(camera.getDirection()).negateLocal();
+    } else {
+      _handle.getRotation().applyPost(handle.getAxis(), _dragAxis).normalizeLocal();
+    }
+
+    // Drag against the ring's plane.
+    final Plane pickPlane = new Plane(_dragAxis, _dragAxis.dot(origin));
+
+    getPickRay(oldMouse, camera);
+    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3A)) {
+      return Quaternion.IDENTITY;
+    }
+    getPickRay(new Vector2(current.getX(), current.getY()), camera);
+    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3B)) {
+      return Quaternion.IDENTITY;
+    }
+
+    final Vector3 oldDir = _calcVec3A.subtractLocal(origin);
+    final Vector3 newDir = _calcVec3B.subtractLocal(origin);
+    if (oldDir.lengthSquared() < 1e-12 || newDir.lengthSquared() < 1e-12) {
+      return Quaternion.IDENTITY;
+    }
+    oldDir.normalizeLocal();
+    newDir.normalizeLocal();
+
+    // Track the accumulated angle for the pie wedge and readout, anchoring the wedge at the
+    // first grab direction.
+    if (_dragStartDir == null) {
+      _dragStartDir = new Vector3(oldDir);
+      _dragAngle = 0;
+    }
+    _dragAngle += GizmoMath.signedAngle(oldDir, newDir, _dragAxis);
+
+    // convert to target coord space
+    final Node parent = manager.getSpatialTarget().getParent();
+    if (parent != null) {
+      parent.getWorldTransform().applyInverseVector(oldDir);
+      parent.getWorldTransform().applyInverseVector(newDir);
+    }
+
+    // return a rotation to take us to the new rotation
+    return _calcQuat.fromVectorToVector(oldDir, newDir);
+  }
+
+  public double getDragAngle() { return _dragAngle; }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
@@ -23,7 +23,6 @@ import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.light.LightProperties;
 import com.ardor3d.math.ColorRGBA;
 import com.ardor3d.math.Matrix3;
-import com.ardor3d.math.Plane;
 import com.ardor3d.math.Quaternion;
 import com.ardor3d.math.Transform;
 import com.ardor3d.math.Vector2;
@@ -37,6 +36,7 @@ import com.ardor3d.renderer.IndexMode;
 import com.ardor3d.renderer.Renderer;
 import com.ardor3d.renderer.state.CullState;
 import com.ardor3d.scenegraph.Mesh;
+import com.ardor3d.scenegraph.MeshData;
 import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.hint.CullHint;
 import com.ardor3d.ui.text.BasicText;
@@ -58,6 +58,8 @@ public class RotateGizmo extends AbstractGizmo {
   public static final double PICK_PROXY_TUBE_RADIUS = 0.06;
   public static final double PIE_RADIUS = 0.95;
   public static final float PIE_ALPHA = 0.3f;
+  /** Cap on pie wedge tessellation; beyond this, segments span more than 5 degrees each. */
+  public static final int PIE_MAX_SEGMENTS = 256;
   public static final int ARC_SAMPLES = 48;
   public static final int TUBE_SAMPLES = 8;
 
@@ -82,6 +84,9 @@ public class RotateGizmo extends AbstractGizmo {
   protected final Vector3 _dragAxis = new Vector3();
 
   protected final Mesh _pieMesh;
+  /** Reused vertex storage for the pie wedge, so dragging stays allocation-free. */
+  protected final FloatBuffer _pieBuffer =
+      BufferUtils.createVector3Buffer(RotateGizmo.PIE_MAX_SEGMENTS + 2);
   protected final BasicText _angleText;
 
   public RotateGizmo() {
@@ -91,8 +96,9 @@ public class RotateGizmo extends AbstractGizmo {
     // to match the dragged ring.
     _pieMesh = new Mesh("dragPie");
     _pieMesh.getMeshData().setIndexMode(IndexMode.TriangleFan);
-    // seed with a degenerate wedge; updatePie() replaces it while dragging
-    _pieMesh.getMeshData().setVertexBuffer(BufferUtils.createVector3Buffer(3));
+    // seed with a degenerate wedge; updatePie() rewrites the buffer while dragging
+    _pieBuffer.limit(3 * 3);
+    _pieMesh.getMeshData().setVertexBuffer(_pieBuffer);
     LightProperties.setLightReceiver(_pieMesh, false);
     final CullState pieCull = new CullState();
     pieCull.setCullFace(CullState.Face.None);
@@ -291,18 +297,21 @@ public class RotateGizmo extends AbstractGizmo {
     _handle.getRotation().applyPre(e1, e1);
     final Vector3 e2 = axisLocal.cross(e1, _calcVec3C);
 
-    final int segments = Math.max(1, (int) Math.ceil(Math.abs(_displayAngle) / (5 * MathUtils.DEG_TO_RAD)));
-    final FloatBuffer vertexBuffer = BufferUtils.createVector3Buffer(segments + 2);
-    vertexBuffer.put(0).put(0).put(0);
+    final int segments = MathUtils.clamp(
+        (int) Math.ceil(Math.abs(_displayAngle) / (5 * MathUtils.DEG_TO_RAD)), 1, RotateGizmo.PIE_MAX_SEGMENTS);
+    _pieBuffer.clear();
+    _pieBuffer.put(0).put(0).put(0);
     for (int i = 0; i <= segments; i++) {
       final double angle = _displayAngle * i / segments;
       final double c = Math.cos(angle) * RotateGizmo.PIE_RADIUS;
       final double s = Math.sin(angle) * RotateGizmo.PIE_RADIUS;
-      vertexBuffer.put((float) (e1.getX() * c + e2.getX() * s)) //
+      _pieBuffer.put((float) (e1.getX() * c + e2.getX() * s)) //
           .put((float) (e1.getY() * c + e2.getY() * s)) //
           .put((float) (e1.getZ() * c + e2.getZ() * s));
     }
-    _pieMesh.getMeshData().setVertexBuffer(vertexBuffer);
+    _pieBuffer.flip();
+    _pieMesh.getMeshData().updateVertexCount();
+    _pieMesh.getMeshData().markBufferDirty(MeshData.KEY_VertexCoords);
   }
 
   @Override
@@ -337,8 +346,8 @@ public class RotateGizmo extends AbstractGizmo {
       return;
     }
 
-    final Vector2 oldMouse = new Vector2(previous.getX(), previous.getY());
-    final ReadOnlyQuaternion rot = getNewRotation(handle, oldMouse, current, camera, manager);
+    _calcVec2A.set(previous.getX(), previous.getY());
+    final ReadOnlyQuaternion rot = getNewRotation(handle, _calcVec2A, current, camera, manager);
     final Transform transform = manager.getSpatialState().getTransform();
     rot.toRotationMatrix(_calcMat3).multiply(transform.getMatrix(), _calcMat3);
     transform.setRotation(_calcMat3);
@@ -365,14 +374,15 @@ public class RotateGizmo extends AbstractGizmo {
     }
 
     // Drag against the ring's plane.
-    final Plane pickPlane = new Plane(_dragAxis, _dragAxis.dot(origin));
+    _calcPlane.setNormal(_dragAxis);
+    _calcPlane.setConstant(_dragAxis.dot(origin));
 
     getPickRay(oldMouse, camera);
-    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3A)) {
+    if (!_calcRay.intersectsPlane(_calcPlane, _calcVec3A)) {
       return Quaternion.IDENTITY;
     }
-    getPickRay(new Vector2(current.getX(), current.getY()), camera);
-    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3B)) {
+    getPickRay(_calcVec2B.set(current.getX(), current.getY()), camera);
+    if (!_calcRay.intersectsPlane(_calcPlane, _calcVec3B)) {
       return Quaternion.IDENTITY;
     }
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
@@ -65,11 +65,19 @@ public class RotateGizmo extends AbstractGizmo {
 
   protected final Quaternion _calcQuat = new Quaternion();
   protected final Matrix3 _calcMat3 = new Matrix3();
+  protected final Matrix3 _calcMat3B = new Matrix3();
 
-  /** Accumulated angle of the active drag, in radians. */
+  /** Accumulated raw angle of the active drag, in radians, before any filters. */
   protected double _dragAngle;
+  /**
+   * The drag angle actually applied to the state after filters ran (e.g. angle snapping), used
+   * for the pie wedge and readout. Matches _dragAngle when no filter modifies the rotation.
+   */
+  protected double _displayAngle;
   /** World-space direction from the gizmo center to the initial drag grab point. */
   protected Vector3 _dragStartDir = null;
+  /** State rotation captured when the drag started, for measuring the applied delta. */
+  protected Matrix3 _dragStartRotation = null;
   /** World-space rotation axis of the active drag. */
   protected final Vector3 _dragAxis = new Vector3();
 
@@ -200,8 +208,47 @@ public class RotateGizmo extends AbstractGizmo {
 
   @Override
   public void render(final Renderer renderer, final InteractManager manager) {
+    _displayAngle = calculateAppliedAngle(manager);
     super.render(renderer, manager);
     updateAngleReadout(manager);
+  }
+
+  /**
+   * The drag angle actually applied to the spatial state, read back after filters ran. A snap
+   * filter, for example, leaves the state at quantized steps while the raw drag angle moves
+   * continuously - the pie wedge and readout must show the former. The result is unwrapped
+   * against the raw angle so drags past a half revolution keep counting.
+   */
+  protected double calculateAppliedAngle(final InteractManager manager) {
+    if (_dragState == DragState.NONE || _dragStartDir == null || _dragStartRotation == null
+        || manager.getSpatialTarget() == null) {
+      return _dragAngle;
+    }
+
+    // Applied delta since drag start, in the target's parent frame.
+    _calcMat3.set(_dragStartRotation).transposeLocal();
+    manager.getSpatialState().getTransform().getMatrix().multiply(_calcMat3, _calcMat3B);
+    final double angle = _calcQuat.fromRotationMatrix(_calcMat3B).toAngleAxis(_calcVec3A);
+
+    // Sign the angle against the drag axis, expressed in the same frame.
+    final Vector3 axis = _calcVec3B.set(_dragAxis);
+    final Node parent = manager.getSpatialTarget().getParent();
+    if (parent != null) {
+      parent.getWorldTransform().applyInverseVector(axis);
+    }
+    if (axis.lengthSquared() < 1e-12) {
+      return _dragAngle;
+    }
+    final double signed = _calcVec3A.dot(axis) < 0 ? -angle : angle;
+
+    // Unwrap: the applied angle is only known modulo a full turn; anchor it to the raw angle.
+    double diff = (signed - _dragAngle) % MathUtils.TWO_PI;
+    if (diff > Math.PI) {
+      diff -= MathUtils.TWO_PI;
+    } else if (diff < -Math.PI) {
+      diff += MathUtils.TWO_PI;
+    }
+    return _dragAngle + diff;
   }
 
   protected void updateAngleReadout(final InteractManager manager) {
@@ -213,7 +260,7 @@ public class RotateGizmo extends AbstractGizmo {
     // Show the readout just above the gizmo center, in screen coordinates (ortho space).
     final Camera camera = Camera.getCurrentCamera();
     final Vector3 screen = camera.getScreenCoordinates(_handle.getWorldTranslation(), _calcVec3A);
-    _angleText.setText(String.format("%.1f°", _dragAngle * MathUtils.RAD_TO_DEG));
+    _angleText.setText(String.format("%.1f°", _displayAngle * MathUtils.RAD_TO_DEG));
     _angleText.setTranslation((int) (screen.getX() + 12), (int) (screen.getY() + 12), 0);
     _angleText.getSceneHints().setCullHint(CullHint.Never);
   }
@@ -244,11 +291,11 @@ public class RotateGizmo extends AbstractGizmo {
     _handle.getRotation().applyPre(e1, e1);
     final Vector3 e2 = axisLocal.cross(e1, _calcVec3C);
 
-    final int segments = Math.max(1, (int) Math.ceil(Math.abs(_dragAngle) / (5 * MathUtils.DEG_TO_RAD)));
+    final int segments = Math.max(1, (int) Math.ceil(Math.abs(_displayAngle) / (5 * MathUtils.DEG_TO_RAD)));
     final FloatBuffer vertexBuffer = BufferUtils.createVector3Buffer(segments + 2);
     vertexBuffer.put(0).put(0).put(0);
     for (int i = 0; i <= segments; i++) {
-      final double angle = _dragAngle * i / segments;
+      final double angle = _displayAngle * i / segments;
       final double c = Math.cos(angle) * RotateGizmo.PIE_RADIUS;
       final double s = Math.sin(angle) * RotateGizmo.PIE_RADIUS;
       vertexBuffer.put((float) (e1.getX() * c + e2.getX() * s)) //
@@ -262,7 +309,9 @@ public class RotateGizmo extends AbstractGizmo {
   public void endDrag(final InteractManager manager, final MouseState current) {
     super.endDrag(manager, current);
     _dragStartDir = null;
+    _dragStartRotation = null;
     _dragAngle = 0;
+    _displayAngle = 0;
     hideAngleReadout();
   }
 
@@ -336,9 +385,11 @@ public class RotateGizmo extends AbstractGizmo {
     newDir.normalizeLocal();
 
     // Track the accumulated angle for the pie wedge and readout, anchoring the wedge at the
-    // first grab direction.
+    // first grab direction. The state still holds the pristine pre-drag rotation here - the
+    // widget's delta is applied after this method returns.
     if (_dragStartDir == null) {
       _dragStartDir = new Vector3(oldDir);
+      _dragStartRotation = new Matrix3(manager.getSpatialState().getTransform().getMatrix());
       _dragAngle = 0;
     }
     _dragAngle += GizmoMath.signedAngle(oldDir, newDir, _dragAxis);

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.gizmo.GizmoHandle.FadeMode;
+import com.ardor3d.framework.Canvas;
+import com.ardor3d.input.logical.TwoInputStates;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.light.LightProperties;
+import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Quaternion;
+import com.ardor3d.math.Transform;
+import com.ardor3d.math.Vector2;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyColorRGBA;
+import com.ardor3d.math.type.ReadOnlyQuaternion;
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.Spatial;
+import com.ardor3d.scenegraph.hint.CullHint;
+import com.ardor3d.scenegraph.shape.Box;
+import com.ardor3d.scenegraph.shape.Cylinder;
+import com.ardor3d.util.MaterialUtil;
+
+/**
+ * A v2 scale gizmo: three cube-tipped axis handles for non-uniform, per-axis scaling and a center
+ * cube for uniform scaling. See {@link AbstractGizmo} for the shared visual behavior.
+ *
+ * Because a non-uniform scale is only meaningful along the target's own axes, this gizmo always
+ * operates in the target's local frame - the interact matrix setting is ignored.
+ *
+ * Axis drags scale by the ratio of the grab point's distance from the gizmo center, so pulling
+ * the X cube out to twice its distance doubles the X scale. The center cube scales uniformly with
+ * mouse movement: up/right grows, down/left shrinks.
+ */
+public class ScaleGizmo extends AbstractGizmo {
+
+  // All geometry is built to a gizmo of length 1.0, sized on screen by AbstractGizmo. Slightly
+  // shorter than the translate arrows so the two read differently at a glance.
+  public static final double SHAFT_RADIUS = 0.015;
+  public static final double SHAFT_START = 0.18;
+  public static final double TIP_HALF_EXTENT = 0.05;
+  public static final double TIP_CENTER = 0.87;
+  public static final double PICK_PROXY_RADIUS = 0.06;
+  public static final double CENTER_HALF_EXTENT = 0.07;
+
+  /** Uniform scale factor applied per pixel of center-cube mouse movement. */
+  public static final double UNIFORM_SCALE_RATE = 0.005;
+
+  /** Bounds on the scale factor applied by a single input event, guarding ratio blow-ups. */
+  public static final double MIN_EVENT_FACTOR = 0.01;
+  public static final double MAX_EVENT_FACTOR = 100.0;
+
+  public ScaleGizmo() {
+    super("scaleGizmo");
+  }
+
+  /** Add the full set of handles: three axis cubes and the uniform center cube. */
+  public ScaleGizmo withAllHandles() {
+    return withAxes().withUniformHandle();
+  }
+
+  /** Add the three cube-tipped axis handles. */
+  public ScaleGizmo withAxes() {
+    addAxisHandle(GizmoPart.AxisX, Vector3.UNIT_X, DEFAULT_X_COLOR,
+        new Quaternion().fromAngleAxis(MathUtils.HALF_PI, Vector3.UNIT_Y));
+    addAxisHandle(GizmoPart.AxisY, Vector3.UNIT_Y, DEFAULT_Y_COLOR,
+        new Quaternion().fromAngleAxis(MathUtils.HALF_PI, Vector3.NEG_UNIT_X));
+    addAxisHandle(GizmoPart.AxisZ, Vector3.UNIT_Z, DEFAULT_Z_COLOR, Quaternion.IDENTITY);
+    return this;
+  }
+
+  /** Add the center cube for uniform scaling. */
+  public ScaleGizmo withUniformHandle() {
+    final Node root = new Node(GizmoPart.Center.name());
+    LightProperties.setLightReceiver(root, false);
+
+    final Box cube = new Box("center", Vector3.ZERO, ScaleGizmo.CENTER_HALF_EXTENT, ScaleGizmo.CENTER_HALF_EXTENT,
+        ScaleGizmo.CENTER_HALF_EXTENT);
+    cube.updateModelBound();
+    root.attachChild(cube);
+
+    addGizmoHandle(new GizmoHandle(GizmoPart.Center, root, DEFAULT_CENTER_COLOR, Vector3.ZERO, FadeMode.None));
+    MaterialUtil.autoMaterials(root);
+    return this;
+  }
+
+  protected void addAxisHandle(final GizmoPart part, final ReadOnlyVector3 axis, final ReadOnlyColorRGBA color,
+      final ReadOnlyQuaternion rotation) {
+    final Node root = new Node(part.name());
+    LightProperties.setLightReceiver(root, false);
+
+    // Geometry is built pointing down +Z, then the whole part is rotated onto its axis.
+    final double shaftLength = ScaleGizmo.TIP_CENTER - ScaleGizmo.TIP_HALF_EXTENT - ScaleGizmo.SHAFT_START;
+    final Cylinder shaft = new Cylinder("shaft", 2, 12, ScaleGizmo.SHAFT_RADIUS, shaftLength, false);
+    shaft.getMeshData().translatePoints(0, 0, ScaleGizmo.SHAFT_START + shaftLength * 0.5);
+    shaft.updateModelBound();
+    root.attachChild(shaft);
+
+    final Box tip = new Box("tip", Vector3.ZERO, ScaleGizmo.TIP_HALF_EXTENT, ScaleGizmo.TIP_HALF_EXTENT,
+        ScaleGizmo.TIP_HALF_EXTENT);
+    tip.getMeshData().translatePoints(0, 0, ScaleGizmo.TIP_CENTER);
+    tip.updateModelBound();
+    root.attachChild(tip);
+
+    // The visible geometry is only a few pixels wide - pick against an invisible, fatter proxy.
+    final double proxyLength = ScaleGizmo.TIP_CENTER + ScaleGizmo.TIP_HALF_EXTENT - ScaleGizmo.SHAFT_START;
+    final Cylinder proxy = new Cylinder("pickProxy", 2, 8, ScaleGizmo.PICK_PROXY_RADIUS, proxyLength, true);
+    proxy.getMeshData().translatePoints(0, 0, ScaleGizmo.SHAFT_START + proxyLength * 0.5);
+    proxy.updateModelBound();
+    proxy.getSceneHints().setCullHint(CullHint.Always);
+    root.attachChild(proxy);
+
+    root.setRotation(rotation);
+
+    addGizmoHandle(new GizmoHandle(part, root, color, axis, FadeMode.Axis));
+    MaterialUtil.autoMaterials(root);
+  }
+
+  /**
+   * Non-uniform scaling is only meaningful in the target's local frame, so this gizmo always
+   * tracks the target's rotation regardless of the interact matrix setting.
+   */
+  @Override
+  public void targetDataUpdated(final InteractManager manager) {
+    final Spatial target = manager.getSpatialTarget();
+    if (target == null) {
+      _handle.setRotation(Matrix3.IDENTITY);
+    } else {
+      target.updateGeometricState(0);
+      _handle.setRotation(target.getWorldRotation());
+    }
+  }
+
+  @Override
+  public void processInput(final Canvas source, final TwoInputStates inputStates, final AtomicBoolean inputConsumed,
+      final InteractManager manager) {
+
+    final Camera camera = source.getCanvasRenderer().getCamera();
+    final MouseState current = inputStates.getCurrent().getMouseState();
+    final MouseState previous = inputStates.getPrevious().getMouseState();
+
+    // first process mouse over state
+    checkMouseOver(source, current, manager);
+
+    // Now check drag status
+    if (!checkShouldDrag(camera, current, previous, inputConsumed, manager)) {
+      return;
+    }
+
+    // act on drag
+    final GizmoHandle handle = findGizmoHandle(_lastDragSpatial);
+    if (handle == null) {
+      return;
+    }
+
+    final Vector2 oldMouse = new Vector2(previous.getX(), previous.getY());
+    final double factor = getScaleFactor(handle, oldMouse, current, camera);
+
+    final Transform transform = manager.getSpatialState().getTransform();
+    final Vector3 scale = new Vector3(transform.getScale());
+    switch (handle.getPart()) {
+      case AxisX -> scale.setX(scale.getX() * factor);
+      case AxisY -> scale.setY(scale.getY() * factor);
+      case AxisZ -> scale.setZ(scale.getZ() * factor);
+      case Center -> scale.multiplyLocal(factor);
+      default -> {
+        return;
+      }
+    }
+    scale.set(Math.max(MIN_SCALE, scale.getX()), Math.max(MIN_SCALE, scale.getY()),
+        Math.max(MIN_SCALE, scale.getZ()));
+    transform.setScale(scale);
+
+    // apply our filters, if any, now that we've made updates.
+    applyFilters(manager);
+  }
+
+  /**
+   * Work out the scale factor described by the mouse moving from oldMouse to the current position
+   * while dragging the given handle.
+   */
+  protected double getScaleFactor(final GizmoHandle handle, final Vector2 oldMouse, final MouseState current,
+      final Camera camera) {
+
+    double factor = 1.0;
+    switch (handle.getPart()) {
+      case AxisX, AxisY, AxisZ -> {
+        // Scale by the ratio of the grab point's distance from the gizmo center along the axis.
+        final Vector3 dragAxis = _handle.getRotation().applyPost(handle.getAxis(), _calcVec3D).normalizeLocal();
+        final Vector2 axisT = new Vector2();
+        if (!projectOnAxis(dragAxis, oldMouse, new Vector2(current.getX(), current.getY()), camera, axisT)
+            || Math.abs(axisT.getX()) < 1e-8) {
+          return 1.0;
+        }
+        factor = axisT.getY() / axisT.getX();
+      }
+      case Center ->
+        // Uniform: grow dragging up/right, shrink dragging down/left.
+        factor = 1.0 + (current.getDx() + current.getDy()) * ScaleGizmo.UNIFORM_SCALE_RATE;
+      default -> {
+        return 1.0;
+      }
+    }
+    return MathUtils.clamp(factor, ScaleGizmo.MIN_EVENT_FACTOR, ScaleGizmo.MAX_EVENT_FACTOR);
+  }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
@@ -167,8 +167,8 @@ public class ScaleGizmo extends AbstractGizmo {
       return;
     }
 
-    final Vector2 oldMouse = new Vector2(previous.getX(), previous.getY());
-    final double factor = getScaleFactor(handle, oldMouse, current, camera);
+    _calcVec2A.set(previous.getX(), previous.getY());
+    final double factor = getScaleFactor(handle, _calcVec2A, current, camera);
 
     final Transform transform = manager.getSpatialState().getTransform();
     final Vector3 scale = new Vector3(transform.getScale());
@@ -201,12 +201,12 @@ public class ScaleGizmo extends AbstractGizmo {
       case AxisX, AxisY, AxisZ -> {
         // Scale by the ratio of the grab point's distance from the gizmo center along the axis.
         final Vector3 dragAxis = _handle.getRotation().applyPost(handle.getAxis(), _calcVec3D).normalizeLocal();
-        final Vector2 axisT = new Vector2();
-        if (!projectOnAxis(dragAxis, oldMouse, new Vector2(current.getX(), current.getY()), camera, axisT)
-            || Math.abs(axisT.getX()) < 1e-8) {
+        _calcVec2B.set(current.getX(), current.getY());
+        if (!projectOnAxis(dragAxis, oldMouse, _calcVec2B, camera, _calcVec2C)
+            || Math.abs(_calcVec2C.getX()) < 1e-8) {
           return 1.0;
         }
-        factor = axisT.getY() / axisT.getX();
+        factor = _calcVec2C.getY() / _calcVec2C.getX();
       }
       case Center ->
         // Uniform: grow dragging up/right, shrink dragging down/left.

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.gizmo.GizmoHandle.FadeMode;
+import com.ardor3d.framework.Canvas;
+import com.ardor3d.input.logical.TwoInputStates;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.light.LightProperties;
+import com.ardor3d.math.ColorRGBA;
+import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Plane;
+import com.ardor3d.math.Quaternion;
+import com.ardor3d.math.Transform;
+import com.ardor3d.math.Vector2;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyColorRGBA;
+import com.ardor3d.math.type.ReadOnlyMatrix3;
+import com.ardor3d.math.type.ReadOnlyQuaternion;
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.state.CullState;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.hint.CullHint;
+import com.ardor3d.scenegraph.shape.Cylinder;
+import com.ardor3d.scenegraph.shape.Disk;
+import com.ardor3d.scenegraph.shape.Quad;
+import com.ardor3d.util.MaterialUtil;
+
+/**
+ * A v2 translation gizmo: three thin, cone-tipped axis arrows, three corner quads for dragging in
+ * the planes spanned by axis pairs, and a camera-facing center disk for dragging in the view
+ * plane. See {@link AbstractGizmo} for the shared visual behavior (constant screen size,
+ * per-handle highlighting, x-ray rendering, view-angle fades).
+ */
+public class TranslateGizmo extends AbstractGizmo {
+
+  // All geometry is built to a gizmo of length 1.0, sized on screen by AbstractGizmo.
+  public static final double SHAFT_RADIUS = 0.015;
+  public static final double SHAFT_START = 0.18;
+  public static final double TIP_RADIUS = 0.055;
+  public static final double TIP_LENGTH = 0.2;
+  public static final double PICK_PROXY_RADIUS = 0.06;
+  public static final double PLANE_QUAD_SIZE = 0.24;
+  public static final double PLANE_QUAD_CENTER = 0.38;
+  public static final double CENTER_RADIUS = 0.08;
+  public static final float PLANE_FILL_ALPHA = 0.55f;
+
+  protected GizmoHandle _centerHandle;
+
+  protected final Quaternion _calcQuat = new Quaternion();
+
+  public TranslateGizmo() {
+    super("translateGizmo");
+  }
+
+  /** Add the full set of handles: axis arrows, plane quads and the view-plane center disk. */
+  public TranslateGizmo withAllHandles() {
+    return withAxes().withPlanes().withViewPlaneHandle();
+  }
+
+  /** Add the three cone-tipped axis arrows. */
+  public TranslateGizmo withAxes() {
+    addAxisHandle(GizmoPart.AxisX, Vector3.UNIT_X, DEFAULT_X_COLOR,
+        new Quaternion().fromAngleAxis(MathUtils.HALF_PI, Vector3.UNIT_Y));
+    addAxisHandle(GizmoPart.AxisY, Vector3.UNIT_Y, DEFAULT_Y_COLOR,
+        new Quaternion().fromAngleAxis(MathUtils.HALF_PI, Vector3.NEG_UNIT_X));
+    addAxisHandle(GizmoPart.AxisZ, Vector3.UNIT_Z, DEFAULT_Z_COLOR, Quaternion.IDENTITY);
+    return this;
+  }
+
+  /** Add the three corner quads for two-axis drags. Each is colored by its plane's normal axis. */
+  public TranslateGizmo withPlanes() {
+    // columns are the images of local X, Y, Z: quads are built in XY facing +Z, then rotated so
+    // the quad spans the named plane and +Z becomes the plane normal.
+    addPlaneHandle(GizmoPart.PlaneXY, Vector3.UNIT_Z, DEFAULT_Z_COLOR, Matrix3.IDENTITY);
+    addPlaneHandle(GizmoPart.PlaneXZ, Vector3.UNIT_Y, DEFAULT_Y_COLOR,
+        new Matrix3().fromAxes(Vector3.UNIT_Z, Vector3.UNIT_X, Vector3.UNIT_Y));
+    addPlaneHandle(GizmoPart.PlaneYZ, Vector3.UNIT_X, DEFAULT_X_COLOR,
+        new Matrix3().fromAxes(Vector3.UNIT_Y, Vector3.UNIT_Z, Vector3.UNIT_X));
+    return this;
+  }
+
+  /** Add the camera-facing center disk for view-plane drags. */
+  public TranslateGizmo withViewPlaneHandle() {
+    final Node root = new Node(GizmoPart.Center.name());
+    LightProperties.setLightReceiver(root, false);
+
+    final Disk disk = new Disk("center", 2, 24, TranslateGizmo.CENTER_RADIUS);
+    disk.updateModelBound();
+    root.attachChild(disk);
+
+    final CullState cull = new CullState();
+    cull.setCullFace(CullState.Face.None);
+    root.setRenderState(cull);
+
+    _centerHandle = new GizmoHandle(GizmoPart.Center, root, DEFAULT_CENTER_COLOR, Vector3.ZERO, FadeMode.None);
+    addGizmoHandle(_centerHandle);
+    MaterialUtil.autoMaterials(root);
+    return this;
+  }
+
+  protected void addAxisHandle(final GizmoPart part, final ReadOnlyVector3 axis, final ReadOnlyColorRGBA color,
+      final ReadOnlyQuaternion rotation) {
+    final Node root = new Node(part.name());
+    LightProperties.setLightReceiver(root, false);
+
+    // Geometry is built pointing down +Z, then the whole part is rotated onto its axis.
+    final double shaftLength = 1.0 - TranslateGizmo.TIP_LENGTH - TranslateGizmo.SHAFT_START;
+    final Cylinder shaft =
+        new Cylinder("shaft", 2, 12, TranslateGizmo.SHAFT_RADIUS, shaftLength, false);
+    shaft.getMeshData().translatePoints(0, 0, TranslateGizmo.SHAFT_START + shaftLength * 0.5);
+    shaft.updateModelBound();
+    root.attachChild(shaft);
+
+    final Cylinder tip = new Cylinder("tip", 2, 16, TranslateGizmo.TIP_RADIUS, TranslateGizmo.TIP_LENGTH, true);
+    // Taper the +Z end to a point, leaving the base radius at -Z: a cone pointing along the axis.
+    tip.setRadius1(0);
+    tip.getMeshData().translatePoints(0, 0, 1.0 - TranslateGizmo.TIP_LENGTH * 0.5);
+    tip.updateModelBound();
+    root.attachChild(tip);
+
+    // The visible geometry is only a few pixels wide - pick against an invisible, fatter proxy.
+    final double proxyLength = 1.0 - TranslateGizmo.SHAFT_START;
+    final Cylinder proxy = new Cylinder("pickProxy", 2, 8, TranslateGizmo.PICK_PROXY_RADIUS, proxyLength, true);
+    proxy.getMeshData().translatePoints(0, 0, TranslateGizmo.SHAFT_START + proxyLength * 0.5);
+    proxy.updateModelBound();
+    proxy.getSceneHints().setCullHint(CullHint.Always);
+    root.attachChild(proxy);
+
+    root.setRotation(rotation);
+
+    addGizmoHandle(new GizmoHandle(part, root, color, axis, FadeMode.Axis));
+    MaterialUtil.autoMaterials(root);
+  }
+
+  protected void addPlaneHandle(final GizmoPart part, final ReadOnlyVector3 normal, final ReadOnlyColorRGBA color,
+      final ReadOnlyMatrix3 rotation) {
+    final Node root = new Node(part.name());
+    LightProperties.setLightReceiver(root, false);
+
+    final Quad fill = new Quad("fill", TranslateGizmo.PLANE_QUAD_SIZE, TranslateGizmo.PLANE_QUAD_SIZE);
+    fill.getMeshData().translatePoints(TranslateGizmo.PLANE_QUAD_CENTER, TranslateGizmo.PLANE_QUAD_CENTER, 0);
+    fill.updateModelBound();
+    root.attachChild(fill);
+
+    final CullState cull = new CullState();
+    cull.setCullFace(CullState.Face.None);
+    root.setRenderState(cull);
+
+    root.setRotation(rotation);
+
+    final ColorRGBA fillColor = new ColorRGBA(color.getRed(), color.getGreen(), color.getBlue(),
+        TranslateGizmo.PLANE_FILL_ALPHA);
+    addGizmoHandle(new GizmoHandle(part, root, fillColor, normal, FadeMode.Plane));
+    MaterialUtil.autoMaterials(root);
+  }
+
+  @Override
+  protected void updateCameraFacingHandles(final Camera camera) {
+    if (_centerHandle == null) {
+      return;
+    }
+    // Orient the center disk's +Z at the camera, expressed in the gizmo's local space.
+    _calcVec3A.set(camera.getDirection()).negateLocal();
+    _handle.getRotation().applyPre(_calcVec3A, _calcVec3A);
+    _calcQuat.fromVectorToVector(Vector3.UNIT_Z, _calcVec3A);
+    _centerHandle.getRoot().setRotation(_calcQuat);
+  }
+
+  @Override
+  public void processInput(final Canvas source, final TwoInputStates inputStates, final AtomicBoolean inputConsumed,
+      final InteractManager manager) {
+
+    final Camera camera = source.getCanvasRenderer().getCamera();
+    final MouseState current = inputStates.getCurrent().getMouseState();
+    final MouseState previous = inputStates.getPrevious().getMouseState();
+
+    // first process mouse over state
+    checkMouseOver(source, current, manager);
+
+    // Now check drag status
+    if (!checkShouldDrag(camera, current, previous, inputConsumed, manager)) {
+      return;
+    }
+
+    // act on drag
+    final GizmoHandle handle = findGizmoHandle(_lastDragSpatial);
+    if (handle == null) {
+      return;
+    }
+
+    final Vector2 oldMouse = new Vector2(previous.getX(), previous.getY());
+    final Vector3 offset = getNewOffset(handle, oldMouse, current, camera, manager);
+    final Transform transform = manager.getSpatialState().getTransform();
+    transform.setTranslation(offset.addLocal(transform.getTranslation()));
+
+    // apply our filters, if any, now that we've made updates.
+    applyFilters(manager);
+  }
+
+  /**
+   * Work out the translation delta, in the target's parent coordinate space, described by the
+   * mouse moving from oldMouse to the current position while dragging the given handle.
+   */
+  protected Vector3 getNewOffset(final GizmoHandle handle, final Vector2 oldMouse, final MouseState current,
+      final Camera camera, final InteractManager manager) {
+
+    final ReadOnlyVector3 origin = _handle.getWorldTranslation();
+
+    // Establish the plane we drag against and, for single-axis handles, the axis to constrain to.
+    Vector3 dragAxis = null;
+    final Vector3 normal = _calcVec3C;
+    switch (handle.getPart()) {
+      case AxisX, AxisY, AxisZ -> {
+        dragAxis = _handle.getRotation().applyPost(handle.getAxis(), _calcVec3D).normalizeLocal();
+        // The plane through the axis that most directly faces the camera: its normal is the
+        // component of the view direction perpendicular to the axis.
+        normal.set(camera.getDirection())
+            .subtractLocal(dragAxis.multiply(camera.getDirection().dot(dragAxis), _calcVec3A));
+        if (normal.lengthSquared() < 1e-10) {
+          // Axis is aligned with the view direction; the drag is ill-conditioned (and the handle
+          // is faded out). Ignore.
+          return _calcVec3A.zero();
+        }
+        normal.normalizeLocal();
+      }
+      case PlaneXY, PlaneXZ, PlaneYZ -> _handle.getRotation().applyPost(handle.getAxis(), normal).normalizeLocal();
+      case Center -> normal.set(camera.getDirection());
+      default -> {
+        return _calcVec3A.zero();
+      }
+    }
+    final Plane pickPlane = new Plane(normal, normal.dot(origin));
+
+    // find out where we were hitting the plane before
+    getPickRay(oldMouse, camera);
+    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3A)) {
+      return _calcVec3A.zero();
+    }
+
+    // find out where we are hitting the plane now
+    getPickRay(new Vector2(current.getX(), current.getY()), camera);
+    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3B)) {
+      return _calcVec3A.zero();
+    }
+
+    if (dragAxis != null) {
+      // Constrain to the axis: replace the two hits with their projections onto the axis line.
+      final double oldT = _calcVec3A.subtractLocal(origin).dot(dragAxis);
+      final double newT = _calcVec3B.subtractLocal(origin).dot(dragAxis);
+      _calcVec3A.set(dragAxis).multiplyLocal(oldT).addLocal(origin);
+      _calcVec3B.set(dragAxis).multiplyLocal(newT).addLocal(origin);
+    }
+
+    // convert to target coord space
+    final Node parent = manager.getSpatialTarget().getParent();
+    if (parent != null) {
+      parent.getWorldTransform().applyInverse(_calcVec3A);
+      parent.getWorldTransform().applyInverse(_calcVec3B);
+    }
+
+    return _calcVec3B.subtractLocal(_calcVec3A);
+  }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
@@ -220,49 +220,39 @@ public class TranslateGizmo extends AbstractGizmo {
 
     final ReadOnlyVector3 origin = _handle.getWorldTranslation();
 
-    // Establish the plane we drag against and, for single-axis handles, the axis to constrain to.
-    Vector3 dragAxis = null;
-    final Vector3 normal = _calcVec3C;
     switch (handle.getPart()) {
       case AxisX, AxisY, AxisZ -> {
-        dragAxis = _handle.getRotation().applyPost(handle.getAxis(), _calcVec3D).normalizeLocal();
-        // The plane through the axis that most directly faces the camera: its normal is the
-        // component of the view direction perpendicular to the axis.
-        normal.set(camera.getDirection())
-            .subtractLocal(dragAxis.multiply(camera.getDirection().dot(dragAxis), _calcVec3A));
-        if (normal.lengthSquared() < 1e-10) {
-          // Axis is aligned with the view direction; the drag is ill-conditioned (and the handle
-          // is faded out). Ignore.
+        // Constrain to the axis: project the two mouse hits onto the axis line.
+        final Vector3 dragAxis = _handle.getRotation().applyPost(handle.getAxis(), _calcVec3D).normalizeLocal();
+        final Vector2 axisT = new Vector2();
+        if (!projectOnAxis(dragAxis, oldMouse, new Vector2(current.getX(), current.getY()), camera, axisT)) {
           return _calcVec3A.zero();
         }
-        normal.normalizeLocal();
+        _calcVec3A.set(dragAxis).multiplyLocal(axisT.getX()).addLocal(origin);
+        _calcVec3B.set(dragAxis).multiplyLocal(axisT.getY()).addLocal(origin);
       }
-      case PlaneXY, PlaneXZ, PlaneYZ -> _handle.getRotation().applyPost(handle.getAxis(), normal).normalizeLocal();
-      case Center -> normal.set(camera.getDirection());
+      case PlaneXY, PlaneXZ, PlaneYZ, Center -> {
+        // Free drag against a plane through the gizmo origin.
+        final Vector3 normal = _calcVec3C;
+        if (handle.getPart() == GizmoPart.Center) {
+          normal.set(camera.getDirection());
+        } else {
+          _handle.getRotation().applyPost(handle.getAxis(), normal).normalizeLocal();
+        }
+        final Plane pickPlane = new Plane(normal, normal.dot(origin));
+
+        getPickRay(oldMouse, camera);
+        if (!_calcRay.intersectsPlane(pickPlane, _calcVec3A)) {
+          return _calcVec3A.zero();
+        }
+        getPickRay(new Vector2(current.getX(), current.getY()), camera);
+        if (!_calcRay.intersectsPlane(pickPlane, _calcVec3B)) {
+          return _calcVec3A.zero();
+        }
+      }
       default -> {
         return _calcVec3A.zero();
       }
-    }
-    final Plane pickPlane = new Plane(normal, normal.dot(origin));
-
-    // find out where we were hitting the plane before
-    getPickRay(oldMouse, camera);
-    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3A)) {
-      return _calcVec3A.zero();
-    }
-
-    // find out where we are hitting the plane now
-    getPickRay(new Vector2(current.getX(), current.getY()), camera);
-    if (!_calcRay.intersectsPlane(pickPlane, _calcVec3B)) {
-      return _calcVec3A.zero();
-    }
-
-    if (dragAxis != null) {
-      // Constrain to the axis: replace the two hits with their projections onto the axis line.
-      final double oldT = _calcVec3A.subtractLocal(origin).dot(dragAxis);
-      final double newT = _calcVec3B.subtractLocal(origin).dot(dragAxis);
-      _calcVec3A.set(dragAxis).multiplyLocal(oldT).addLocal(origin);
-      _calcVec3B.set(dragAxis).multiplyLocal(newT).addLocal(origin);
     }
 
     // convert to target coord space

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
@@ -20,7 +20,6 @@ import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.light.LightProperties;
 import com.ardor3d.math.ColorRGBA;
 import com.ardor3d.math.Matrix3;
-import com.ardor3d.math.Plane;
 import com.ardor3d.math.Quaternion;
 import com.ardor3d.math.Transform;
 import com.ardor3d.math.Vector2;
@@ -202,8 +201,8 @@ public class TranslateGizmo extends AbstractGizmo {
       return;
     }
 
-    final Vector2 oldMouse = new Vector2(previous.getX(), previous.getY());
-    final Vector3 offset = getNewOffset(handle, oldMouse, current, camera, manager);
+    _calcVec2A.set(previous.getX(), previous.getY());
+    final Vector3 offset = getNewOffset(handle, _calcVec2A, current, camera, manager);
     final Transform transform = manager.getSpatialState().getTransform();
     transform.setTranslation(offset.addLocal(transform.getTranslation()));
 
@@ -224,12 +223,12 @@ public class TranslateGizmo extends AbstractGizmo {
       case AxisX, AxisY, AxisZ -> {
         // Constrain to the axis: project the two mouse hits onto the axis line.
         final Vector3 dragAxis = _handle.getRotation().applyPost(handle.getAxis(), _calcVec3D).normalizeLocal();
-        final Vector2 axisT = new Vector2();
-        if (!projectOnAxis(dragAxis, oldMouse, new Vector2(current.getX(), current.getY()), camera, axisT)) {
+        _calcVec2B.set(current.getX(), current.getY());
+        if (!projectOnAxis(dragAxis, oldMouse, _calcVec2B, camera, _calcVec2C)) {
           return _calcVec3A.zero();
         }
-        _calcVec3A.set(dragAxis).multiplyLocal(axisT.getX()).addLocal(origin);
-        _calcVec3B.set(dragAxis).multiplyLocal(axisT.getY()).addLocal(origin);
+        _calcVec3A.set(dragAxis).multiplyLocal(_calcVec2C.getX()).addLocal(origin);
+        _calcVec3B.set(dragAxis).multiplyLocal(_calcVec2C.getY()).addLocal(origin);
       }
       case PlaneXY, PlaneXZ, PlaneYZ, Center -> {
         // Free drag against a plane through the gizmo origin.
@@ -239,14 +238,15 @@ public class TranslateGizmo extends AbstractGizmo {
         } else {
           _handle.getRotation().applyPost(handle.getAxis(), normal).normalizeLocal();
         }
-        final Plane pickPlane = new Plane(normal, normal.dot(origin));
+        _calcPlane.setNormal(normal);
+        _calcPlane.setConstant(normal.dot(origin));
 
         getPickRay(oldMouse, camera);
-        if (!_calcRay.intersectsPlane(pickPlane, _calcVec3A)) {
+        if (!_calcRay.intersectsPlane(_calcPlane, _calcVec3A)) {
           return _calcVec3A.zero();
         }
-        getPickRay(new Vector2(current.getX(), current.getY()), camera);
-        if (!_calcRay.intersectsPlane(pickPlane, _calcVec3B)) {
+        getPickRay(_calcVec2B.set(current.getX(), current.getY()), camera);
+        if (!_calcRay.intersectsPlane(_calcPlane, _calcVec3B)) {
           return _calcVec3A.zero();
         }
       }

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
@@ -195,6 +195,18 @@ public class SnapFilterTest {
   }
 
   @Test
+  public void testAngleSnapDisabled() {
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    filter.setEnabled(false);
+    filter.beginDrag(_manager, _widget, null);
+
+    final Matrix3 rot = new Matrix3().fromAngleNormalAxis(20 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z);
+    _manager.getSpatialState().getTransform().setRotation(rot);
+    filter.applyFilter(_manager, _widget);
+    assertMatrixEquals(rot, _manager.getSpatialState().getTransform().getMatrix());
+  }
+
+  @Test
   public void testAngleSnapWithoutDragIsANoOp() {
     final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
     // no beginDrag

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
@@ -63,20 +63,65 @@ public class SnapFilterTest {
   // --- GridSnapFilter ---
 
   @Test
-  public void testGridSnapRoundsTranslation() {
+  public void testGridSnapRoundsDragOffset() {
     final GridSnapFilter filter = new GridSnapFilter(0.5);
+    filter.beginDrag(_manager, _widget, null);
     _manager.getSpatialState().getTransform().setTranslation(1.2, 0.26, -0.9);
     filter.applyFilter(_manager, _widget);
     assertVectorEquals(1.0, 0.5, -1.0, _manager.getSpatialState().getTransform().getTranslation());
   }
 
   @Test
+  public void testGridSnapStepsFromDragStart() {
+    // Snapping is relative to where the drag began, so off-grid targets move in whole steps
+    // rather than jumping onto the absolute grid.
+    _target.setTranslation(0.3, 0, 0);
+    _target.updateGeometricState(0);
+    _manager.getSpatialState().copyState(_target);
+
+    final GridSnapFilter filter = new GridSnapFilter(1.0);
+    filter.beginDrag(_manager, _widget, null);
+    _manager.getSpatialState().getTransform().setTranslation(1.0, 0, 0);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.3, 0.0, 0.0, _manager.getSpatialState().getTransform().getTranslation());
+  }
+
+  @Test
   public void testGridSnapDisabled() {
     final GridSnapFilter filter = new GridSnapFilter(0.5);
     filter.setEnabled(false);
+    filter.beginDrag(_manager, _widget, null);
     _manager.getSpatialState().getTransform().setTranslation(1.2, 0.26, -0.9);
     filter.applyFilter(_manager, _widget);
     assertVectorEquals(1.2, 0.26, -0.9, _manager.getSpatialState().getTransform().getTranslation());
+  }
+
+  @Test
+  public void testGridSnapWithoutDragIsANoOp() {
+    final GridSnapFilter filter = new GridSnapFilter(0.5);
+    // no beginDrag
+    _manager.getSpatialState().getTransform().setTranslation(1.2, 0.26, -0.9);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.2, 0.26, -0.9, _manager.getSpatialState().getTransform().getTranslation());
+  }
+
+  @Test
+  public void testGridSnapAccumulatesAcrossInputCycles() {
+    final GridSnapFilter filter = new GridSnapFilter(1.0);
+    filter.beginDrag(_manager, _widget, null);
+
+    // The manager copies the state from the target before every input event, so each event's
+    // widget delta (0.2 units here) is far below the grid size. Ten of them must accumulate to
+    // 2 units - not round away to nothing cycle after cycle.
+    for (int i = 0; i < 10; i++) {
+      _manager.getSpatialState().copyState(_target);
+      _manager.getSpatialState().getTransform().setTranslation(
+          _manager.getSpatialState().getTransform().getTranslation().add(0.2, 0, 0, new Vector3()));
+      filter.applyFilter(_manager, _widget);
+      _manager.getSpatialState().applyState(_target);
+    }
+
+    assertVectorEquals(2.0, 0.0, 0.0, _target.getTranslation());
   }
 
   // --- AngleSnapFilter ---
@@ -93,6 +138,26 @@ public class SnapFilterTest {
 
     assertMatrixEquals(new Matrix3().fromAngleNormalAxis(15 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z),
         _manager.getSpatialState().getTransform().getMatrix());
+  }
+
+  @Test
+  public void testAngleSnapAccumulatesAcrossInputCycles() {
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    filter.beginDrag(_manager, _widget, null);
+
+    // Per-event deltas of 2 degrees are far below the 7.5 degree rounding threshold; a slow
+    // 20 degree drag must still snap the target to 15 degrees, not stay pinned at the start.
+    final Matrix3 eventDelta = new Matrix3().fromAngleNormalAxis(2 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z);
+    for (int i = 0; i < 10; i++) {
+      _manager.getSpatialState().copyState(_target);
+      _manager.getSpatialState().getTransform()
+          .setRotation(eventDelta.multiply(_manager.getSpatialState().getTransform().getMatrix(), new Matrix3()));
+      filter.applyFilter(_manager, _widget);
+      _manager.getSpatialState().applyState(_target);
+    }
+
+    assertMatrixEquals(new Matrix3().fromAngleNormalAxis(15 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z),
+        _target.getRotation());
   }
 
   @Test

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo;
+import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyMatrix3;
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.scenegraph.Node;
+
+public class SnapFilterTest {
+
+  private static final double EPS = 1e-9;
+
+  private Node _target;
+  private InteractManager _manager;
+  private RotateGizmo _widget;
+
+  @Before
+  public void setup() {
+    _target = new Node("target");
+    _target.updateGeometricState(0);
+
+    _manager = new InteractManager();
+    _widget = new RotateGizmo();
+    _manager.addWidget(_widget);
+    _manager.setSpatialTarget(_target);
+    // mirror the manager's input cycle: state starts from the target's transform
+    _manager.getSpatialState().copyState(_target);
+  }
+
+  private static void assertVectorEquals(final double x, final double y, final double z, final ReadOnlyVector3 v) {
+    assertEquals(x, v.getX(), EPS);
+    assertEquals(y, v.getY(), EPS);
+    assertEquals(z, v.getZ(), EPS);
+  }
+
+  private static void assertMatrixEquals(final ReadOnlyMatrix3 expected, final ReadOnlyMatrix3 actual) {
+    for (int r = 0; r < 3; r++) {
+      for (int c = 0; c < 3; c++) {
+        assertEquals("[" + r + "," + c + "]", expected.getValue(r, c), actual.getValue(r, c), 1e-9);
+      }
+    }
+  }
+
+  // --- GridSnapFilter ---
+
+  @Test
+  public void testGridSnapRoundsTranslation() {
+    final GridSnapFilter filter = new GridSnapFilter(0.5);
+    _manager.getSpatialState().getTransform().setTranslation(1.2, 0.26, -0.9);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.0, 0.5, -1.0, _manager.getSpatialState().getTransform().getTranslation());
+  }
+
+  @Test
+  public void testGridSnapDisabled() {
+    final GridSnapFilter filter = new GridSnapFilter(0.5);
+    filter.setEnabled(false);
+    _manager.getSpatialState().getTransform().setTranslation(1.2, 0.26, -0.9);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.2, 0.26, -0.9, _manager.getSpatialState().getTransform().getTranslation());
+  }
+
+  // --- AngleSnapFilter ---
+
+  @Test
+  public void testAngleSnapQuantizesDragDelta() {
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    filter.beginDrag(_manager, _widget, null);
+
+    // Drag has rotated the state 20 degrees about Z: snaps to 15.
+    _manager.getSpatialState().getTransform()
+        .setRotation(new Matrix3().fromAngleNormalAxis(20 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z));
+    filter.applyFilter(_manager, _widget);
+
+    assertMatrixEquals(new Matrix3().fromAngleNormalAxis(15 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z),
+        _manager.getSpatialState().getTransform().getMatrix());
+  }
+
+  @Test
+  public void testAngleSnapSmallDeltaSnapsBackToStart() {
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    filter.beginDrag(_manager, _widget, null);
+
+    _manager.getSpatialState().getTransform()
+        .setRotation(new Matrix3().fromAngleNormalAxis(7 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z));
+    filter.applyFilter(_manager, _widget);
+
+    assertMatrixEquals(Matrix3.IDENTITY, _manager.getSpatialState().getTransform().getMatrix());
+  }
+
+  @Test
+  public void testAngleSnapComposesWithStartRotation() {
+    // Start the target at 30 degrees about X.
+    final Matrix3 start = new Matrix3().fromAngleNormalAxis(30 * MathUtils.DEG_TO_RAD, Vector3.UNIT_X);
+    _target.setRotation(start);
+    _target.updateGeometricState(0);
+    _manager.getSpatialState().copyState(_target);
+
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    filter.beginDrag(_manager, _widget, null);
+
+    // Drag applies a further 20 degrees about Z (pre-multiplied, like the rotate widgets do).
+    final Matrix3 drag = new Matrix3().fromAngleNormalAxis(20 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z);
+    _manager.getSpatialState().getTransform().setRotation(drag.multiply(start, new Matrix3()));
+    filter.applyFilter(_manager, _widget);
+
+    // Expect the drag portion snapped to 15 degrees, still on top of the start rotation.
+    final Matrix3 expected =
+        new Matrix3().fromAngleNormalAxis(15 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z).multiply(start, new Matrix3());
+    assertMatrixEquals(expected, _manager.getSpatialState().getTransform().getMatrix());
+  }
+
+  @Test
+  public void testAngleSnapWithoutDragIsANoOp() {
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    // no beginDrag
+    final Matrix3 rot = new Matrix3().fromAngleNormalAxis(20 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z);
+    _manager.getSpatialState().getTransform().setRotation(rot);
+    filter.applyFilter(_manager, _widget);
+    assertMatrixEquals(rot, _manager.getSpatialState().getTransform().getMatrix());
+  }
+
+  @Test
+  public void testAngleSnapEndDragClearsCapture() {
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    filter.beginDrag(_manager, _widget, null);
+    filter.endDrag(_manager, _widget, null);
+
+    final Matrix3 rot = new Matrix3().fromAngleNormalAxis(20 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Z);
+    _manager.getSpatialState().getTransform().setRotation(rot);
+    filter.applyFilter(_manager, _widget);
+    assertMatrixEquals(rot, _manager.getSpatialState().getTransform().getMatrix());
+  }
+
+  @Test
+  public void testAngleSnapExactIncrementUnchanged() {
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    filter.beginDrag(_manager, _widget, null);
+
+    final Matrix3 rot = new Matrix3().fromAngleNormalAxis(45 * MathUtils.DEG_TO_RAD, Vector3.UNIT_Y);
+    _manager.getSpatialState().getTransform().setRotation(rot);
+    filter.applyFilter(_manager, _widget);
+    assertMatrixEquals(rot, _manager.getSpatialState().getTransform().getMatrix());
+
+    assertTrue(filter.isEnabled());
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMathTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMathTest.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.Camera.ProjectionMode;
+
+public class GizmoMathTest {
+
+  private static final double EPS = 1e-9;
+
+  // --- worldSizeForPixels (perspective) ---
+
+  @Test
+  public void testWorldSizeForPixelsKnownValue() {
+    // 60 degree vertical fov, near=1 -> frustumTop = tan(30 deg). At depth 10 the frustum is
+    // 2 * 10 * tan(30) = 11.547 world units tall. 90px of a 900px viewport is a tenth of that.
+    final double top = Math.tan(30 * MathUtils.DEG_TO_RAD);
+    final double size = GizmoMath.worldSizeForPixels(90, 10, top, 1, 900);
+    assertEquals(90.0 / 900.0 * 2.0 * 10.0 * top, size, EPS);
+    assertEquals(1.1547005383792515, size, 1e-12);
+  }
+
+  @Test
+  public void testWorldSizeForPixelsScalesLinearlyWithDepth() {
+    final double top = Math.tan(30 * MathUtils.DEG_TO_RAD);
+    final double near = GizmoMath.worldSizeForPixels(90, 5, top, 1, 900);
+    final double far = GizmoMath.worldSizeForPixels(90, 50, top, 1, 900);
+    assertEquals(10.0, far / near, EPS);
+  }
+
+  @Test
+  public void testWorldSizeForPixelsInverseWithViewportHeight() {
+    // Same fov on a taller viewport means more pixels per world unit, so a smaller world size.
+    final double top = Math.tan(30 * MathUtils.DEG_TO_RAD);
+    final double at900 = GizmoMath.worldSizeForPixels(90, 10, top, 1, 900);
+    final double at1800 = GizmoMath.worldSizeForPixels(90, 10, top, 1, 1800);
+    assertEquals(at900 / 2.0, at1800, EPS);
+  }
+
+  @Test
+  public void testWorldSizeForPixelsNearPlaneIndependence() {
+    // frustumTop and frustumNear encode the same fov when scaled together; result must not change.
+    final double top = Math.tan(30 * MathUtils.DEG_TO_RAD);
+    final double nearOne = GizmoMath.worldSizeForPixels(90, 10, top, 1, 900);
+    final double nearTen = GizmoMath.worldSizeForPixels(90, 10, 10 * top, 10, 900);
+    assertEquals(nearOne, nearTen, EPS);
+  }
+
+  // --- worldSizeForPixelsOrtho ---
+
+  @Test
+  public void testWorldSizeForPixelsOrtho() {
+    // 40 world units of frustum height over 800 pixels = 0.05 units per pixel.
+    assertEquals(90 * 0.05, GizmoMath.worldSizeForPixelsOrtho(90, 20, -20, 800), EPS);
+  }
+
+  // --- calculateFixedScreenScale ---
+
+  @Test
+  public void testFixedScreenScalePerspective() {
+    final Camera cam = new Camera(1200, 900);
+    cam.setFrustumPerspective(60, 1200.0 / 900.0, 1, 1000);
+    cam.setLocation(0, 0, 10);
+    cam.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+
+    final double scale = GizmoMath.calculateFixedScreenScale(cam, Vector3.ZERO, 90);
+    assertEquals(1.1547005383792515, scale, 1e-9);
+  }
+
+  @Test
+  public void testFixedScreenScaleUsesViewDepthNotDistance() {
+    final Camera cam = new Camera(1200, 900);
+    cam.setFrustumPerspective(60, 1200.0 / 900.0, 1, 1000);
+    cam.setLocation(0, 0, 10);
+    cam.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+
+    // A point off to the side at the same view depth (z=0 plane) must get the same scale,
+    // even though its euclidean distance from the camera is larger.
+    final double centered = GizmoMath.calculateFixedScreenScale(cam, Vector3.ZERO, 90);
+    final double offside = GizmoMath.calculateFixedScreenScale(cam, new Vector3(7, 3, 0), 90);
+    assertEquals(centered, offside, EPS);
+  }
+
+  @Test
+  public void testFixedScreenScaleClampsBehindCamera() {
+    final Camera cam = new Camera(1200, 900);
+    cam.setFrustumPerspective(60, 1200.0 / 900.0, 1, 1000);
+    cam.setLocation(0, 0, 10);
+    cam.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+
+    // Behind the camera: clamped to the near plane, still a small positive scale.
+    final double scale = GizmoMath.calculateFixedScreenScale(cam, new Vector3(0, 0, 50), 90);
+    assertTrue("expected positive scale, got " + scale, scale > 0);
+    assertEquals(GizmoMath.worldSizeForPixels(90, cam.getFrustumNear(), cam.getFrustumTop(), cam.getFrustumNear(),
+        cam.getHeight()), scale, EPS);
+  }
+
+  @Test
+  public void testFixedScreenScaleOrthographic() {
+    final Camera cam = new Camera(800, 800);
+    cam.setProjectionMode(ProjectionMode.Orthographic);
+    cam.setFrustum(1, 1000, -20, 20, 20, -20);
+    cam.setLocation(0, 0, 10);
+    cam.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+
+    // Ortho ignores depth entirely.
+    final double near = GizmoMath.calculateFixedScreenScale(cam, Vector3.ZERO, 90);
+    final double far = GizmoMath.calculateFixedScreenScale(cam, new Vector3(0, 0, -500), 90);
+    assertEquals(near, far, EPS);
+    assertEquals(90 * 40.0 / 800.0, near, EPS);
+  }
+
+  // --- axisViewAngle / planeViewAngle ---
+
+  @Test
+  public void testAxisViewAngle() {
+    // Perpendicular to the view: fully well-conditioned.
+    assertEquals(MathUtils.HALF_PI, GizmoMath.axisViewAngle(Vector3.UNIT_X, Vector3.NEG_UNIT_Z), EPS);
+    // Pointing straight along the view: degenerate, folded the same both ways.
+    assertEquals(0.0, GizmoMath.axisViewAngle(Vector3.UNIT_Z, Vector3.NEG_UNIT_Z), EPS);
+    assertEquals(0.0, GizmoMath.axisViewAngle(Vector3.NEG_UNIT_Z, Vector3.NEG_UNIT_Z), EPS);
+    // 45 degrees.
+    final Vector3 diag = new Vector3(1, 0, 1).normalizeLocal();
+    assertEquals(MathUtils.QUARTER_PI, GizmoMath.axisViewAngle(diag, Vector3.NEG_UNIT_Z), EPS);
+  }
+
+  @Test
+  public void testPlaneViewAngle() {
+    // Plane faces the camera (normal along view): fully visible.
+    assertEquals(MathUtils.HALF_PI, GizmoMath.planeViewAngle(Vector3.UNIT_Z, Vector3.NEG_UNIT_Z), EPS);
+    // Plane edge-on to the camera (normal perpendicular to view): degenerate.
+    assertEquals(0.0, GizmoMath.planeViewAngle(Vector3.UNIT_X, Vector3.NEG_UNIT_Z), EPS);
+    // 45 degrees.
+    final Vector3 diag = new Vector3(1, 0, 1).normalizeLocal();
+    assertEquals(MathUtils.QUARTER_PI, GizmoMath.planeViewAngle(diag, Vector3.NEG_UNIT_Z), EPS);
+  }
+
+  @Test
+  public void testViewAnglesTolerateUnnormalizedRoundoff() {
+    // dot may drift a hair over 1.0 for normalized inputs; acos/asin must not return NaN.
+    final Vector3 axis = new Vector3(1 + 1e-12, 0, 0);
+    final double angle = GizmoMath.axisViewAngle(axis, Vector3.UNIT_X);
+    assertEquals(0.0, angle, EPS);
+    final double plane = GizmoMath.planeViewAngle(axis, Vector3.UNIT_X);
+    assertEquals(MathUtils.HALF_PI, plane, EPS);
+  }
+
+  // --- fadeAlpha ---
+
+  @Test
+  public void testFadeAlpha() {
+    final double hide = 10 * MathUtils.DEG_TO_RAD;
+    final double full = 20 * MathUtils.DEG_TO_RAD;
+
+    assertEquals(0.0, GizmoMath.fadeAlpha(0, hide, full), EPS);
+    assertEquals(0.0, GizmoMath.fadeAlpha(hide, hide, full), EPS);
+    assertEquals(0.5, GizmoMath.fadeAlpha(15 * MathUtils.DEG_TO_RAD, hide, full), EPS);
+    assertEquals(1.0, GizmoMath.fadeAlpha(full, hide, full), EPS);
+    assertEquals(1.0, GizmoMath.fadeAlpha(MathUtils.HALF_PI, hide, full), EPS);
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMathTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMathTest.java
@@ -161,6 +161,25 @@ public class GizmoMathTest {
     assertEquals(MathUtils.HALF_PI, plane, EPS);
   }
 
+  // --- signedAngle ---
+
+  @Test
+  public void testSignedAngle() {
+    // Counter-clockwise about +Z (right-hand rule): X to Y is +90 degrees.
+    assertEquals(MathUtils.HALF_PI, GizmoMath.signedAngle(Vector3.UNIT_X, Vector3.UNIT_Y, Vector3.UNIT_Z), EPS);
+    // ...and clockwise is negative.
+    assertEquals(-MathUtils.HALF_PI, GizmoMath.signedAngle(Vector3.UNIT_Y, Vector3.UNIT_X, Vector3.UNIT_Z), EPS);
+    // Flipping the axis flips the sign.
+    assertEquals(-MathUtils.HALF_PI, GizmoMath.signedAngle(Vector3.UNIT_X, Vector3.UNIT_Y, Vector3.NEG_UNIT_Z), EPS);
+    // Identity and half-turn.
+    assertEquals(0.0, GizmoMath.signedAngle(Vector3.UNIT_X, Vector3.UNIT_X, Vector3.UNIT_Z), EPS);
+    assertEquals(MathUtils.PI, Math.abs(GizmoMath.signedAngle(Vector3.UNIT_X, Vector3.NEG_UNIT_X, Vector3.UNIT_Z)),
+        EPS);
+    // 45 degrees.
+    final Vector3 diag = new Vector3(1, 1, 0).normalizeLocal();
+    assertEquals(MathUtils.QUARTER_PI, GizmoMath.signedAngle(Vector3.UNIT_X, diag, Vector3.UNIT_Z), EPS);
+  }
+
   // --- fadeAlpha ---
 
   @Test

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmoDragTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmoDragTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Vector2;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.scenegraph.Node;
+
+/**
+ * Headless geometric tests of ScaleGizmo's drag math, using the same synthetic camera as
+ * TranslateGizmoDragTest: 90 degree fov, square 100px viewport, distance 10 - so mouse x=60 maps
+ * to 2 world units from center on a plane through the origin, x=70 to 4, and so on.
+ */
+public class ScaleGizmoDragTest {
+
+  private static final double EPS = 1e-9;
+
+  private Node _target;
+  private InteractManager _manager;
+  private TestGizmo _gizmo;
+  private Camera _camera;
+
+  /** Exposes the protected drag math for testing. */
+  private static class TestGizmo extends ScaleGizmo {
+    double factor(final GizmoHandle handle, final Vector2 oldMouse, final MouseState current, final Camera camera) {
+      return getScaleFactor(handle, oldMouse, current, camera);
+    }
+  }
+
+  @Before
+  public void setup() {
+    _target = new Node("target");
+    _target.updateGeometricState(0);
+
+    _manager = new InteractManager();
+    _gizmo = new TestGizmo();
+    _gizmo.withAllHandles();
+    _manager.addWidget(_gizmo);
+    _manager.setSpatialTarget(_target);
+
+    _camera = new Camera(100, 100);
+    _camera.setFrustumPerspective(90, 1, 1, 1000);
+    _camera.setLocation(0, 0, 10);
+    _camera.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+
+    _gizmo.getHandle().setTranslation(_target.getWorldTranslation());
+    _gizmo.getHandle().updateGeometricState(0);
+  }
+
+  private GizmoHandle handle(final GizmoPart part) {
+    for (final GizmoHandle handle : _gizmo.getGizmoHandles()) {
+      if (handle.getPart() == part) {
+        return handle;
+      }
+    }
+    return null;
+  }
+
+  private double drag(final GizmoPart part, final int fromX, final int fromY, final int toX, final int toY) {
+    final GizmoHandle handle = handle(part);
+    assertNotNull("gizmo should have a handle for " + part, handle);
+    final MouseState current = new MouseState(toX, toY, toX - fromX, toY - fromY, 0, null, null);
+    return _gizmo.factor(handle, new Vector2(fromX, fromY), current, _camera);
+  }
+
+  @Test
+  public void testAxisScaleIsDistanceRatio() {
+    // Grab at 2 world units from center, pull to 4: double.
+    assertEquals(2.0, drag(GizmoPart.AxisX, 60, 50, 70, 50), EPS);
+    // ...and push back in to 1 world unit: quarter.
+    assertEquals(0.25, drag(GizmoPart.AxisX, 70, 50, 55, 50), EPS);
+  }
+
+  @Test
+  public void testAxisScaleIgnoresOffAxisMovement() {
+    // Vertical mouse movement is perpendicular to the X axis here; only the X component counts.
+    assertEquals(1.0, drag(GizmoPart.AxisX, 60, 50, 60, 70), EPS);
+  }
+
+  @Test
+  public void testAxisScaleClampsAtCenterCrossing() {
+    // Dragging across the gizmo center would flip the sign; the per-event factor is clamped
+    // to a small positive value instead of mirroring or exploding.
+    assertEquals(ScaleGizmo.MIN_EVENT_FACTOR, drag(GizmoPart.AxisX, 60, 50, 40, 50), EPS);
+  }
+
+  @Test
+  public void testAxisAlignedWithViewIsRejected() {
+    // The Z axis points straight at this camera; the drag must be a no-op.
+    assertEquals(1.0, drag(GizmoPart.AxisZ, 60, 50, 70, 50), EPS);
+  }
+
+  @Test
+  public void testUniformScaleFollowsMouseDelta() {
+    // 20px right at UNIFORM_SCALE_RATE 0.005 -> 1.1; up adds the same way, down-left shrinks.
+    assertEquals(1.1, drag(GizmoPart.Center, 50, 50, 70, 50), EPS);
+    assertEquals(1.1, drag(GizmoPart.Center, 50, 50, 50, 70), EPS);
+    assertEquals(0.9, drag(GizmoPart.Center, 50, 50, 40, 40), EPS);
+  }
+
+  @Test
+  public void testAxisScaleTracksLocalFrame() {
+    // Rotate the target 90 degrees about Z: its local X axis is world +Y. The X handle must
+    // project against world Y - the same 2:1 pull, made vertically, still doubles.
+    _target.setRotation(new Matrix3().fromAngleNormalAxis(MathUtils.HALF_PI, Vector3.UNIT_Z));
+    _target.updateGeometricState(0);
+    _gizmo.targetDataUpdated(_manager);
+    _gizmo.getHandle().updateGeometricState(0);
+
+    assertEquals(2.0, drag(GizmoPart.AxisX, 50, 60, 50, 70), EPS);
+    // ...and horizontal movement no longer affects it.
+    assertEquals(1.0, drag(GizmoPart.AxisX, 50, 60, 70, 60), EPS);
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmoDragTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmoDragTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.InteractMatrix;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.math.Matrix3;
+import com.ardor3d.math.Vector2;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.scenegraph.Node;
+
+/**
+ * Headless geometric tests of TranslateGizmo's drag math: synthetic camera, hand-computed pick
+ * rays, no GL. The camera uses a 90 degree fov on a square 100px viewport at distance 10, so a
+ * 10px mouse move through the view center maps to exactly 2 world units on a plane through the
+ * origin.
+ */
+public class TranslateGizmoDragTest {
+
+  private static final double EPS = 1e-9;
+
+  private Node _parent;
+  private Node _target;
+  private InteractManager _manager;
+  private TestGizmo _gizmo;
+  private Camera _camera;
+
+  /** Exposes the protected drag math for testing. */
+  private static class TestGizmo extends TranslateGizmo {
+    Vector3 offset(final GizmoHandle handle, final Vector2 oldMouse, final MouseState current, final Camera camera,
+        final InteractManager manager) {
+      return getNewOffset(handle, oldMouse, current, camera, manager);
+    }
+  }
+
+  @Before
+  public void setup() {
+    _parent = new Node("parent");
+    _target = new Node("target");
+    _parent.attachChild(_target);
+    _parent.updateGeometricState(0);
+
+    _manager = new InteractManager();
+    _gizmo = new TestGizmo();
+    _gizmo.withAllHandles();
+    _manager.addWidget(_gizmo);
+    _manager.setSpatialTarget(_target);
+
+    _camera = new Camera(100, 100);
+    _camera.setFrustumPerspective(90, 1, 1, 1000);
+    _camera.setLocation(0, 0, 10);
+    _camera.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+
+    syncHandleToTarget();
+  }
+
+  /** Mirror what AbstractGizmo.render does before drag math runs: position the handle node. */
+  private void syncHandleToTarget() {
+    _gizmo.getHandle().setTranslation(_target.getWorldTranslation());
+    _gizmo.getHandle().updateGeometricState(0);
+  }
+
+  private GizmoHandle handle(final GizmoPart part) {
+    for (final GizmoHandle handle : _gizmo.getGizmoHandles()) {
+      if (handle.getPart() == part) {
+        return handle;
+      }
+    }
+    return null;
+  }
+
+  private Vector3 drag(final GizmoPart part, final int fromX, final int fromY, final int toX, final int toY) {
+    final GizmoHandle handle = handle(part);
+    assertNotNull("gizmo should have a handle for " + part, handle);
+    final MouseState current = new MouseState(toX, toY, toX - fromX, toY - fromY, 0, null, null);
+    return _gizmo.offset(handle, new Vector2(fromX, fromY), current, _camera, _manager);
+  }
+
+  @Test
+  public void testAxisDragMapsPixelsToWorldUnits() {
+    // 10px right from view center -> ndc 0.2 -> 0.2 * depth 10 = 2 world units along +X.
+    final Vector3 offset = drag(GizmoPart.AxisX, 50, 50, 60, 50);
+    assertEquals(2.0, offset.getX(), EPS);
+    assertEquals(0.0, offset.getY(), EPS);
+    assertEquals(0.0, offset.getZ(), EPS);
+  }
+
+  @Test
+  public void testAxisDragConstrainsToAxis() {
+    // A diagonal mouse move only translates by its component along the dragged axis.
+    final Vector3 offset = drag(GizmoPart.AxisX, 50, 50, 60, 60);
+    assertEquals(2.0, offset.getX(), EPS);
+    assertEquals(0.0, offset.getY(), EPS);
+    assertEquals(0.0, offset.getZ(), EPS);
+
+    final Vector3 offsetY = drag(GizmoPart.AxisY, 50, 50, 60, 60);
+    assertEquals(0.0, offsetY.getX(), EPS);
+    assertEquals(2.0, offsetY.getY(), EPS);
+    assertEquals(0.0, offsetY.getZ(), EPS);
+  }
+
+  @Test
+  public void testAxisAlignedWithViewIsRejected() {
+    // The Z axis points straight at this camera; the drag is ill-conditioned and must be a no-op.
+    final Vector3 offset = drag(GizmoPart.AxisZ, 50, 50, 60, 50);
+    assertEquals(0.0, offset.length(), EPS);
+  }
+
+  @Test
+  public void testCenterDragMovesInViewPlane() {
+    // The view plane here is the XY plane: mouse up maps straight to +Y.
+    final Vector3 offset = drag(GizmoPart.Center, 50, 50, 50, 60);
+    assertEquals(0.0, offset.getX(), EPS);
+    assertEquals(2.0, offset.getY(), EPS);
+    assertEquals(0.0, offset.getZ(), EPS);
+  }
+
+  @Test
+  public void testPlaneDragStaysInPlane() {
+    // Look down at 45 degrees so the XZ plane is visible.
+    _camera.setLocation(0, 10, 10);
+    _camera.lookAt(Vector3.ZERO, Vector3.UNIT_Y);
+
+    // Mouse right: ndc 0.2 of the half-frustum, the ray hits y=0 at depth |(0,10,10)| along the
+    // view ray's center line -> x = 0.2 * sqrt(200) = 2*sqrt(2). Must have no Y component.
+    final Vector3 offset = drag(GizmoPart.PlaneXZ, 50, 50, 60, 50);
+    assertEquals(2.0 * Math.sqrt(2.0), offset.getX(), 1e-6);
+    assertEquals(0.0, offset.getY(), EPS);
+    assertEquals(0.0, offset.getZ(), 1e-6);
+
+    // Mouse up from the view center slides the hit point away from the camera across the plane:
+    // still y=0, moving in -Z.
+    final Vector3 offsetUp = drag(GizmoPart.PlaneXZ, 50, 50, 50, 60);
+    assertEquals(0.0, offsetUp.getX(), 1e-6);
+    assertEquals(0.0, offsetUp.getY(), EPS);
+    assertEquals(-5.0, offsetUp.getZ(), 1e-6);
+  }
+
+  @Test
+  public void testOffsetIsConvertedToParentSpace() {
+    // With the parent scaled 2x, the same world-space drag is half as large in parent units.
+    _parent.setScale(2);
+    _parent.updateGeometricState(0);
+    syncHandleToTarget();
+
+    final Vector3 offset = drag(GizmoPart.AxisX, 50, 50, 60, 50);
+    assertEquals(1.0, offset.getX(), EPS);
+    assertEquals(0.0, offset.getY(), EPS);
+    assertEquals(0.0, offset.getZ(), EPS);
+  }
+
+  @Test
+  public void testLocalInteractMatrixDragsAlongRotatedAxis() {
+    // Rotate the target 90 degrees about Z: its local X axis becomes world +Y. In Local mode the
+    // X handle must drag along world +Y.
+    _target.setRotation(new Matrix3().fromAngleNormalAxis(MathUtils.HALF_PI, Vector3.UNIT_Z));
+    _target.updateGeometricState(0);
+
+    _gizmo.setInteractMatrix(InteractMatrix.Local);
+    _gizmo.targetDataUpdated(_manager);
+    syncHandleToTarget();
+
+    final Vector3 offset = drag(GizmoPart.AxisX, 50, 50, 50, 60);
+    assertEquals(0.0, offset.getX(), EPS);
+    assertEquals(2.0, offset.getY(), EPS);
+    assertEquals(0.0, offset.getZ(), EPS);
+  }
+}


### PR DESCRIPTION
## What this adds

A new package `com.ardor3d.extension.interact.widget.gizmo` in ardor3d-extras with a modern replacement for the aging interact widgets, plus grid/angle snap filters and a showcase example.

**The existing widgets are untouched** (MoveWidget, RotateWidget, SimpleScaleWidget, the planar widgets, CompoundInteractWidget) — downstream consumers keep their current behavior. The new gizmos speak the same InteractManager / SpatialState / UpdateFilter pipeline, so existing filter and undo integrations work unchanged.

### Shared behavior (`AbstractGizmo`)
- **Constant screen size**: handles are scaled per-frame from the camera frustum to hold a ~90px footprint regardless of target size or distance (the old widgets sized from the target's world bound — tiny gizmo on small/far targets).
- **Per-handle hover highlight**: the handle under the mouse brightens to yellow; the rest keep their axis colors (replaces the whole-widget 1.1x mouseover scale).
- **Two-pass x-ray rendering**: a dimmed pass drawn where the gizmo is occluded (enforced GreaterThan z-test) plus a normal full-strength pass — the gizmo never sinks invisibly into the target. Handles render immediately via the Skip bucket after the scene flushes.
- **View-angle fades**: handles whose drag math is ill-conditioned at the current view angle (axis pointing at the camera, plane edge-on) fade out over a 10–20° band and stop picking.
- Thin visuals pick against invisible fatter proxy meshes (CullHint.Always + the ignoreCulled pick overload).

### The gizmos
- **TranslateGizmo** — thin cone-tipped axis arrows, corner plane quads for two-axis drags, and a camera-facing center disk for view-plane drags.
- **RotateGizmo** — three axis rings drawn as half-circle tubes re-oriented every frame to hug the camera-facing hemisphere, plus an outer roll ring for rotating about the view direction. While dragging, a translucent pie wedge sweeps the applied angle and a screen-space readout shows it in degrees (a BasicText in the ortho render queue; apps attach `getAngleReadout()` to their UI root).
- **ScaleGizmo** — cube-tipped axis handles doing **non-uniform per-axis scale** (factor = ratio of the grab point's distance from center, clamped so crossing center can't mirror) and a center cube for uniform scale. Always operates in the target's local frame.

### Snap filters
`GridSnapFilter` and `AngleSnapFilter` in the existing filter package snap the translation/rotation accumulated over a drag to grid steps / angle increments (relative to drag start, Blender/Unity-style). They accumulate raw per-event deltas themselves — the manager resets the state from the target every input event, so naive per-event quantization stalls on slow drags (found interactively; pinned red→green in SnapFilterTest). Delta-based, so AngleSnapFilter also works with the old RotateWidget. Enabled toggles leave the modifier-key policy to the app.

### Example
`InteractGizmoExample`: keys 1/2/3 switch gizmos, R toggles world/local, Ctrl-held snaps (1-unit grid / 15°). Also doubles as an unattended verification probe: `-Dgizmo.shot=path` grabs a PNG and prints gizmo-pixel stats, with options to override the camera (`-Dgizmo.camera=far|xaxis` for screen-size and fade checks), simulate hover (`-Dgizmo.hover=x`), and drive a synthetic ring drag through the full processInput path (`-Dgizmo.drag=ringx`, `-Dgizmo.snap=true`).

## Testing
- 39 unit tests: screen-scale math against a GL-free Camera, translate/scale drag geometry against hand-computed pick rays (including parent-space conversion and local-frame behavior), signed-angle math, and the snap filters simulating the manager's copy/apply input cycle.
- Visual verification via the example's screenshot probe: constant size at 4x distance, axis/plane fades in an axis-aligned view, hover highlight, x-ray through geometry, and a simulated 45.7° ring drag landing at exactly 45.0° with snapping.
- Full `gradlew build` green.

## Follow-ups (intentionally out of scope)
- Shape polish pass (tessellation, tip proportions, quad borders, outlined center circle, palette tuning) — next branch.
- Editor integration lands separately on the editor branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new interactive example demonstrating move, rotate, and scale gizmos.
  * Introduced v2 gizmos with axis, plane, ring, and center handles, including improved on-screen sizing, highlighting, fading, and x-ray rendering.
  * Added translation and rotation snapping via grid and angle snap filters (configurable increments and enable/disable controls).
* **Tests**
  * Added automated coverage for gizmo snapping and gizmo math/drag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->