### PR TITLE
Gizmo micro-interactions: hover, snap, cursors, and drag feedback

### DIFF
--- a/ardor3d-awt/src/main/java/com/ardor3d/image/util/awt/CursorFactory.java
+++ b/ardor3d-awt/src/main/java/com/ardor3d/image/util/awt/CursorFactory.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.image.util.awt;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Arc2D;
+import java.awt.geom.Area;
+import java.awt.geom.Path2D;
+import java.awt.image.BufferedImage;
+
+import com.ardor3d.image.Image;
+import com.ardor3d.input.mouse.MouseCursor;
+
+/**
+ * Generates crisp, high-contrast manipulation cursors - a four-way move arrow, a diagonal resize
+ * arrow and a curved rotate arrow - as {@link MouseCursor}s, drawn with Java2D so they antialias
+ * cleanly and need no bundled image assets. Each is a white shape with a dark outline, sized and
+ * proportioned to read on any background (a thin outline-only cursor is easily mistaken for a
+ * missing pointer). Intended for the interact gizmos (translate/scale/rotate) but usable anywhere a
+ * manipulation cursor is wanted.
+ * <p>
+ * Each accessor returns a cached, shared instance, so repeated calls hand back the same
+ * {@link MouseCursor} - keeping a downstream cursor cache (e.g. the GLFW mouse manager's) keyed on a
+ * stable object.
+ */
+public final class CursorFactory {
+
+  /** Cursor image size, in pixels. The hotspot is the center. */
+  public static final int SIZE = 40;
+
+  private static final Color FILL = Color.WHITE;
+  private static final Color OUTLINE = new Color(0, 0, 0, 235);
+  private static final float OUTLINE_WIDTH = 2f;
+
+  private static MouseCursor MOVE;
+  private static MouseCursor SCALE;
+  private static MouseCursor ROTATE;
+
+  private CursorFactory() {}
+
+  /** A four-way (up/down/left/right) move arrow - the translate-gizmo cursor. */
+  public static synchronized MouseCursor move() {
+    if (CursorFactory.MOVE == null) {
+      CursorFactory.MOVE = CursorFactory.fromShape("gizmoMove", CursorFactory.moveShape());
+    }
+    return CursorFactory.MOVE;
+  }
+
+  /** A diagonal double-headed resize arrow - the scale-gizmo cursor. */
+  public static synchronized MouseCursor scale() {
+    if (CursorFactory.SCALE == null) {
+      CursorFactory.SCALE = CursorFactory.fromShape("gizmoScale", CursorFactory.scaleShape());
+    }
+    return CursorFactory.SCALE;
+  }
+
+  /** A curved double-headed rotate arrow - the rotate-gizmo cursor. */
+  public static synchronized MouseCursor rotate() {
+    if (CursorFactory.ROTATE == null) {
+      CursorFactory.ROTATE = CursorFactory.fromShape("gizmoRotate", CursorFactory.rotateShape());
+    }
+    return CursorFactory.ROTATE;
+  }
+
+  /** The four-way arrow, centered. Arrowheads kept well apart so the outline never closes the
+   * notches between arms into a solid diamond. */
+  private static Shape moveShape() {
+    final int r = 18, ab = 12, hh = 6, sh = 3;
+    final int[][] pts = {{0, -r}, {hh, -ab}, {sh, -ab}, {sh, -sh}, {ab, -sh}, {ab, -hh}, {r, 0}, {ab, hh}, {ab, sh},
+        {sh, sh}, {sh, ab}, {hh, ab}, {0, r}, {-hh, ab}, {-sh, ab}, {-sh, sh}, {-ab, sh}, {-ab, hh}, {-r, 0},
+        {-ab, -hh}, {-ab, -sh}, {-sh, -sh}, {-sh, -ab}, {-hh, -ab}};
+    return CursorFactory.polygon(pts, null);
+  }
+
+  /** A horizontal double-headed arrow rotated 45 degrees into a diagonal resize arrow. */
+  private static Shape scaleShape() {
+    final int r = 17, ab = 9, ah = 6, sh = 3;
+    final int[][] pts = {{-r, 0}, {-ab, -ah}, {-ab, -sh}, {ab, -sh}, {ab, -ah}, {r, 0}, {ab, ah}, {ab, sh}, {-ab, sh},
+        {-ab, ah}};
+    return CursorFactory.polygon(pts, AffineTransform.getRotateInstance(Math.PI / 4, CursorFactory.SIZE / 2.0,
+        CursorFactory.SIZE / 2.0));
+  }
+
+  /** A ~240-degree arc band with an arrowhead at each end, tangent to the arc. */
+  private static Shape rotateShape() {
+    final double radius = 12, band = 4.5, headHalf = 6, tipSweep = Math.toRadians(30);
+    final double start = 60, extent = 240; // degrees, Arc2D convention (measured ccw in math space)
+    final double c = CursorFactory.SIZE / 2.0;
+    final Arc2D arc = new Arc2D.Double(c - radius, c - radius, 2 * radius, 2 * radius, start, extent, Arc2D.OPEN);
+    final Area area = new Area(
+        new BasicStroke((float) band, BasicStroke.CAP_BUTT, BasicStroke.JOIN_ROUND).createStrokedShape(arc));
+    final double startRad = Math.toRadians(start), endRad = Math.toRadians(start + extent);
+    area.add(new Area(CursorFactory.arrowhead(c, radius, startRad, startRad - tipSweep, headHalf)));
+    area.add(new Area(CursorFactory.arrowhead(c, radius, endRad, endRad + tipSweep, headHalf)));
+    return area;
+  }
+
+  /**
+   * A triangular arrowhead straddling the arc at {@code baseAngle} (base corners at radius +/-
+   * headHalf) with its tip swept along the arc to {@code tipAngle}. Angles are in the Arc2D
+   * convention (device y is flipped), so screen y uses {@code -sin}.
+   */
+  private static Shape arrowhead(final double c, final double radius, final double baseAngle, final double tipAngle,
+      final double headHalf) {
+    final Path2D.Double p = new Path2D.Double();
+    p.moveTo(c + (radius - headHalf) * Math.cos(baseAngle), c - (radius - headHalf) * Math.sin(baseAngle));
+    p.lineTo(c + (radius + headHalf) * Math.cos(baseAngle), c - (radius + headHalf) * Math.sin(baseAngle));
+    p.lineTo(c + radius * Math.cos(tipAngle), c - radius * Math.sin(tipAngle));
+    p.closePath();
+    return p;
+  }
+
+  /** Build a closed polygon from center-relative integer points, optionally transformed. */
+  private static Shape polygon(final int[][] pts, final AffineTransform xf) {
+    final double c = CursorFactory.SIZE / 2.0;
+    final Path2D.Double path = new Path2D.Double();
+    path.moveTo(c + pts[0][0], c + pts[0][1]);
+    for (int i = 1; i < pts.length; i++) {
+      path.lineTo(c + pts[i][0], c + pts[i][1]);
+    }
+    path.closePath();
+    return xf == null ? path : xf.createTransformedShape(path);
+  }
+
+  /** Rasterize a shape as a white fill with a dark outline into a center-hotspot cursor. */
+  private static MouseCursor fromShape(final String name, final Shape shape) {
+    final BufferedImage img = new BufferedImage(CursorFactory.SIZE, CursorFactory.SIZE, BufferedImage.TYPE_INT_ARGB);
+    final Graphics2D g = img.createGraphics();
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    g.setColor(CursorFactory.FILL);
+    g.fill(shape);
+    g.setStroke(new BasicStroke(CursorFactory.OUTLINE_WIDTH, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+    g.setColor(CursorFactory.OUTLINE);
+    g.draw(shape);
+    g.dispose();
+
+    final Image image = AWTImageLoader.makeArdor3dImage(img, false);
+    return new MouseCursor(name, image, CursorFactory.SIZE / 2, CursorFactory.SIZE / 2);
+  }
+}

--- a/ardor3d-awt/src/test/java/com/ardor3d/image/util/awt/CursorFactoryTest.java
+++ b/ardor3d-awt/src/test/java/com/ardor3d/image/util/awt/CursorFactoryTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.image.util.awt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import com.ardor3d.image.ImageDataFormat;
+import com.ardor3d.input.mouse.MouseCursor;
+
+/**
+ * The generated manipulation cursors are the right size/format for the native mouse managers (40px
+ * RGBA, centered hotspot), and each accessor hands back one cached, distinct instance.
+ */
+public class CursorFactoryTest {
+
+  @Test
+  public void testCursorsAre40pxRgbaWithCenteredHotspot() {
+    for (final MouseCursor cursor : new MouseCursor[] {CursorFactory.move(), CursorFactory.scale(),
+        CursorFactory.rotate()}) {
+      assertEquals(CursorFactory.SIZE, cursor.getWidth());
+      assertEquals(CursorFactory.SIZE, cursor.getHeight());
+      assertEquals("native mouse managers expect RGBA cursor data", ImageDataFormat.RGBA,
+          cursor.getImage().getDataFormat());
+      assertEquals(CursorFactory.SIZE / 2, cursor.getHotspotX());
+      assertEquals(CursorFactory.SIZE / 2, cursor.getHotspotY());
+    }
+  }
+
+  @Test
+  public void testCursorsAreCachedAndDistinct() {
+    // Same instance on repeat, so a downstream cursor cache stays keyed on a stable object.
+    assertSame(CursorFactory.move(), CursorFactory.move());
+    assertSame(CursorFactory.scale(), CursorFactory.scale());
+    assertSame(CursorFactory.rotate(), CursorFactory.rotate());
+    // ...but the three are different cursors.
+    assertNotEquals(CursorFactory.move(), CursorFactory.scale());
+    assertNotEquals(CursorFactory.move(), CursorFactory.rotate());
+    assertNotEquals(CursorFactory.scale(), CursorFactory.rotate());
+  }
+}

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -10,11 +10,6 @@
 
 package com.ardor3d.example.interact;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.geom.Path2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -34,14 +29,13 @@ import com.ardor3d.extension.interact.filter.AngleSnapFilter;
 import com.ardor3d.extension.interact.filter.GridSnapFilter;
 import com.ardor3d.extension.interact.filter.ScaleSnapFilter;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
-import com.ardor3d.extension.interact.widget.gizmo.AbstractGizmo;
+import com.ardor3d.extension.interact.widget.SetCursorCallback;
 import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.ScaleGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.TranslateGizmo;
-import com.ardor3d.image.Image;
 import com.ardor3d.image.ImageDataFormat;
 import com.ardor3d.image.Texture;
-import com.ardor3d.image.util.awt.AWTImageLoader;
+import com.ardor3d.image.util.awt.CursorFactory;
 import com.ardor3d.input.InputState;
 import com.ardor3d.input.character.CharacterInputState;
 import com.ardor3d.input.controller.ControllerState;
@@ -55,7 +49,6 @@ import com.ardor3d.input.logical.KeyReleasedCondition;
 import com.ardor3d.input.logical.TwoInputStates;
 import com.ardor3d.input.mouse.ButtonState;
 import com.ardor3d.input.mouse.MouseButton;
-import com.ardor3d.input.mouse.MouseCursor;
 import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.intersection.PickData;
 import com.ardor3d.intersection.Pickable;
@@ -81,9 +74,9 @@ import com.ardor3d.util.ReadOnlyTimer;
 import com.ardor3d.util.TextureManager;
 
 /**
- * Showcases the v2 interact gizmos. Hover a handle to highlight it (the cursor also swaps to a
- * move cursor), drag to manipulate the target. Click objects to change the interact target. Press
- * 1 for the translate gizmo, 2 for
+ * Showcases the v2 interact gizmos. Hover a handle to highlight it (the cursor also swaps to match
+ * the gizmo - move, rotate or scale), drag to manipulate the target. Click objects to change the
+ * interact target. Press 1 for the translate gizmo, 2 for
  * rotate, 3 for scale, and R to toggle between world and local interact frames. Hold Ctrl while
  * dragging to snap: translation to a 1-unit grid, rotation to 15 degree steps, scale to quarter
  * steps. Press Escape while dragging to cancel, restoring the target to where the drag began.
@@ -313,10 +306,6 @@ public class InteractGizmoExample extends ExampleBase {
     manager = new InteractManager();
     manager.setupInput(_canvas, _physicalLayer, _logicalLayer);
 
-    // Show a move cursor while the mouse is over any gizmo handle (and during a drag). Set before
-    // constructing the gizmos so each wires it as its mouse-over callback (AbstractGizmo.DEFAULT_CURSOR).
-    AbstractGizmo.DEFAULT_CURSOR = buildMoveCursor();
-
     translateGizmo = new TranslateGizmo().withAllHandles();
     manager.addWidget(translateGizmo);
 
@@ -325,6 +314,14 @@ public class InteractGizmoExample extends ExampleBase {
 
     scaleGizmo = new ScaleGizmo().withAllHandles();
     manager.addWidget(scaleGizmo);
+
+    // Per-gizmo cursor feedback: while a handle is hovered (and during a drag) the cursor swaps to
+    // one matching that gizmo's manipulation, restored to the default on leave. SetCursorCallback is
+    // the shared mouse-over hook; setting AbstractGizmo.DEFAULT_CURSOR would give all gizmos one
+    // cursor instead.
+    translateGizmo.setMouseOverCallback(new SetCursorCallback(CursorFactory.move()));
+    rotateGizmo.setMouseOverCallback(new SetCursorCallback(CursorFactory.rotate()));
+    scaleGizmo.setMouseOverCallback(new SetCursorCallback(CursorFactory.scale()));
 
     // Each gizmo's drag readout is screen-space ui rendered with the ortho pass; only the active
     // gizmo shows its own while dragging.
@@ -398,43 +395,6 @@ public class InteractGizmoExample extends ExampleBase {
       angleSnap.setEnabled(true);
       scaleSnap.setEnabled(true);
     }
-  }
-
-  /**
-   * Build the shared "move" cursor shown while a gizmo handle is hovered: a filled white four-way
-   * arrow with a dark outline, drawn large enough to read clearly on any background (a thin
-   * outline-only cursor reads as a broken/missing pointer). The hotspot is the arrow's center.
-   */
-  private static MouseCursor buildMoveCursor() {
-    // 40px so it reads clearly; arrowheads kept well apart so the notches between arms stay open
-    // (a fatter shaft/heads would let the outline stroke close the gaps into a solid diamond).
-    final int size = 40, c = size / 2, r = 18, arrowBase = 12, headHalf = 6, shaftHalf = 3;
-    // The classic 24-vertex four-way arrow, centered, traced clockwise from the top tip.
-    final int[][] pts = {{0, -r}, {headHalf, -arrowBase}, {shaftHalf, -arrowBase}, {shaftHalf, -shaftHalf},
-        {arrowBase, -shaftHalf}, {arrowBase, -headHalf}, {r, 0}, {arrowBase, headHalf}, {arrowBase, shaftHalf},
-        {shaftHalf, shaftHalf}, {shaftHalf, arrowBase}, {headHalf, arrowBase}, {0, r}, {-headHalf, arrowBase},
-        {-shaftHalf, arrowBase}, {-shaftHalf, shaftHalf}, {-arrowBase, shaftHalf}, {-arrowBase, headHalf}, {-r, 0},
-        {-arrowBase, -headHalf}, {-arrowBase, -shaftHalf}, {-shaftHalf, -shaftHalf}, {-shaftHalf, -arrowBase},
-        {-headHalf, -arrowBase}};
-    final Path2D.Double path = new Path2D.Double();
-    path.moveTo(c + pts[0][0], c + pts[0][1]);
-    for (int i = 1; i < pts.length; i++) {
-      path.lineTo(c + pts[i][0], c + pts[i][1]);
-    }
-    path.closePath();
-
-    final BufferedImage img = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
-    final Graphics2D g = img.createGraphics();
-    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-    g.setColor(Color.WHITE);
-    g.fill(path);
-    g.setStroke(new BasicStroke(2f));
-    g.setColor(new Color(0, 0, 0, 235));
-    g.draw(path);
-    g.dispose();
-
-    final Image image = AWTImageLoader.makeArdor3dImage(img, false);
-    return new MouseCursor("gizmoMove", image, c, c);
   }
 
   /**

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -75,7 +75,8 @@ import com.ardor3d.util.TextureManager;
  * target. Click objects to change the interact target. Press 1 for the translate gizmo, 2 for
  * rotate, 3 for scale, and R to toggle between world and local interact frames. Hold Ctrl while
  * dragging to snap: translation to a 1-unit grid, rotation to 15 degree steps. Press Escape while
- * dragging to cancel, restoring the target to where the drag began.
+ * dragging to cancel, restoring the target to where the drag began. Press U to toggle the rotate
+ * angle readout between degrees and radians.
  *
  * For unattended verification, -Dgizmo.shot=path skips the settings dialog, grabs a frame to the
  * given PNG once the scene has settled, prints a summary of gizmo-colored pixels and exits.
@@ -266,11 +267,15 @@ public class InteractGizmoExample extends ExampleBase {
 
     rotateGizmo = new RotateGizmo().withAllHandles();
     manager.addWidget(rotateGizmo);
-    // the angle readout is screen-space ui - it renders with the ortho pass
-    _orthoRoot.attachChild(rotateGizmo.getAngleReadout());
 
     scaleGizmo = new ScaleGizmo().withAllHandles();
     manager.addWidget(scaleGizmo);
+
+    // Each gizmo's drag readout is screen-space ui rendered with the ortho pass; only the active
+    // gizmo shows its own while dragging.
+    _orthoRoot.attachChild(translateGizmo.getReadout());
+    _orthoRoot.attachChild(rotateGizmo.getReadout());
+    _orthoRoot.attachChild(scaleGizmo.getReadout());
 
     // Drag simulations drive their gizmo directly; it must also be the active widget or the
     // manager would render a different gizmo than the one being dragged.
@@ -302,6 +307,13 @@ public class InteractGizmoExample extends ExampleBase {
           rotateGizmo.setInteractMatrix(next);
           manager.fireTargetDataUpdated();
         }));
+
+    // toggle the rotate angle readout between the built-in degrees text and a radians formatter,
+    // demonstrating the readout formatter callback
+    manager.getLogicalLayer()
+        .registerTrigger(new InputTrigger(new KeyPressedCondition(Key.U),
+            (source, inputStates, tpf) -> rotateGizmo.setReadoutFormatter(rotateGizmo.getReadoutFormatter() == null
+                ? (angleRadians, m) -> String.format("%.3f rad", angleRadians) : null)));
 
     // hold Ctrl to snap: translate to a 1-unit grid, rotate to 15 degree steps
     final GridSnapFilter gridSnap = new GridSnapFilter(1.0);
@@ -462,7 +474,7 @@ public class InteractGizmoExample extends ExampleBase {
       final double targetAngle =
           new Quaternion().fromRotationMatrix(manager.getSpatialTarget().getRotation()).toAngleAxis(new Vector3());
       System.out.println("GIZMO dragAngle=" + rotateGizmo.getDragAngle() + " text='"
-          + rotateGizmo.getAngleReadout().getText() + "' targetAngleDeg=" + targetAngle * MathUtils.RAD_TO_DEG);
+          + rotateGizmo.getReadout().getText() + "' targetAngleDeg=" + targetAngle * MathUtils.RAD_TO_DEG);
     } else if ("scalex".equals(System.getProperty("gizmo.drag"))) {
       System.out.println("GIZMO targetScaleX=" + manager.getSpatialTarget().getScale().getX());
     }

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -27,6 +27,7 @@ import com.ardor3d.example.Purpose;
 import com.ardor3d.extension.interact.InteractManager;
 import com.ardor3d.extension.interact.filter.AngleSnapFilter;
 import com.ardor3d.extension.interact.filter.GridSnapFilter;
+import com.ardor3d.extension.interact.filter.ScaleSnapFilter;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
 import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.ScaleGizmo;
@@ -74,9 +75,9 @@ import com.ardor3d.util.TextureManager;
  * Showcases the v2 interact gizmos. Hover a handle to highlight it, drag to manipulate the
  * target. Click objects to change the interact target. Press 1 for the translate gizmo, 2 for
  * rotate, 3 for scale, and R to toggle between world and local interact frames. Hold Ctrl while
- * dragging to snap: translation to a 1-unit grid, rotation to 15 degree steps. Press Escape while
- * dragging to cancel, restoring the target to where the drag began. Press U to toggle the rotate
- * angle readout between degrees and radians.
+ * dragging to snap: translation to a 1-unit grid, rotation to 15 degree steps, scale to quarter
+ * steps. Press Escape while dragging to cancel, restoring the target to where the drag began.
+ * Press U to toggle the rotate angle readout between degrees and radians.
  *
  * For unattended verification, -Dgizmo.shot=path skips the settings dialog, grabs a frame to the
  * given PNG once the scene has settled, prints a summary of gizmo-colored pixels and exits.
@@ -315,27 +316,33 @@ public class InteractGizmoExample extends ExampleBase {
             (source, inputStates, tpf) -> rotateGizmo.setReadoutFormatter(rotateGizmo.getReadoutFormatter() == null
                 ? (angleRadians, m) -> String.format("%.3f rad", angleRadians) : null)));
 
-    // hold Ctrl to snap: translate to a 1-unit grid, rotate to 15 degree steps
+    // hold Ctrl to snap: translate to a 1-unit grid, rotate to 15 degree steps, scale to quarters
     final GridSnapFilter gridSnap = new GridSnapFilter(1.0);
     gridSnap.setEnabled(false);
     translateGizmo.addFilter(gridSnap);
     final AngleSnapFilter angleSnap = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
     angleSnap.setEnabled(false);
     rotateGizmo.addFilter(angleSnap);
+    final ScaleSnapFilter scaleSnap = new ScaleSnapFilter(0.25);
+    scaleSnap.setEnabled(false);
+    scaleGizmo.addFilter(scaleSnap);
     manager.getLogicalLayer()
         .registerTrigger(new InputTrigger(new KeyHeldCondition(Key.LEFT_CONTROL), (source, inputStates, tpf) -> {
           gridSnap.setEnabled(true);
           angleSnap.setEnabled(true);
+          scaleSnap.setEnabled(true);
         }));
     manager.getLogicalLayer()
         .registerTrigger(new InputTrigger(new KeyReleasedCondition(Key.LEFT_CONTROL), (source, inputStates, tpf) -> {
           gridSnap.setEnabled(false);
           angleSnap.setEnabled(false);
+          scaleSnap.setEnabled(false);
         }));
     if (System.getProperty("gizmo.snap") != null) {
       // Simulated-drag screenshot runs mute real input, so Ctrl can't reach the triggers.
       gridSnap.setEnabled(true);
       angleSnap.setEnabled(true);
+      scaleSnap.setEnabled(true);
     }
   }
 

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -10,6 +10,11 @@
 
 package com.ardor3d.example.interact;
 
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.geom.Path2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -29,11 +34,14 @@ import com.ardor3d.extension.interact.filter.AngleSnapFilter;
 import com.ardor3d.extension.interact.filter.GridSnapFilter;
 import com.ardor3d.extension.interact.filter.ScaleSnapFilter;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
+import com.ardor3d.extension.interact.widget.gizmo.AbstractGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.ScaleGizmo;
 import com.ardor3d.extension.interact.widget.gizmo.TranslateGizmo;
+import com.ardor3d.image.Image;
 import com.ardor3d.image.ImageDataFormat;
 import com.ardor3d.image.Texture;
+import com.ardor3d.image.util.awt.AWTImageLoader;
 import com.ardor3d.input.InputState;
 import com.ardor3d.input.character.CharacterInputState;
 import com.ardor3d.input.controller.ControllerState;
@@ -47,6 +55,7 @@ import com.ardor3d.input.logical.KeyReleasedCondition;
 import com.ardor3d.input.logical.TwoInputStates;
 import com.ardor3d.input.mouse.ButtonState;
 import com.ardor3d.input.mouse.MouseButton;
+import com.ardor3d.input.mouse.MouseCursor;
 import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.intersection.PickData;
 import com.ardor3d.intersection.Pickable;
@@ -72,8 +81,9 @@ import com.ardor3d.util.ReadOnlyTimer;
 import com.ardor3d.util.TextureManager;
 
 /**
- * Showcases the v2 interact gizmos. Hover a handle to highlight it, drag to manipulate the
- * target. Click objects to change the interact target. Press 1 for the translate gizmo, 2 for
+ * Showcases the v2 interact gizmos. Hover a handle to highlight it (the cursor also swaps to a
+ * move cursor), drag to manipulate the target. Click objects to change the interact target. Press
+ * 1 for the translate gizmo, 2 for
  * rotate, 3 for scale, and R to toggle between world and local interact frames. Hold Ctrl while
  * dragging to snap: translation to a 1-unit grid, rotation to 15 degree steps, scale to quarter
  * steps. Press Escape while dragging to cancel, restoring the target to where the drag began.
@@ -303,6 +313,10 @@ public class InteractGizmoExample extends ExampleBase {
     manager = new InteractManager();
     manager.setupInput(_canvas, _physicalLayer, _logicalLayer);
 
+    // Show a move cursor while the mouse is over any gizmo handle (and during a drag). Set before
+    // constructing the gizmos so each wires it as its mouse-over callback (AbstractGizmo.DEFAULT_CURSOR).
+    AbstractGizmo.DEFAULT_CURSOR = buildMoveCursor();
+
     translateGizmo = new TranslateGizmo().withAllHandles();
     manager.addWidget(translateGizmo);
 
@@ -384,6 +398,43 @@ public class InteractGizmoExample extends ExampleBase {
       angleSnap.setEnabled(true);
       scaleSnap.setEnabled(true);
     }
+  }
+
+  /**
+   * Build the shared "move" cursor shown while a gizmo handle is hovered: a filled white four-way
+   * arrow with a dark outline, drawn large enough to read clearly on any background (a thin
+   * outline-only cursor reads as a broken/missing pointer). The hotspot is the arrow's center.
+   */
+  private static MouseCursor buildMoveCursor() {
+    // 40px so it reads clearly; arrowheads kept well apart so the notches between arms stay open
+    // (a fatter shaft/heads would let the outline stroke close the gaps into a solid diamond).
+    final int size = 40, c = size / 2, r = 18, arrowBase = 12, headHalf = 6, shaftHalf = 3;
+    // The classic 24-vertex four-way arrow, centered, traced clockwise from the top tip.
+    final int[][] pts = {{0, -r}, {headHalf, -arrowBase}, {shaftHalf, -arrowBase}, {shaftHalf, -shaftHalf},
+        {arrowBase, -shaftHalf}, {arrowBase, -headHalf}, {r, 0}, {arrowBase, headHalf}, {arrowBase, shaftHalf},
+        {shaftHalf, shaftHalf}, {shaftHalf, arrowBase}, {headHalf, arrowBase}, {0, r}, {-headHalf, arrowBase},
+        {-shaftHalf, arrowBase}, {-shaftHalf, shaftHalf}, {-arrowBase, shaftHalf}, {-arrowBase, headHalf}, {-r, 0},
+        {-arrowBase, -headHalf}, {-arrowBase, -shaftHalf}, {-shaftHalf, -shaftHalf}, {-shaftHalf, -arrowBase},
+        {-headHalf, -arrowBase}};
+    final Path2D.Double path = new Path2D.Double();
+    path.moveTo(c + pts[0][0], c + pts[0][1]);
+    for (int i = 1; i < pts.length; i++) {
+      path.lineTo(c + pts[i][0], c + pts[i][1]);
+    }
+    path.closePath();
+
+    final BufferedImage img = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+    final Graphics2D g = img.createGraphics();
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    g.setColor(Color.WHITE);
+    g.fill(path);
+    g.setStroke(new BasicStroke(2f));
+    g.setColor(new Color(0, 0, 0, 235));
+    g.draw(path);
+    g.dispose();
+
+    final Image image = AWTImageLoader.makeArdor3dImage(img, false);
+    return new MouseCursor("gizmoMove", image, c, c);
   }
 
   /**

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -85,7 +85,8 @@ import com.ardor3d.util.TextureManager;
  * fading); -Dgizmo.hover=x simulates the mouse resting on the +X arrow (to check highlighting);
  * -Dgizmo.widget=rotate starts with the rotate gizmo active; -Dgizmo.drag=ringx simulates a slow
  * drag around the X ring (to check the pie wedge and angle readout); -Dgizmo.drag=scalex simulates
- * pulling the +X scale cube outward (to check the shaft stretch).
+ * pulling the +X scale cube outward (to check the shaft stretch); -Dgizmo.drag=movex simulates
+ * dragging the +X translate arrow (to check the origin ghost and translate snap ticks).
  */
 @Purpose(
     htmlDescriptionKey = "com.ardor3d.example.interact.InteractGizmoExample", //
@@ -133,6 +134,9 @@ public class InteractGizmoExample extends ExampleBase {
       // (absent) mouse each update.
       simulateHoverOnXArrow();
     }
+    if (shot != null && _frames >= 20 && "movex".equals(System.getProperty("gizmo.drag"))) {
+      simulateDragOnXTranslate();
+    }
     if (shot != null && _frames >= 20 && "ringx".equals(System.getProperty("gizmo.drag"))) {
       simulateDragOnXRing();
     }
@@ -166,6 +170,42 @@ public class InteractGizmoExample extends ExampleBase {
   // Shared by both drag simulators, but only one runs per probe JVM (selected by -Dgizmo.drag),
   // so it carries the previous frame's mouse for whichever drag is active with no cross-talk.
   private MouseState _lastDragMouse = null;
+
+  /**
+   * Feed the translate gizmo a synthetic left-button drag that slides the +X arrow outward, driving
+   * the full processInput path so a screenshot run can verify the origin ghost and translate snap
+   * ticks (the target's origin moves, so the ghost anchors at the start point).
+   */
+  private void simulateDragOnXTranslate() {
+    final Camera cam = _canvas.getCanvasRenderer().getCamera();
+    final Spatial target = manager.getSpatialTarget();
+    final ReadOnlyVector3 origin = target.getWorldTranslation();
+    final double scale = translateGizmo.getHandle().getScale().getX();
+
+    // Grab mid-shaft on the +X arrow and slide the grab point along the axis a bit more each frame,
+    // pulling the target along X. The target is unrotated in this scene, so its local X is world X.
+    final double alongX = (0.6 + (_frames - 20) * 0.05) * scale;
+    final Vector3 onAxis = new Vector3(alongX, origin.getY(), origin.getZ());
+    final Vector3 screen = cam.getScreenCoordinates(onAxis);
+
+    final EnumMap<MouseButton, ButtonState> buttons = new EnumMap<>(MouseButton.class);
+    buttons.put(MouseButton.LEFT, ButtonState.DOWN);
+    // First frame: previous state has the button up at the same spot, starting the drag there.
+    final MouseState previous = _lastDragMouse != null ? _lastDragMouse
+        : new MouseState((int) screen.getX(), (int) screen.getY(), 0, 0, 0, null, null);
+    final MouseState current = new MouseState((int) screen.getX(), (int) screen.getY(),
+        (int) screen.getX() - previous.getX(), (int) screen.getY() - previous.getY(), 0, buttons, null);
+    _lastDragMouse = current;
+
+    final InputState previousState = new InputState(KeyboardState.NOTHING, previous, ControllerState.NOTHING,
+        GestureState.NOTHING, CharacterInputState.NOTHING);
+    final InputState currentState = new InputState(KeyboardState.NOTHING, current, ControllerState.NOTHING,
+        GestureState.NOTHING, CharacterInputState.NOTHING);
+
+    translateGizmo.processInput(_canvas, new TwoInputStates(previousState, currentState), new AtomicBoolean(false),
+        manager);
+    manager.getSpatialState().applyState(target);
+  }
 
   /**
    * Feed the rotate gizmo a synthetic left-button drag that walks around the X ring, driving the
@@ -484,6 +524,8 @@ public class InteractGizmoExample extends ExampleBase {
           + rotateGizmo.getReadout().getText() + "' targetAngleDeg=" + targetAngle * MathUtils.RAD_TO_DEG);
     } else if ("scalex".equals(System.getProperty("gizmo.drag"))) {
       System.out.println("GIZMO targetScaleX=" + manager.getSpatialTarget().getScale().getX());
+    } else if ("movex".equals(System.getProperty("gizmo.drag"))) {
+      System.out.println("GIZMO targetTranslateX=" + manager.getSpatialTarget().getTranslation().getX());
     }
 
     try {

--- a/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
+++ b/ardor3d-examples/src/main/java/com/ardor3d/example/interact/InteractGizmoExample.java
@@ -74,7 +74,8 @@ import com.ardor3d.util.TextureManager;
  * Showcases the v2 interact gizmos. Hover a handle to highlight it, drag to manipulate the
  * target. Click objects to change the interact target. Press 1 for the translate gizmo, 2 for
  * rotate, 3 for scale, and R to toggle between world and local interact frames. Hold Ctrl while
- * dragging to snap: translation to a 1-unit grid, rotation to 15 degree steps.
+ * dragging to snap: translation to a 1-unit grid, rotation to 15 degree steps. Press Escape while
+ * dragging to cancel, restoring the target to where the drag began.
  *
  * For unattended verification, -Dgizmo.shot=path skips the settings dialog, grabs a frame to the
  * given PNG once the scene has settled, prints a summary of gizmo-colored pixels and exits.

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/AngleSnapFilter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/AngleSnapFilter.java
@@ -29,7 +29,7 @@ import com.ardor3d.math.Vector3;
  * held); the raw total keeps accumulating while disabled, so mid-drag toggles snap relative to
  * the whole drag.
  */
-public class AngleSnapFilter extends UpdateFilterAdapter {
+public class AngleSnapFilter extends UpdateFilterAdapter implements SnapSource {
 
   protected final Matrix3 _calcMat3A = new Matrix3();
   protected final Matrix3 _calcMat3B = new Matrix3();
@@ -104,4 +104,10 @@ public class AngleSnapFilter extends UpdateFilterAdapter {
   public boolean isEnabled() { return _enabled; }
 
   public void setEnabled(final boolean enabled) { _enabled = enabled; }
+
+  @Override
+  public boolean isSnapping() { return _enabled && _snapAngle > 0; }
+
+  @Override
+  public double getSnapIncrement() { return _snapAngle; }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/GridSnapFilter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/GridSnapFilter.java
@@ -26,7 +26,7 @@ import com.ardor3d.math.Vector3;
  * while Ctrl is held); the raw total keeps accumulating while disabled, so mid-drag toggles snap
  * relative to the whole drag.
  */
-public class GridSnapFilter extends UpdateFilterAdapter {
+public class GridSnapFilter extends UpdateFilterAdapter implements SnapSource {
 
   protected final Vector3 _calcVec = new Vector3();
 
@@ -87,4 +87,10 @@ public class GridSnapFilter extends UpdateFilterAdapter {
   public boolean isEnabled() { return _enabled; }
 
   public void setEnabled(final boolean enabled) { _enabled = enabled; }
+
+  @Override
+  public boolean isSnapping() { return _enabled && _gridSize > 0; }
+
+  @Override
+  public double getSnapIncrement() { return _gridSize; }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/ScaleSnapFilter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/ScaleSnapFilter.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.filter;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.data.SpatialState;
+import com.ardor3d.extension.interact.widget.AbstractInteractWidget;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.math.util.MathUtils;
+
+/**
+ * Filter that snaps the scale factor accumulated over the course of a drag to fixed increments,
+ * e.g. quarter steps. The scale at drag start is captured, the raw per-event factors the widget
+ * applies are accumulated per axis (the manager resets the state from the target every input
+ * event, and the target only ever receives snapped values - the filter must keep the running total
+ * itself), and each axis' factor is quantized so the target ends on a clean multiple of the start
+ * scale. Only axes the drag has actually changed are snapped, so a single-axis drag leaves the
+ * other two alone regardless of their (possibly off-grid) start scale. Works with any widget that
+ * scales the state (ScaleWidget, ScaleGizmo). Toggle with {@link #setEnabled(boolean)} to make
+ * snapping a modifier-key behavior (e.g. while Ctrl is held); the raw total keeps accumulating
+ * while disabled, so mid-drag toggles snap relative to the whole drag.
+ */
+public class ScaleSnapFilter extends UpdateFilterAdapter implements SnapSource {
+
+  protected double _snapStep;
+  protected boolean _enabled = true;
+
+  /** Target scale captured at drag start; null when no drag is active. */
+  protected Vector3 _startScale = null;
+  /** Raw (unsnapped) factor the drag has applied per axis since it started. */
+  protected final Vector3 _accumulated = new Vector3(1, 1, 1);
+
+  /**
+   * @param snapStep
+   *          the scale-factor increment to snap to (e.g. 0.25 for quarter steps).
+   */
+  public ScaleSnapFilter(final double snapStep) {
+    _snapStep = snapStep;
+  }
+
+  @Override
+  public void beginDrag(final InteractManager manager, final AbstractInteractWidget widget, final MouseState state) {
+    if (manager.getSpatialTarget() != null) {
+      _startScale = new Vector3(manager.getSpatialTarget().getTransform().getScale());
+      _accumulated.set(1, 1, 1);
+    }
+  }
+
+  @Override
+  public void endDrag(final InteractManager manager, final AbstractInteractWidget widget, final MouseState state) {
+    _startScale = null;
+  }
+
+  @Override
+  public void applyFilter(final InteractManager manager, final AbstractInteractWidget widget) {
+    if (_startScale == null || manager.getSpatialTarget() == null) {
+      return;
+    }
+    final SpatialState state = manager.getSpatialState();
+
+    // This event's raw widget factor is the state's divergence from the target, which the manager
+    // has not yet updated this cycle. Fold it into the running per-axis total.
+    final ReadOnlyVector3 target = manager.getSpatialTarget().getTransform().getScale();
+    final ReadOnlyVector3 current = state.getTransform().getScale();
+    _accumulated.multiplyLocal(current.getX() / target.getX(), current.getY() / target.getY(),
+        current.getZ() / target.getZ());
+
+    if (!_enabled || _snapStep <= 0) {
+      return;
+    }
+
+    // Quantize each axis the drag has touched to a clean multiple of its start scale, leaving the
+    // untouched axes (factor still exactly 1) alone so a single-axis drag doesn't nudge the others.
+    state.getTransform().setScale(snap(_accumulated.getX(), _startScale.getX(), current.getX()),
+        snap(_accumulated.getY(), _startScale.getY(), current.getY()),
+        snap(_accumulated.getZ(), _startScale.getZ(), current.getZ()));
+  }
+
+  /**
+   * Snap one axis: if the drag has changed this axis' factor, round it to the nearest step (floored
+   * at one step so it never collapses to zero) and apply it to the start scale; otherwise leave the
+   * axis at the value the widget already left in the state.
+   */
+  protected double snap(final double factor, final double startScale, final double unsnapped) {
+    if (Math.abs(factor - 1.0) <= MathUtils.ZERO_TOLERANCE) {
+      return unsnapped;
+    }
+    final double snapped = Math.max(_snapStep, Math.round(factor / _snapStep) * _snapStep);
+    return startScale * snapped;
+  }
+
+  public double getSnapStep() { return _snapStep; }
+
+  /** Set the scale-factor increment to snap to (e.g. 0.25 for quarter steps). */
+  public void setSnapStep(final double snapStep) { _snapStep = snapStep; }
+
+  public boolean isEnabled() { return _enabled; }
+
+  public void setEnabled(final boolean enabled) { _enabled = enabled; }
+
+  @Override
+  public boolean isSnapping() { return _enabled && _snapStep > 0; }
+
+  @Override
+  public double getSnapIncrement() { return _snapStep; }
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/ScaleSnapFilter.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/ScaleSnapFilter.java
@@ -72,8 +72,8 @@ public class ScaleSnapFilter extends UpdateFilterAdapter implements SnapSource {
     // has not yet updated this cycle. Fold it into the running per-axis total.
     final ReadOnlyVector3 target = manager.getSpatialTarget().getTransform().getScale();
     final ReadOnlyVector3 current = state.getTransform().getScale();
-    _accumulated.multiplyLocal(current.getX() / target.getX(), current.getY() / target.getY(),
-        current.getZ() / target.getZ());
+    _accumulated.multiplyLocal(ratio(current.getX(), target.getX()), ratio(current.getY(), target.getY()),
+        ratio(current.getZ(), target.getZ()));
 
     if (!_enabled || _snapStep <= 0) {
       return;
@@ -86,10 +86,18 @@ public class ScaleSnapFilter extends UpdateFilterAdapter implements SnapSource {
         snap(_accumulated.getZ(), _startScale.getZ(), current.getZ()));
   }
 
+  /** This event's raw factor for one axis, guarding a zero (degenerate) target scale that would
+   * otherwise poison the running total with NaN/Infinity. */
+  private static double ratio(final double current, final double target) {
+    return target != 0.0 ? current / target : 1.0;
+  }
+
   /**
    * Snap one axis: if the drag has changed this axis' factor, round it to the nearest step (floored
    * at one step so it never collapses to zero) and apply it to the start scale; otherwise leave the
-   * axis at the value the widget already left in the state.
+   * axis at the value the widget already left in the state. Assumes a positive factor - the interact
+   * widgets floor scale at a small positive minimum, so factors are always positive; a negative
+   * factor would be forced positive by the one-step floor.
    */
   protected double snap(final double factor, final double startScale, final double unsnapped) {
     if (Math.abs(factor - 1.0) <= MathUtils.ZERO_TOLERANCE) {

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/SnapSource.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/filter/SnapSource.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.filter;
+
+/**
+ * A filter that snaps a drag to fixed increments and can report that increment, so a widget can
+ * visualize the snap grid (e.g. draw tick marks). The increment is in the filter's own quantity:
+ * radians for a rotation snap, world units for a translation grid.
+ */
+public interface SnapSource {
+
+  /**
+   * @return true if this filter is currently snapping (enabled with a positive increment), so a
+   *         widget should show its snap grid.
+   */
+  boolean isSnapping();
+
+  /**
+   * @return the snap increment, in the filter's native quantity (radians or world units). Only
+   *         meaningful when {@link #isSnapping()} is true.
+   */
+  double getSnapIncrement();
+}

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -43,6 +43,7 @@ import com.ardor3d.renderer.state.ZBufferState.TestFunction;
 import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.Spatial;
 import com.ardor3d.scenegraph.hint.PickingHint;
+import com.ardor3d.util.ReadOnlyTimer;
 
 /**
  * Base class for the v2 interact gizmos. Compared to the older widgets in the parent package,
@@ -78,6 +79,19 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   /** Chroma (max minus min channel) below which a handle counts as gray for highlighting. */
   public static final float HIGHLIGHT_CHROMA_FLOOR = 0.15f;
 
+  /**
+   * Default time constant for easing the hover highlight in and out, in seconds. At ~0.05s the
+   * handle reads as reaching full highlight in roughly 100ms - snappy but not instant.
+   */
+  public static final double DEFAULT_HIGHLIGHT_EASE_TAU = 0.05;
+
+  /**
+   * Default fraction a fully-highlighted handle's strokes thicken. The pop grows the stroke width
+   * in place rather than scaling the handle, so the geometry stays put under the cursor - important
+   * for the rings, where a growing radius would slide the line away from the mouse.
+   */
+  public static final double DEFAULT_HIGHLIGHT_LINE_WIDTH_POP = 0.5;
+
   /** Default on-screen footprint of a gizmo, in pixels. */
   public static final double DEFAULT_PIXEL_SIZE = 100;
 
@@ -94,6 +108,11 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   protected final ColorRGBA _highlightColor = new ColorRGBA(AbstractGizmo.DEFAULT_HIGHLIGHT_COLOR);
   protected float _ghostAlpha = AbstractGizmo.DEFAULT_GHOST_ALPHA;
   protected boolean _xray = true;
+
+  /** Time constant for easing the hover highlight in and out, in seconds. */
+  protected double _highlightEaseTau = AbstractGizmo.DEFAULT_HIGHLIGHT_EASE_TAU;
+  /** Fraction a fully-highlighted handle's strokes thicken, in place. */
+  protected double _highlightLineWidthPop = AbstractGizmo.DEFAULT_HIGHLIGHT_LINE_WIDTH_POP;
 
   /** View angle at or below which fading handles are fully hidden, in radians. */
   protected double _fadeHideAngle = 10 * MathUtils.DEG_TO_RAD;
@@ -118,6 +137,7 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   protected final Vector2 _calcVec2C = new Vector2();
   protected final Plane _calcPlane = new Plane();
   protected final ColorRGBA _calcColor = new ColorRGBA();
+  protected final ColorRGBA _calcColorB = new ColorRGBA();
 
   public AbstractGizmo(final String name) {
     _handle = new Node(name);
@@ -177,6 +197,25 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     return null;
   }
 
+  /**
+   * Ease each handle's hover highlight toward its target - 1 for the handle under the mouse or
+   * being dragged, 0 for the rest - before the base class refreshes geometric state. The highlight
+   * drives both the color lerp and the scale pop applied in {@link #render}. Animation is advanced
+   * here, so a gizmo that is rendered without being updated each frame simply sits at rest; the
+   * standard {@link InteractManager} loop updates then renders every frame.
+   */
+  @Override
+  public void update(final ReadOnlyTimer timer, final InteractManager manager) {
+    final double dt = timer.getTimePerFrame();
+    final GizmoHandle active = getActiveHandle();
+    for (int i = _gizmoHandles.size(); --i >= 0;) {
+      final GizmoHandle handle = _gizmoHandles.get(i);
+      handle.setHighlight(
+          GizmoMath.approach(handle.getHighlight(), handle == active ? 1.0 : 0.0, dt, _highlightEaseTau));
+    }
+    super.update(timer, manager);
+  }
+
   @Override
   public void targetDataUpdated(final InteractManager manager) {
     final Spatial target = manager.getSpatialTarget();
@@ -212,14 +251,14 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
 
     updateCameraFacingHandles(camera);
     updateHandleFades(camera);
+    applyHandleLineWidths();
     _handle.updateGeometricState(0);
 
-    final GizmoHandle active = getActiveHandle();
     final RenderContext context = ContextManager.getCurrentContext();
 
     if (_xray) {
       // Occluded pass: only draw where the gizmo is behind scene geometry, dimmed.
-      applyHandleColors(active, _ghostAlpha);
+      applyHandleColors(_ghostAlpha);
       final RenderState previousZ = context.getEnforcedState(StateType.ZBuffer);
       context.enforceState(_ghostZState);
       renderer.draw(_handle);
@@ -231,8 +270,20 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     }
 
     // Visible pass: full strength wherever the gizmo passes the normal depth test.
-    applyHandleColors(active, 1.0f);
+    applyHandleColors(1.0f);
     renderer.draw(_handle);
+  }
+
+  /**
+   * Set each handle's stroke widths for the frame: the display DPI scale, thickened in place by the
+   * handle's current highlight amount. Growing the width rather than scaling the handle keeps the
+   * geometry under the cursor - a ring pops thicker without its radius sliding away from the mouse.
+   */
+  protected void applyHandleLineWidths() {
+    for (int i = _gizmoHandles.size(); --i >= 0;) {
+      final GizmoHandle handle = _gizmoHandles.get(i);
+      handle.applyLineWidthScale((float) (_appliedDpiScale * (1.0 + _highlightLineWidthPop * handle.getHighlight())));
+    }
   }
 
   /**
@@ -243,18 +294,14 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     /**/}
 
   /**
-   * Track the display's DPI scale, rescaling the gizmo's stroke widths when it changes. The
-   * gizmo's pixel footprint picks the scale up in render(). No-op until a scale provider is known
-   * - set one directly or let processInput capture the interacting canvas.
+   * Track the display's DPI scale. The gizmo's pixel footprint and per-frame stroke widths (see
+   * {@link #applyHandleLineWidths}) both pick it up in render(). No-op until a scale provider is
+   * known - set one directly or let processInput capture the interacting canvas.
    */
   protected void updateDpiScale() {
     final double scale = _dpiScaleProvider != null ? _dpiScaleProvider.scaleToScreenDpi(1.0) : 1.0;
-    if (scale == _appliedDpiScale || scale <= 0) {
-      return;
-    }
-    _appliedDpiScale = scale;
-    for (int i = _gizmoHandles.size(); --i >= 0;) {
-      _gizmoHandles.get(i).applyLineWidthScale((float) scale);
+    if (scale > 0) {
+      _appliedDpiScale = scale;
     }
   }
 
@@ -291,11 +338,23 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     }
   }
 
-  protected void applyHandleColors(final GizmoHandle active, final float alphaMultiplier) {
+  protected void applyHandleColors(final float alphaMultiplier) {
     for (int i = _gizmoHandles.size(); --i >= 0;) {
       final GizmoHandle handle = _gizmoHandles.get(i);
-      final ReadOnlyColorRGBA rgb = handle == active ? highlightColorFor(handle) : handle.getBaseColor();
-      final float alpha = handle.getBaseColor().getAlpha() * (float) handle.getFadeAlpha() * alphaMultiplier;
+      final ReadOnlyColorRGBA base = handle.getBaseColor();
+      final float h = (float) handle.getHighlight();
+      final ReadOnlyColorRGBA rgb;
+      if (h <= 0f) {
+        rgb = base;
+      } else {
+        // Lerp base -> its highlight color by the eased amount. highlightColorFor may hand back
+        // _calcColor, so lerp into the separate _calcColorB. Alpha is carried by the alpha arg.
+        final ReadOnlyColorRGBA hi = highlightColorFor(handle);
+        rgb = _calcColorB.set(base.getRed() + (hi.getRed() - base.getRed()) * h,
+            base.getGreen() + (hi.getGreen() - base.getGreen()) * h,
+            base.getBlue() + (hi.getBlue() - base.getBlue()) * h, base.getAlpha());
+      }
+      final float alpha = base.getAlpha() * (float) handle.getFadeAlpha() * alphaMultiplier;
       handle.applyColor(rgb, alpha);
     }
   }
@@ -391,6 +450,16 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   public ReadOnlyColorRGBA getHighlightColor() { return _highlightColor; }
 
   public void setHighlightColor(final ReadOnlyColorRGBA color) { _highlightColor.set(color); }
+
+  public double getHighlightEaseTau() { return _highlightEaseTau; }
+
+  /** Set the time constant for easing the hover highlight in and out, in seconds; 0 to snap. */
+  public void setHighlightEaseTau(final double seconds) { _highlightEaseTau = seconds; }
+
+  public double getHighlightLineWidthPop() { return _highlightLineWidthPop; }
+
+  /** Set the fraction a fully-highlighted handle's strokes thicken in place; 0 for no pop. */
+  public void setHighlightLineWidthPop(final double fraction) { _highlightLineWidthPop = fraction; }
 
   public boolean isXRay() { return _xray; }
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -502,6 +502,10 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   public void render(final Renderer renderer, final InteractManager manager) {
     final Spatial target = manager.getSpatialTarget();
     if (target == null) {
+      // No target, so the rest of render() (which shows/positions these) is skipped. The readout
+      // lives in the app's ortho root and would otherwise stay frozen on screen; hide both here.
+      hideReadout();
+      hideOriginGhost();
       return;
     }
 
@@ -563,6 +567,9 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     final double above = _pixelSize * _appliedDpiScale + AbstractGizmo.READOUT_MARGIN;
     _readoutText.setTranslation(Math.round(screen.getX()), Math.round(screen.getY() + above), 0);
     _readoutText.getSceneHints().setCullHint(CullHint.Never);
+    // The readout is mutated here, outside the scene's normal update pass, then drawn by the app's
+    // ortho root - refresh its world transform now so it is not a frame stale (like _handle above).
+    _readoutText.updateGeometricState(0);
   }
 
   protected void hideReadout() {

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -12,6 +12,7 @@ package com.ardor3d.extension.interact.widget.gizmo;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.ardor3d.extension.interact.InteractManager;
 import com.ardor3d.extension.interact.widget.AbstractInteractWidget;
@@ -19,11 +20,15 @@ import com.ardor3d.extension.interact.widget.DragState;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
 import com.ardor3d.framework.Canvas;
 import com.ardor3d.framework.IDpiScaleProvider;
+import com.ardor3d.input.keyboard.Key;
+import com.ardor3d.input.keyboard.KeyboardState;
+import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.intersection.PickingUtil;
 import com.ardor3d.light.LightProperties;
 import com.ardor3d.math.ColorRGBA;
 import com.ardor3d.math.Matrix3;
 import com.ardor3d.math.Plane;
+import com.ardor3d.math.Transform;
 import com.ardor3d.math.Vector2;
 import com.ardor3d.math.Vector3;
 import com.ardor3d.math.type.ReadOnlyColorRGBA;
@@ -139,6 +144,11 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   protected final ColorRGBA _calcColor = new ColorRGBA();
   protected final ColorRGBA _calcColorB = new ColorRGBA();
 
+  /** The target's transform when the current drag began, restored if the drag is cancelled. */
+  protected final Transform _dragStartTransform = new Transform();
+  /** Whether {@link #_dragStartTransform} holds a snapshot for the active drag. */
+  protected boolean _hasDragStartTransform = false;
+
   public AbstractGizmo(final String name) {
     _handle = new Node(name);
     LightProperties.setLightReceiver(_handle, false);
@@ -214,6 +224,52 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
           GizmoMath.approach(handle.getHighlight(), handle == active ? 1.0 : 0.0, dt, _highlightEaseTau));
     }
     super.update(timer, manager);
+  }
+
+  @Override
+  public void beginDrag(final InteractManager manager, final MouseState current) {
+    super.beginDrag(manager, current);
+    // super sets START_DRAG only if a handle was picked; snapshot the pre-drag transform so the
+    // drag can be cancelled back to it (see cancelDrag).
+    if (_dragState != DragState.NONE) {
+      _dragStartTransform.set(manager.getSpatialState().getTransform());
+      _hasDragStartTransform = true;
+    }
+  }
+
+  /**
+   * Cancel an in-progress drag: restore the target to the transform it had when the drag began and
+   * end the interaction, discarding the drag's changes. A no-op when no drag is active.
+   */
+  public void cancelDrag(final InteractManager manager, final MouseState current) {
+    if (_dragState == DragState.NONE) {
+      return;
+    }
+    final Spatial target = manager.getSpatialTarget();
+    if (_hasDragStartTransform && target != null) {
+      manager.getSpatialState().getTransform().set(_dragStartTransform);
+      manager.getSpatialState().applyState(target);
+      manager.fireTargetDataUpdated();
+    }
+    endDrag(manager, current);
+    _hasDragStartTransform = false;
+  }
+
+  /**
+   * If a drag is active and Escape is held, cancel it and mark the input consumed. Gizmos call this
+   * at the top of processInput so Escape aborts a drag in progress; the drag stays cancelled until
+   * the mouse button is released and pressed again.
+   *
+   * @return true if a drag was cancelled by this call.
+   */
+  protected boolean cancelDragIfRequested(final KeyboardState keyboard, final MouseState current,
+      final AtomicBoolean inputConsumed, final InteractManager manager) {
+    if (_dragState == DragState.NONE || keyboard == null || !keyboard.isDown(Key.ESCAPE)) {
+      return false;
+    }
+    cancelDrag(manager, current);
+    inputConsumed.set(true);
+    return true;
   }
 
   @Override

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -10,6 +10,7 @@
 
 package com.ardor3d.extension.interact.widget.gizmo;
 
+import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,9 +46,13 @@ import com.ardor3d.renderer.state.RenderState;
 import com.ardor3d.renderer.state.RenderState.StateType;
 import com.ardor3d.renderer.state.ZBufferState;
 import com.ardor3d.renderer.state.ZBufferState.TestFunction;
+import com.ardor3d.scenegraph.Line;
+import com.ardor3d.scenegraph.MeshData;
 import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.Spatial;
+import com.ardor3d.scenegraph.hint.CullHint;
 import com.ardor3d.scenegraph.hint.PickingHint;
+import com.ardor3d.util.MaterialUtil;
 import com.ardor3d.util.ReadOnlyTimer;
 
 /**
@@ -97,6 +102,19 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
    */
   public static final double DEFAULT_HIGHLIGHT_LINE_WIDTH_POP = 0.5;
 
+  /**
+   * Default opacity the inactive handles fade to while a drag is in progress, so the handle being
+   * dragged stands out. 1 disables the drag-focus dim.
+   */
+  public static final double DEFAULT_DRAG_FOCUS_DIM = 0.15;
+
+  /** Half-length of the axis guide line, in gizmo-local units; large enough to span any viewport. */
+  public static final double AXIS_GUIDE_HALF_LENGTH = 100.0;
+  /** Axis guide stroke width, in screen pixels at 1:1 DPI scale. */
+  public static final float AXIS_GUIDE_WIDTH = 1.5f;
+  /** Axis guide opacity. */
+  public static final float AXIS_GUIDE_ALPHA = 0.55f;
+
   /** Default on-screen footprint of a gizmo, in pixels. */
   public static final double DEFAULT_PIXEL_SIZE = 100;
 
@@ -118,6 +136,10 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   protected double _highlightEaseTau = AbstractGizmo.DEFAULT_HIGHLIGHT_EASE_TAU;
   /** Fraction a fully-highlighted handle's strokes thicken, in place. */
   protected double _highlightLineWidthPop = AbstractGizmo.DEFAULT_HIGHLIGHT_LINE_WIDTH_POP;
+  /** Opacity the inactive handles fade to while dragging. */
+  protected double _dragFocusDim = AbstractGizmo.DEFAULT_DRAG_FOCUS_DIM;
+  /** Eased drag-focus amount in [0, 1]: 0 at rest, 1 while a drag is in progress. */
+  protected double _dragFocus = 0.0;
 
   /** View angle at or below which fading handles are fully hidden, in radians. */
   protected double _fadeHideAngle = 10 * MathUtils.DEG_TO_RAD;
@@ -149,6 +171,13 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   /** Whether {@link #_dragStartTransform} holds a snapshot for the active drag. */
   protected boolean _hasDragStartTransform = false;
 
+  /**
+   * A long stroke through the gizmo origin along the axis of an active single-axis drag, extending
+   * the constraint line across the viewport. Hidden except during axis drags; its two endpoints are
+   * rewritten each frame onto the active axis.
+   */
+  protected final Line _axisGuide;
+
   public AbstractGizmo(final String name) {
     _handle = new Node(name);
     LightProperties.setLightReceiver(_handle, false);
@@ -166,6 +195,15 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     final CullState cull = new CullState();
     cull.setCullFace(CullState.Face.None);
     _handle.setRenderState(cull);
+
+    // Axis constraint guide: an antialiased stroke along +/-X, reoriented onto the active axis and
+    // shown only during single-axis drags (see updateAxisGuide). Built like the handle strokes.
+    _axisGuide = GizmoGeometry.segmentStroke("axisGuide", new Vector3(-AbstractGizmo.AXIS_GUIDE_HALF_LENGTH, 0, 0),
+        new Vector3(AbstractGizmo.AXIS_GUIDE_HALF_LENGTH, 0, 0), AbstractGizmo.AXIS_GUIDE_WIDTH);
+    LightProperties.setLightReceiver(_axisGuide, false);
+    _axisGuide.getSceneHints().setCullHint(CullHint.Always);
+    _handle.attachChild(_axisGuide);
+    MaterialUtil.autoMaterials(_axisGuide);
 
     // Render immediately when drawn rather than queueing - the gizmo is drawn once per pass by
     // render(), after the scene buckets have flushed.
@@ -223,6 +261,8 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
       handle.setHighlight(
           GizmoMath.approach(handle.getHighlight(), handle == active ? 1.0 : 0.0, dt, _highlightEaseTau));
     }
+    // Ease the drag-focus dim in while a drag is active, out when it ends.
+    _dragFocus = GizmoMath.approach(_dragFocus, _dragState != DragState.NONE ? 1.0 : 0.0, dt, _highlightEaseTau);
     super.update(timer, manager);
   }
 
@@ -308,6 +348,7 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     updateCameraFacingHandles(camera);
     updateHandleFades(camera);
     applyHandleLineWidths();
+    updateAxisGuide();
     _handle.updateGeometricState(0);
 
     final RenderContext context = ContextManager.getCurrentContext();
@@ -340,6 +381,41 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
       final GizmoHandle handle = _gizmoHandles.get(i);
       handle.applyLineWidthScale((float) (_appliedDpiScale * (1.0 + _highlightLineWidthPop * handle.getHighlight())));
     }
+  }
+
+  /**
+   * Reorient and show the axis guide line while a single-axis drag is active, or hide it otherwise.
+   * The guide runs through the gizmo origin along the dragged axis (in the gizmo's local frame) and
+   * takes that axis's color, so the constraint line reads across the whole viewport.
+   */
+  protected void updateAxisGuide() {
+    final GizmoHandle active = getActiveHandle();
+    final boolean axisDrag = _dragState != DragState.NONE && active != null && switch (active.getPart()) {
+      case AxisX, AxisY, AxisZ -> true;
+      default -> false;
+    };
+    if (!axisDrag) {
+      if (_axisGuide.getSceneHints().getCullHint() != CullHint.Always) {
+        _axisGuide.getSceneHints().setCullHint(CullHint.Always);
+      }
+      return;
+    }
+
+    final ReadOnlyVector3 axis = active.getAxis();
+    final float x = (float) (axis.getX() * AbstractGizmo.AXIS_GUIDE_HALF_LENGTH);
+    final float y = (float) (axis.getY() * AbstractGizmo.AXIS_GUIDE_HALF_LENGTH);
+    final float z = (float) (axis.getZ() * AbstractGizmo.AXIS_GUIDE_HALF_LENGTH);
+    final FloatBuffer verts = _axisGuide.getMeshData().getVertexBuffer();
+    verts.clear();
+    verts.put(-x).put(-y).put(-z).put(x).put(y).put(z);
+    verts.rewind();
+    _axisGuide.getMeshData().markBufferDirty(MeshData.KEY_VertexCoords);
+    _axisGuide.updateModelBound();
+
+    final ReadOnlyColorRGBA c = active.getBaseColor();
+    _axisGuide.setDefaultColor(c.getRed(), c.getGreen(), c.getBlue(), AbstractGizmo.AXIS_GUIDE_ALPHA);
+    _axisGuide.setLineWidth(AbstractGizmo.AXIS_GUIDE_WIDTH * (float) _appliedDpiScale);
+    _axisGuide.getSceneHints().setCullHint(CullHint.Never);
   }
 
   /**
@@ -410,7 +486,11 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
             base.getGreen() + (hi.getGreen() - base.getGreen()) * h,
             base.getBlue() + (hi.getBlue() - base.getBlue()) * h, base.getAlpha());
       }
-      final float alpha = base.getAlpha() * (float) handle.getFadeAlpha() * alphaMultiplier;
+      // Drag-focus: dim the handles that are not the drag's focus toward _dragFocusDim while a
+      // drag is active. Keyed off the eased highlight, so the dragged (highlight ~1) handle stays
+      // full and the rest fade; zero effect when no drag is active (_dragFocus ~0).
+      final float focus = 1f - (float) (_dragFocus * (1.0 - _dragFocusDim) * (1.0 - h));
+      final float alpha = base.getAlpha() * (float) handle.getFadeAlpha() * focus * alphaMultiplier;
       handle.applyColor(rgb, alpha);
     }
   }
@@ -516,6 +596,14 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
 
   /** Set the fraction a fully-highlighted handle's strokes thicken in place; 0 for no pop. */
   public void setHighlightLineWidthPop(final double fraction) { _highlightLineWidthPop = fraction; }
+
+  public double getDragFocusDim() { return _dragFocusDim; }
+
+  /** Set the opacity inactive handles fade to while dragging; 1 disables the drag-focus dim. */
+  public void setDragFocusDim(final double opacity) { _dragFocusDim = opacity; }
+
+  /** @return the shared axis constraint guide line, shown during single-axis drags. */
+  public Line getAxisGuide() { return _axisGuide; }
 
   public boolean isXRay() { return _xray; }
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -21,10 +21,12 @@ import com.ardor3d.extension.interact.filter.UpdateFilter;
 import com.ardor3d.extension.interact.widget.AbstractInteractWidget;
 import com.ardor3d.extension.interact.widget.DragState;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
+import com.ardor3d.extension.interact.widget.SetCursorCallback;
 import com.ardor3d.framework.Canvas;
 import com.ardor3d.framework.IDpiScaleProvider;
 import com.ardor3d.input.keyboard.Key;
 import com.ardor3d.input.keyboard.KeyboardState;
+import com.ardor3d.input.mouse.MouseCursor;
 import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.intersection.PickingUtil;
 import com.ardor3d.light.LightProperties;
@@ -174,6 +176,14 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   /** Handles are not pickable once faded below this alpha. */
   public static final double PICK_ALPHA_FLOOR = 0.2;
 
+  /**
+   * Cursor shown while the mouse is over a gizmo handle (and during a drag), restored to the system
+   * default otherwise. Null disables cursor feedback. Set this before constructing gizmos to opt in
+   * - the constructor wires it as the mouse-over callback, mirroring {@code MoveWidget.DEFAULT_CURSOR}.
+   * An app that wants per-gizmo cursors can instead call {@link #setMouseOverCallback} on each gizmo.
+   */
+  public static MouseCursor DEFAULT_CURSOR = null;
+
   protected double _pixelSize = AbstractGizmo.DEFAULT_PIXEL_SIZE;
   protected final ColorRGBA _highlightColor = new ColorRGBA(AbstractGizmo.DEFAULT_HIGHLIGHT_COLOR);
   protected float _ghostAlpha = AbstractGizmo.DEFAULT_GHOST_ALPHA;
@@ -319,6 +329,13 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
 
     _ghostZState.setFunction(TestFunction.GreaterThan);
     _ghostZState.setWritable(false);
+
+    // Cursor feedback: if an app has opted in by setting DEFAULT_CURSOR, show it while a handle is
+    // hovered (or dragged) and restore the default when the mouse leaves. Fires only on hover
+    // enter/leave, not per frame. Mirrors MoveWidget.
+    if (AbstractGizmo.DEFAULT_CURSOR != null) {
+      setMouseOverCallback(new SetCursorCallback(AbstractGizmo.DEFAULT_CURSOR));
+    }
   }
 
   protected void addGizmoHandle(final GizmoHandle handle) {

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -52,8 +52,13 @@ import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.Spatial;
 import com.ardor3d.scenegraph.hint.CullHint;
 import com.ardor3d.scenegraph.hint.PickingHint;
+import com.ardor3d.ui.text.BMFont;
+import com.ardor3d.ui.text.BMText;
+import com.ardor3d.ui.text.BasicText;
 import com.ardor3d.util.MaterialUtil;
 import com.ardor3d.util.ReadOnlyTimer;
+import com.ardor3d.util.resource.ResourceLocatorTool;
+import com.ardor3d.util.resource.URLResourceSource;
 
 /**
  * Base class for the v2 interact gizmos. Compared to the older widgets in the parent package,
@@ -114,6 +119,30 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   public static final float AXIS_GUIDE_WIDTH = 1.5f;
   /** Axis guide opacity. */
   public static final float AXIS_GUIDE_ALPHA = 0.55f;
+
+  /** Point size of the drag readout text. */
+  public static final double DEFAULT_READOUT_SIZE = 20;
+  /** Pixels the readout floats above the top of the gizmo's on-screen footprint. */
+  public static final double READOUT_MARGIN = 16;
+
+  /**
+   * Outlined font for the drag readout, lazily loaded and shared across gizmos. Its baked dark
+   * glyph halo keeps the white numbers legible over any background (e.g. a bright, sun-lit floor)
+   * without a separate backing panel. Falls back to the plain default font if it cannot be loaded.
+   */
+  protected static BMFont READOUT_FONT;
+
+  protected static synchronized BMFont readoutFont() {
+    if (AbstractGizmo.READOUT_FONT == null) {
+      try {
+        AbstractGizmo.READOUT_FONT = new BMFont(new URLResourceSource(ResourceLocatorTool
+            .getClassPathResource(BasicText.class, "com/ardor3d/ui/text/DroidSans-20-bold-regular-outline2.fnt")), true);
+      } catch (final Exception ex) {
+        AbstractGizmo.READOUT_FONT = BasicText.DEFAULT_FONT;
+      }
+    }
+    return AbstractGizmo.READOUT_FONT;
+  }
 
   /** Default on-screen footprint of a gizmo, in pixels. */
   public static final double DEFAULT_PIXEL_SIZE = 100;
@@ -178,6 +207,13 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
    */
   protected final Line _axisGuide;
 
+  /**
+   * Screen-space numeric readout shown while dragging (translation delta, angle, or scale factor).
+   * Lives in the application's ortho/screen root - the app attaches {@link #getReadout()} there and
+   * the gizmo shows, positions and fills it. Content comes from {@link #getReadoutText}.
+   */
+  protected final BasicText _readoutText;
+
   public AbstractGizmo(final String name) {
     _handle = new Node(name);
     LightProperties.setLightReceiver(_handle, false);
@@ -204,6 +240,13 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     _axisGuide.getSceneHints().setCullHint(CullHint.Always);
     _handle.attachChild(_axisGuide);
     MaterialUtil.autoMaterials(_axisGuide);
+
+    // Drag readout: a centered, outlined-font label the app renders in its ortho root. Hidden until
+    // a drag is active. Not attached to _handle - it lives in screen space, not the gizmo's frame.
+    _readoutText = new BasicText("gizmoReadout", "", AbstractGizmo.readoutFont(), AbstractGizmo.DEFAULT_READOUT_SIZE);
+    _readoutText.setTextColor(ColorRGBA.WHITE);
+    _readoutText.setAlign(BMText.Align.Center);
+    _readoutText.getSceneHints().setCullHint(CullHint.Always);
 
     // Render immediately when drawn rather than queueing - the gizmo is drawn once per pass by
     // render(), after the scene buckets have flushed.
@@ -277,6 +320,13 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     }
   }
 
+  @Override
+  public void endDrag(final InteractManager manager, final MouseState current) {
+    super.endDrag(manager, current);
+    // The pre-drag snapshot is only valid during a drag - drop it so the readout stops showing.
+    _hasDragStartTransform = false;
+  }
+
   /**
    * Cancel an in-progress drag: restore the target to the transform it had when the drag began and
    * end the interaction, discarding the drag's changes. A no-op when no drag is active.
@@ -310,6 +360,14 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     cancelDrag(manager, current);
     inputConsumed.set(true);
     return true;
+  }
+
+  @Override
+  public void lostControl(final InteractManager manager) {
+    super.lostControl(manager);
+    // A deactivated gizmo's render() no longer runs, so its readout (which lives in the shared ortho
+    // root) would otherwise stay frozen on screen if it was mid-drag. Hide it here.
+    hideReadout();
   }
 
   @Override
@@ -369,6 +427,41 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     // Visible pass: full strength wherever the gizmo passes the normal depth test.
     applyHandleColors(1.0f);
     renderer.draw(_handle);
+
+    updateReadout(manager);
+  }
+
+  /**
+   * Show and position the drag readout for the frame, filling it from {@link #getReadoutText}, or
+   * hide it when no drag is active. The readout floats just above the gizmo's on-screen footprint,
+   * centered; it lives in the app's ortho root, so it is positioned in screen pixels.
+   */
+  protected void updateReadout(final InteractManager manager) {
+    final String text = _dragState != DragState.NONE && manager.getSpatialTarget() != null ? getReadoutText(manager)
+        : null;
+    if (text == null) {
+      hideReadout();
+      return;
+    }
+    _readoutText.setText(text);
+    final Vector3 screen = Camera.getCurrentCamera().getScreenCoordinates(_handle.getWorldTranslation(), _calcVec3A);
+    final double above = _pixelSize * _appliedDpiScale + AbstractGizmo.READOUT_MARGIN;
+    _readoutText.setTranslation(Math.round(screen.getX()), Math.round(screen.getY() + above), 0);
+    _readoutText.getSceneHints().setCullHint(CullHint.Never);
+  }
+
+  protected void hideReadout() {
+    if (_readoutText.getSceneHints().getCullHint() != CullHint.Always) {
+      _readoutText.getSceneHints().setCullHint(CullHint.Always);
+    }
+  }
+
+  /**
+   * The numeric readout string for the current drag, or null to show nothing. Overridden per gizmo
+   * (translation delta, rotation angle, scale factor); the base gizmo shows no readout.
+   */
+  protected String getReadoutText(final InteractManager manager) {
+    return null;
   }
 
   /**
@@ -604,6 +697,13 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
 
   /** @return the shared axis constraint guide line, shown during single-axis drags. */
   public Line getAxisGuide() { return _axisGuide; }
+
+  /**
+   * @return the screen-space drag readout. Attach it to an application node rendered in ortho/screen
+   *         coordinates (origin at the bottom left) to enable it; the gizmo handles visibility,
+   *         position and content.
+   */
+  public BasicText getReadout() { return _readoutText; }
 
   public boolean isXRay() { return _xray; }
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -31,6 +31,7 @@ import com.ardor3d.light.LightProperties;
 import com.ardor3d.math.ColorRGBA;
 import com.ardor3d.math.Matrix3;
 import com.ardor3d.math.Plane;
+import com.ardor3d.math.Quaternion;
 import com.ardor3d.math.Transform;
 import com.ardor3d.math.Vector2;
 import com.ardor3d.math.Vector3;
@@ -54,6 +55,7 @@ import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.Spatial;
 import com.ardor3d.scenegraph.hint.CullHint;
 import com.ardor3d.scenegraph.hint.PickingHint;
+import com.ardor3d.scenegraph.shape.Disk;
 import com.ardor3d.ui.text.BMFont;
 import com.ardor3d.ui.text.BMText;
 import com.ardor3d.ui.text.BasicText;
@@ -124,6 +126,17 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
 
   /** Time constant for the snap pulse to ease back out after a snapped-value change, in seconds. */
   public static final double DEFAULT_SNAP_PULSE_TAU = 0.12;
+
+  /** Neutral tint of the origin ghost marker drawn where a translate drag began. */
+  public static final ReadOnlyColorRGBA DEFAULT_ORIGIN_GHOST_COLOR = new ColorRGBA(0.85f, 0.85f, 0.85f, 1.0f);
+  /** Opacity of the origin ghost marker. */
+  public static final float ORIGIN_GHOST_ALPHA = 0.4f;
+  /** Origin ghost ring radius and center-dot radius, in gizmo-local units (constant screen size). */
+  public static final double ORIGIN_GHOST_RADIUS = 0.12;
+  public static final double ORIGIN_GHOST_DOT_RADIUS = 0.025;
+  /** Origin ghost ring stroke width, in screen pixels at 1:1 DPI scale, and its arc sample count. */
+  public static final float ORIGIN_GHOST_WIDTH = 2.5f;
+  public static final int ORIGIN_GHOST_SAMPLES = 40;
 
   /** Point size of the drag readout text. */
   public static final double DEFAULT_READOUT_SIZE = 20;
@@ -202,6 +215,7 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   protected final Vector2 _calcVec2B = new Vector2();
   protected final Vector2 _calcVec2C = new Vector2();
   protected final Plane _calcPlane = new Plane();
+  protected final Quaternion _calcQuat = new Quaternion();
   protected final ColorRGBA _calcColor = new ColorRGBA();
   protected final ColorRGBA _calcColorB = new ColorRGBA();
 
@@ -223,6 +237,20 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
    * the gizmo shows, positions and fills it. Content comes from {@link #getReadoutText}.
    */
   protected final BasicText _readoutText;
+
+  /**
+   * A faint marker drawn at the world origin where the current drag began, shown once the origin has
+   * moved away from it - a "you moved from here" anchor. Only translate drags move the origin, so it
+   * self-hides for rotate and scale (whose origin stays put). Standalone, not a child of
+   * {@link #_handle}, which tracks the moving target; positioned and sized per frame in render().
+   */
+  protected final Node _originGhost;
+  /** Gizmo world origin captured at drag start - where the ghost is drawn. */
+  protected final Vector3 _dragStartWorldTranslation = new Vector3();
+  /** Whether a drag with a captured start origin is active. */
+  protected boolean _hasOriginGhost = false;
+  /** Whether to show the origin ghost at all. */
+  protected boolean _showOriginGhost = true;
 
   public AbstractGizmo(final String name) {
     _handle = new Node(name);
@@ -257,6 +285,32 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     _readoutText.setTextColor(ColorRGBA.WHITE);
     _readoutText.setAlign(BMText.Align.Center);
     _readoutText.getSceneHints().setCullHint(CullHint.Always);
+
+    // Origin ghost: a faint camera-facing ring plus a center dot, marking where a translate drag
+    // began. Standalone (not under _handle) so it stays at the start point while the gizmo tracks
+    // the moving target; drawn immediately by render() like _handle. updateOriginGhost() positions,
+    // orients and shows/hides it each frame.
+    _originGhost = new Node("originGhost");
+    LightProperties.setLightReceiver(_originGhost, false);
+    final BlendState ghostBlend = new BlendState();
+    ghostBlend.setBlendEnabled(true);
+    _originGhost.setRenderState(ghostBlend);
+    final ReadOnlyColorRGBA gc = AbstractGizmo.DEFAULT_ORIGIN_GHOST_COLOR;
+    final Line ghostRing = GizmoGeometry.arcStroke("ghostRing", AbstractGizmo.ORIGIN_GHOST_RADIUS, 0,
+        MathUtils.TWO_PI, AbstractGizmo.ORIGIN_GHOST_SAMPLES, AbstractGizmo.ORIGIN_GHOST_WIDTH);
+    ghostRing.setDefaultColor(gc.getRed(), gc.getGreen(), gc.getBlue(), AbstractGizmo.ORIGIN_GHOST_ALPHA);
+    _originGhost.attachChild(ghostRing);
+    final Disk ghostDot = new Disk("ghostDot", 2, 16, AbstractGizmo.ORIGIN_GHOST_DOT_RADIUS);
+    ghostDot.updateModelBound();
+    LightProperties.setLightReceiver(ghostDot, false);
+    ghostDot.setDefaultColor(gc.getRed(), gc.getGreen(), gc.getBlue(), AbstractGizmo.ORIGIN_GHOST_ALPHA);
+    GizmoGeometry.disableDepthWrite(ghostDot);
+    _originGhost.attachChild(ghostDot);
+    _originGhost.getSceneHints().setAllPickingHints(false);
+    _originGhost.getSceneHints().setCullHint(CullHint.Always);
+    _originGhost.getSceneHints().setRenderBucketType(RenderBucketType.Skip);
+    MaterialUtil.autoMaterials(_originGhost);
+    _originGhost.updateGeometricState(0);
 
     // Render immediately when drawn rather than queueing - the gizmo is drawn once per pass by
     // render(), after the scene buckets have flushed.
@@ -345,10 +399,16 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   public void beginDrag(final InteractManager manager, final MouseState current) {
     super.beginDrag(manager, current);
     // super sets START_DRAG only if a handle was picked; snapshot the pre-drag transform so the
-    // drag can be cancelled back to it (see cancelDrag).
+    // drag can be cancelled back to it (see cancelDrag), and the world origin so the origin ghost
+    // can anchor there (see updateOriginGhost).
     if (_dragState != DragState.NONE) {
       _dragStartTransform.set(manager.getSpatialState().getTransform());
       _hasDragStartTransform = true;
+      final Spatial target = manager.getSpatialTarget();
+      if (target != null) {
+        _dragStartWorldTranslation.set(target.getWorldTranslation());
+        _hasOriginGhost = true;
+      }
     }
   }
 
@@ -357,6 +417,7 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     super.endDrag(manager, current);
     // The pre-drag snapshot is only valid during a drag - drop it so the readout stops showing.
     _hasDragStartTransform = false;
+    _hasOriginGhost = false;
   }
 
   /**
@@ -440,6 +501,11 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     applyHandleLineWidths();
     updateAxisGuide();
     _handle.updateGeometricState(0);
+
+    // Origin ghost: a standalone marker at the drag's start point, drawn under the gizmo. Self-hides
+    // (via its cull hint) when not applicable, so the draw call is a no-op then.
+    updateOriginGhost(camera);
+    renderer.draw(_originGhost);
 
     final RenderContext context = ContextManager.getCurrentContext();
 
@@ -541,6 +607,40 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     _axisGuide.setDefaultColor(c.getRed(), c.getGreen(), c.getBlue(), AbstractGizmo.AXIS_GUIDE_ALPHA);
     _axisGuide.setLineWidth(AbstractGizmo.AXIS_GUIDE_WIDTH * (float) _appliedDpiScale);
     _axisGuide.getSceneHints().setCullHint(CullHint.Never);
+  }
+
+  /**
+   * Position, orient and show the origin ghost for the frame, or hide it. The ghost anchors at the
+   * world origin captured when the drag began and appears only once the current origin has moved
+   * away from it - so it marks "you moved from here" during a translate drag and stays hidden for
+   * rotate and scale, whose origin does not move. Sized to a constant screen footprint like the
+   * gizmo and turned to face the camera so the ring always reads as a circle.
+   */
+  protected void updateOriginGhost(final Camera camera) {
+    if (!_showOriginGhost || !_hasOriginGhost || _dragState == DragState.NONE) {
+      hideOriginGhost();
+      return;
+    }
+    final ReadOnlyVector3 current = _handle.getWorldTranslation();
+    if (_dragStartWorldTranslation.distanceSquared(current) <= MathUtils.ZERO_TOLERANCE) {
+      // Origin has not moved: rotate/scale drag, or a translate drag that has not moved yet.
+      hideOriginGhost();
+      return;
+    }
+    _originGhost.setTranslation(_dragStartWorldTranslation);
+    _originGhost.setScale(Math.max(AbstractInteractWidget.MIN_SCALE, GizmoMath.calculateFixedScreenScale(camera,
+        _dragStartWorldTranslation, _pixelSize * _appliedDpiScale)));
+    _calcVec3A.set(camera.getDirection()).negateLocal();
+    _calcQuat.fromVectorToVector(Vector3.UNIT_Z, _calcVec3A);
+    _originGhost.setRotation(_calcQuat);
+    _originGhost.getSceneHints().setCullHint(CullHint.Never);
+    _originGhost.updateGeometricState(0);
+  }
+
+  private void hideOriginGhost() {
+    if (_originGhost.getSceneHints().getCullHint() != CullHint.Always) {
+      _originGhost.getSceneHints().setCullHint(CullHint.Always);
+    }
   }
 
   /**
@@ -729,6 +829,14 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
 
   /** @return the shared axis constraint guide line, shown during single-axis drags. */
   public Line getAxisGuide() { return _axisGuide; }
+
+  /** @return the origin ghost marker drawn at a translate drag's start point. */
+  public Node getOriginGhost() { return _originGhost; }
+
+  public boolean isShowOriginGhost() { return _showOriginGhost; }
+
+  /** Enable or disable the faint marker drawn where a translate drag began. */
+  public void setShowOriginGhost(final boolean show) { _showOriginGhost = show; }
 
   /**
    * @return the screen-space drag readout. Attach it to an application node rendered in ortho/screen

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/AbstractGizmo.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.filter.SnapSource;
+import com.ardor3d.extension.interact.filter.UpdateFilter;
 import com.ardor3d.extension.interact.widget.AbstractInteractWidget;
 import com.ardor3d.extension.interact.widget.DragState;
 import com.ardor3d.extension.interact.widget.InteractMatrix;
@@ -120,6 +122,9 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   /** Axis guide opacity. */
   public static final float AXIS_GUIDE_ALPHA = 0.55f;
 
+  /** Time constant for the snap pulse to ease back out after a snapped-value change, in seconds. */
+  public static final double DEFAULT_SNAP_PULSE_TAU = 0.12;
+
   /** Point size of the drag readout text. */
   public static final double DEFAULT_READOUT_SIZE = 20;
   /** Pixels the readout floats above the top of the gizmo's on-screen footprint. */
@@ -169,6 +174,11 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
   protected double _dragFocusDim = AbstractGizmo.DEFAULT_DRAG_FOCUS_DIM;
   /** Eased drag-focus amount in [0, 1]: 0 at rest, 1 while a drag is in progress. */
   protected double _dragFocus = 0.0;
+
+  /** Time constant for the snap pulse to ease out. */
+  protected double _snapPulseTau = AbstractGizmo.DEFAULT_SNAP_PULSE_TAU;
+  /** Eased snap pulse in [0, 1]: set to 1 on a snapped-value change, eases back to 0. */
+  protected double _snapPulse = 0.0;
 
   /** View angle at or below which fading handles are fully hidden, in radians. */
   protected double _fadeHideAngle = 10 * MathUtils.DEG_TO_RAD;
@@ -306,8 +316,30 @@ public abstract class AbstractGizmo extends AbstractInteractWidget {
     }
     // Ease the drag-focus dim in while a drag is active, out when it ends.
     _dragFocus = GizmoMath.approach(_dragFocus, _dragState != DragState.NONE ? 1.0 : 0.0, dt, _highlightEaseTau);
+    // The snap pulse eases back to rest; gizmos re-arm it on each snapped-value change.
+    _snapPulse = GizmoMath.approach(_snapPulse, 0.0, dt, _snapPulseTau);
     super.update(timer, manager);
   }
+
+  /**
+   * @return the increment (in the gizmo's native quantity) of the first actively-snapping filter on
+   *         this gizmo, or 0 if none is snapping. Used to draw the snap tick grid during a drag.
+   */
+  protected double activeSnapIncrement() {
+    for (final UpdateFilter filter : _filters) {
+      if (filter instanceof SnapSource snap && snap.isSnapping()) {
+        return snap.getSnapIncrement();
+      }
+    }
+    return 0.0;
+  }
+
+  /** Re-arm the snap pulse to full; it eases back out over {@link #_snapPulseTau}. */
+  protected void triggerSnapPulse() {
+    _snapPulse = 1.0;
+  }
+
+  public double getSnapPulse() { return _snapPulse; }
 
   @Override
   public void beginDrag(final InteractManager manager, final MouseState current) {

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoHandle.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoHandle.java
@@ -54,8 +54,17 @@ public class GizmoHandle {
   /** Stroke widths as authored, in pixels, so they can be rescaled for display DPI. */
   protected final Map<Line, Float> _baseLineWidths = new IdentityHashMap<>();
 
+  /** The scale last pushed to the strokes, so the per-frame width update only writes on change. */
+  protected float _appliedLineWidthScale = Float.NaN;
+
   /** Most recently calculated view-angle fade, applied as an alpha multiplier. */
   protected double _fadeAlpha = 1.0;
+
+  /**
+   * Eased hover-highlight amount in [0, 1]: 0 at rest, 1 fully highlighted. The owning gizmo eases
+   * this toward its target each frame and uses it to lerp the handle's color and pop its scale.
+   */
+  protected double _highlight = 0.0;
 
   /**
    * @param part
@@ -117,9 +126,14 @@ public class GizmoHandle {
 
   /**
    * Rescale this handle's stroke widths, multiplying each stroke's authored pixel width - used to
-   * match the display's DPI scale.
+   * match the display's DPI scale and to thicken the strokes on hover. Cheap to call every frame:
+   * it only writes when the scale actually changes.
    */
   public void applyLineWidthScale(final float scale) {
+    if (scale == _appliedLineWidthScale) {
+      return;
+    }
+    _appliedLineWidthScale = scale;
     for (final Map.Entry<Line, Float> entry : _baseLineWidths.entrySet()) {
       entry.getKey().setLineWidth(entry.getValue().floatValue() * scale);
     }
@@ -142,6 +156,10 @@ public class GizmoHandle {
   public double getFadeAlpha() { return _fadeAlpha; }
 
   public void setFadeAlpha(final double alpha) { _fadeAlpha = alpha; }
+
+  public double getHighlight() { return _highlight; }
+
+  public void setHighlight(final double highlight) { _highlight = highlight; }
 
   public List<Mesh> getMeshes() { return _meshes; }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMath.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMath.java
@@ -161,4 +161,31 @@ public final class GizmoMath {
   public static double fadeAlpha(final double angle, final double hideBelow, final double fullAbove) {
     return MathUtils.clamp((angle - hideBelow) / (fullAbove - hideBelow), 0.0, 1.0);
   }
+
+  /**
+   * Advance a value toward a target by frame-rate independent exponential smoothing. Over an
+   * elapsed time equal to {@code tau} the value covers {@code 1 - 1/e} (~63%) of the remaining gap,
+   * ~95% over {@code 3*tau}; it eases in - fast then slow - and never overshoots the target.
+   * Composing two half-steps lands exactly where one full step of the summed time would, so the
+   * animation looks the same regardless of frame rate.
+   *
+   * @param current
+   *          the current value.
+   * @param target
+   *          the value to move toward.
+   * @param dt
+   *          elapsed time, in the same units as tau. Values &lt;= 0 leave current unchanged.
+   * @param tau
+   *          the smoothing time constant. Values &lt;= 0 snap straight to the target.
+   * @return the value moved toward the target.
+   */
+  public static double approach(final double current, final double target, final double dt, final double tau) {
+    if (tau <= 0.0) {
+      return target;
+    }
+    if (dt <= 0.0) {
+      return current;
+    }
+    return current + (target - current) * (1.0 - Math.exp(-dt / tau));
+  }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMath.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMath.java
@@ -85,8 +85,13 @@ public final class GizmoMath {
   public static double calculateFixedScreenScale(final Camera camera, final ReadOnlyVector3 worldPos,
       final double pixels) {
     if (camera.getProjectionMode() == ProjectionMode.Perspective) {
-      final double depth = Math.max(camera.getFrustumNear(),
-          worldPos.subtract(camera.getLocation(), null).dot(camera.getDirection()));
+      // Depth = (worldPos - cameraLocation) . cameraDirection, computed inline: this runs every
+      // frame per gizmo, so avoid allocating a scratch vector for the subtraction.
+      final ReadOnlyVector3 loc = camera.getLocation();
+      final ReadOnlyVector3 dir = camera.getDirection();
+      final double along = (worldPos.getX() - loc.getX()) * dir.getX() + (worldPos.getY() - loc.getY()) * dir.getY()
+          + (worldPos.getZ() - loc.getZ()) * dir.getZ();
+      final double depth = Math.max(camera.getFrustumNear(), along);
       return worldSizeForPixels(pixels, depth, camera.getFrustumTop(), camera.getFrustumNear(), camera.getHeight());
     }
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
@@ -377,6 +377,11 @@ public class RotateGizmo extends AbstractGizmo {
 
     captureDpiScaleProvider(source);
 
+    // Escape aborts a drag in progress, restoring the target to its pre-drag transform.
+    if (cancelDragIfRequested(inputStates.getCurrent().getKeyboardState(), current, inputConsumed, manager)) {
+      return;
+    }
+
     // first process mouse over state
     checkMouseOver(source, current, manager);
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
@@ -66,6 +66,13 @@ public class RotateGizmo extends AbstractGizmo {
   public static final int PIE_MAX_SEGMENTS = 256;
   public static final int ARC_SAMPLES = 48;
 
+  /** Snap tick notches straddle the ring: half radial extent and half tangential width, in units. */
+  public static final double SNAP_TICK_RADIAL = 0.06;
+  public static final double SNAP_TICK_TANGENT = 0.012;
+  public static final float SNAP_TICK_ALPHA = 0.9f;
+  /** Cap on snap ticks drawn to each side of the grab direction. */
+  public static final int SNAP_TICK_MAX_PER_SIDE = 18;
+
   /** The roll ring's white, a touch brighter than the shared center-handle gray. */
   public static final ReadOnlyColorRGBA VIEW_RING_COLOR = new ColorRGBA(0.95f, 0.95f, 0.95f, 0.9f);
 
@@ -113,6 +120,13 @@ public class RotateGizmo extends AbstractGizmo {
   protected final Line _pieEdgeLine;
   protected final FloatBuffer _pieEdgeBuffer = BufferUtils.createVector3Buffer(3);
 
+  /** Radial snap tick notches around the active ring, shown while a snapping ring drag is active. */
+  protected final Mesh _snapTicks;
+  protected final FloatBuffer _snapTickBuffer =
+      BufferUtils.createVector3Buffer((2 * RotateGizmo.SNAP_TICK_MAX_PER_SIDE + 1) * 6);
+  /** Last snapped step index, to pulse when it changes; Long.MIN_VALUE when not snapping. */
+  protected long _lastSnapStep = Long.MIN_VALUE;
+
   public RotateGizmo() {
     super("rotateGizmo");
 
@@ -145,6 +159,18 @@ public class RotateGizmo extends AbstractGizmo {
     GizmoGeometry.disableDepthWrite(_pieEdgeLine);
     _handle.attachChild(_pieEdgeLine);
     MaterialUtil.autoMaterials(_pieEdgeLine);
+
+    // Snap tick notches (small solid quads straddling the ring), shown while a snapping ring drag
+    // is active; updateSnapTicks() rewrites them each frame. Non-indexed triangles, two per notch.
+    _snapTicks = new Mesh("snapTicks");
+    _snapTicks.getMeshData().setVertexBuffer(_snapTickBuffer);
+    _snapTicks.getMeshData().setIndexMode(IndexMode.Triangles);
+    LightProperties.setLightReceiver(_snapTicks, false);
+    _snapTicks.getSceneHints().setAllPickingHints(false);
+    _snapTicks.getSceneHints().setCullHint(CullHint.Always);
+    GizmoGeometry.disableDepthWrite(_snapTicks);
+    _handle.attachChild(_snapTicks);
+    MaterialUtil.autoMaterials(_snapTicks);
   }
 
   /** Add the full set of handles: the three axis rings and the view roll ring. */
@@ -233,6 +259,75 @@ public class RotateGizmo extends AbstractGizmo {
     }
 
     updatePie();
+    updateSnapTicks();
+  }
+
+  /**
+   * Rebuild the radial snap tick notches around the active ring at the snap increment, or hide them
+   * when no snapping ring drag is active. Also pulses when the applied angle crosses to a new step.
+   */
+  protected void updateSnapTicks() {
+    final GizmoHandle active = _dragState != DragState.NONE ? findGizmoHandle(_lastDragSpatial) : null;
+    final double inc = activeSnapIncrement();
+    if (active == null || _dragStartDir == null || inc <= 0) {
+      if (_snapTicks.getSceneHints().getCullHint() != CullHint.Always) {
+        _snapTicks.getSceneHints().setCullHint(CullHint.Always);
+      }
+      _lastSnapStep = Long.MIN_VALUE;
+      return;
+    }
+
+    // Pulse when the applied (snapped) angle crosses to a new increment.
+    final long step = Math.round(_displayAngle / inc);
+    if (_lastSnapStep != Long.MIN_VALUE && step != _lastSnapStep) {
+      triggerSnapPulse();
+    }
+    _lastSnapStep = step;
+
+    // In-plane basis from the grab direction and drag axis, in the gizmo's local frame (as updatePie).
+    final Vector3 axisLocal = _calcVec3A.set(_dragAxis);
+    _handle.getRotation().applyPre(axisLocal, axisLocal);
+    final Vector3 e1 = _calcVec3B.set(_dragStartDir);
+    _handle.getRotation().applyPre(e1, e1);
+    final Vector3 e2 = axisLocal.cross(e1, _calcVec3C);
+
+    final int perSide = Math.min(RotateGizmo.SNAP_TICK_MAX_PER_SIDE, (int) Math.floor(MathUtils.HALF_PI / inc));
+    final double rIn = RotateGizmo.RING_RADIUS - RotateGizmo.SNAP_TICK_RADIAL;
+    final double rOut = RotateGizmo.RING_RADIUS + RotateGizmo.SNAP_TICK_RADIAL;
+    final double w = RotateGizmo.SNAP_TICK_TANGENT;
+    _snapTickBuffer.clear();
+    for (int k = -perSide; k <= perSide; k++) {
+      final double theta = k * inc;
+      final double c = Math.cos(theta), s = Math.sin(theta);
+      // radial unit dir and tangent, in local space
+      final double dx = e1.getX() * c + e2.getX() * s, dy = e1.getY() * c + e2.getY() * s,
+          dz = e1.getZ() * c + e2.getZ() * s;
+      final double tx = -e1.getX() * s + e2.getX() * c, ty = -e1.getY() * s + e2.getY() * c,
+          tz = -e1.getZ() * s + e2.getZ() * c;
+      putTick(dx, dy, dz, tx, ty, tz, rIn, rOut, w);
+    }
+    _snapTickBuffer.flip();
+    _snapTicks.getMeshData().updateVertexCount();
+    _snapTicks.getMeshData().markBufferDirty(MeshData.KEY_VertexCoords);
+    _snapTicks.updateModelBound();
+
+    // Color: the active ring's color, brightened toward white by the snap pulse.
+    final ReadOnlyColorRGBA base = active.getBaseColor();
+    final float p = (float) getSnapPulse();
+    _snapTicks.setDefaultColor(base.getRed() + (1f - base.getRed()) * p, base.getGreen() + (1f - base.getGreen()) * p,
+        base.getBlue() + (1f - base.getBlue()) * p, RotateGizmo.SNAP_TICK_ALPHA);
+    _snapTicks.getSceneHints().setCullHint(CullHint.Never);
+  }
+
+  /** Append one tick notch (two triangles) spanning the radial range at the given in-plane dir/tangent. */
+  private void putTick(final double dx, final double dy, final double dz, final double tx, final double ty,
+      final double tz, final double rIn, final double rOut, final double w) {
+    final float ix = (float) (dx * rIn - tx * w), iy = (float) (dy * rIn - ty * w), iz = (float) (dz * rIn - tz * w);
+    final float ox = (float) (dx * rOut - tx * w), oy = (float) (dy * rOut - ty * w), oz = (float) (dz * rOut - tz * w);
+    final float ox2 = (float) (dx * rOut + tx * w), oy2 = (float) (dy * rOut + ty * w), oz2 = (float) (dz * rOut + tz * w);
+    final float ix2 = (float) (dx * rIn + tx * w), iy2 = (float) (dy * rIn + ty * w), iz2 = (float) (dz * rIn + tz * w);
+    _snapTickBuffer.put(ix).put(iy).put(iz).put(ox).put(oy).put(oz).put(ox2).put(oy2).put(oz2);
+    _snapTickBuffer.put(ix).put(iy).put(iz).put(ox2).put(oy2).put(oz2).put(ix2).put(iy2).put(iz2);
   }
 
   @Override
@@ -365,6 +460,7 @@ public class RotateGizmo extends AbstractGizmo {
     _dragStartRotation = null;
     _dragAngle = 0;
     _displayAngle = 0;
+    _lastSnapStep = Long.MIN_VALUE;
   }
 
   @Override

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
@@ -39,7 +39,6 @@ import com.ardor3d.scenegraph.Mesh;
 import com.ardor3d.scenegraph.MeshData;
 import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.hint.CullHint;
-import com.ardor3d.ui.text.BasicText;
 import com.ardor3d.util.MaterialUtil;
 import com.ardor3d.util.geom.GeometryTool;
 
@@ -70,6 +69,22 @@ public class RotateGizmo extends AbstractGizmo {
   /** The roll ring's white, a touch brighter than the shared center-handle gray. */
   public static final ReadOnlyColorRGBA VIEW_RING_COLOR = new ColorRGBA(0.95f, 0.95f, 0.95f, 0.9f);
 
+  /** Formats the drag angle readout - see {@link RotateGizmo#setReadoutFormatter}. */
+  @FunctionalInterface
+  public interface ReadoutFormatter {
+    /**
+     * @param angleRadians
+     *          the applied drag angle, in radians.
+     * @param manager
+     *          the interact manager (for the target, etc.).
+     * @return the readout text, or null to show nothing.
+     */
+    String format(double angleRadians, InteractManager manager);
+  }
+
+  /** Custom formatter for the angle readout; the built-in degrees text is used when null. */
+  protected ReadoutFormatter _readoutFormatter;
+
   protected GizmoHandle _viewRingHandle;
 
   protected final Quaternion _calcQuat = new Quaternion();
@@ -97,7 +112,6 @@ public class RotateGizmo extends AbstractGizmo {
   /** Stroke along the pie wedge's two radial edges: grab direction and current direction. */
   protected final Line _pieEdgeLine;
   protected final FloatBuffer _pieEdgeBuffer = BufferUtils.createVector3Buffer(3);
-  protected final BasicText _angleText;
 
   public RotateGizmo() {
     super("rotateGizmo");
@@ -131,21 +145,7 @@ public class RotateGizmo extends AbstractGizmo {
     GizmoGeometry.disableDepthWrite(_pieEdgeLine);
     _handle.attachChild(_pieEdgeLine);
     MaterialUtil.autoMaterials(_pieEdgeLine);
-
-    // Screen-space angle readout, living in the ortho render queue. The gizmo shows, hides,
-    // positions and updates it during ring drags; the application decides where it renders by
-    // attaching it to its UI/ortho root (see getAngleReadout()).
-    _angleText = BasicText.createDefaultTextLabel("angleReadout", "", 16);
-    _angleText.setTextColor(ColorRGBA.WHITE);
-    _angleText.getSceneHints().setCullHint(CullHint.Always);
   }
-
-  /**
-   * @return the screen-space angle readout shown while dragging a ring. Attach it to an
-   *         application node rendered in ortho/screen coordinates (with the ortho origin at the
-   *         bottom left) to enable it; the gizmo takes care of visibility, position and content.
-   */
-  public BasicText getAngleReadout() { return _angleText; }
 
   /** Add the full set of handles: the three axis rings and the view roll ring. */
   public RotateGizmo withAllHandles() {
@@ -237,10 +237,31 @@ public class RotateGizmo extends AbstractGizmo {
 
   @Override
   public void render(final Renderer renderer, final InteractManager manager) {
+    // Resolve the applied angle before super.render(), which fills the shared readout via
+    // getReadoutText().
     _displayAngle = calculateAppliedAngle(manager);
     super.render(renderer, manager);
-    updateAngleReadout(manager);
   }
+
+  @Override
+  protected String getReadoutText(final InteractManager manager) {
+    if (_dragStartDir == null) {
+      return null;
+    }
+    if (_readoutFormatter != null) {
+      return _readoutFormatter.format(_displayAngle, manager);
+    }
+    // ASCII only - the outlined readout font carries just printable ASCII, no degree glyph.
+    return String.format("%.1f deg", _displayAngle * MathUtils.RAD_TO_DEG);
+  }
+
+  public ReadoutFormatter getReadoutFormatter() { return _readoutFormatter; }
+
+  /**
+   * Set a custom formatter for the drag angle readout (e.g. radians, or a localized string). Pass
+   * null to restore the built-in degrees text.
+   */
+  public void setReadoutFormatter(final ReadoutFormatter formatter) { _readoutFormatter = formatter; }
 
   /**
    * The drag angle actually applied to the spatial state, read back after filters ran. A snap
@@ -278,26 +299,6 @@ public class RotateGizmo extends AbstractGizmo {
       diff += MathUtils.TWO_PI;
     }
     return _dragAngle + diff;
-  }
-
-  protected void updateAngleReadout(final InteractManager manager) {
-    if (manager.getSpatialTarget() == null || _dragState == DragState.NONE || _dragStartDir == null) {
-      hideAngleReadout();
-      return;
-    }
-
-    // Show the readout just above the gizmo center, in screen coordinates (ortho space).
-    final Camera camera = Camera.getCurrentCamera();
-    final Vector3 screen = camera.getScreenCoordinates(_handle.getWorldTranslation(), _calcVec3A);
-    _angleText.setText(String.format("%.1f°", _displayAngle * MathUtils.RAD_TO_DEG));
-    _angleText.setTranslation((int) (screen.getX() + 12), (int) (screen.getY() + 12), 0);
-    _angleText.getSceneHints().setCullHint(CullHint.Never);
-  }
-
-  protected void hideAngleReadout() {
-    if (_angleText.getSceneHints().getCullHint() != CullHint.Always) {
-      _angleText.getSceneHints().setCullHint(CullHint.Always);
-    }
   }
 
   /**
@@ -364,7 +365,6 @@ public class RotateGizmo extends AbstractGizmo {
     _dragStartRotation = null;
     _dragAngle = 0;
     _displayAngle = 0;
-    hideAngleReadout();
   }
 
   @Override

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/RotateGizmo.java
@@ -94,7 +94,7 @@ public class RotateGizmo extends AbstractGizmo {
 
   protected GizmoHandle _viewRingHandle;
 
-  protected final Quaternion _calcQuat = new Quaternion();
+  // _calcQuat is the shared scratch quaternion from AbstractGizmo.
   protected final Matrix3 _calcMat3 = new Matrix3();
   protected final Matrix3 _calcMat3B = new Matrix3();
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
@@ -14,6 +14,7 @@ import java.nio.FloatBuffer;
 import java.util.EnumMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.ardor3d.buffer.BufferUtils;
 import com.ardor3d.extension.interact.InteractManager;
 import com.ardor3d.extension.interact.widget.DragState;
 import com.ardor3d.extension.interact.widget.gizmo.GizmoHandle.FadeMode;
@@ -31,6 +32,7 @@ import com.ardor3d.math.type.ReadOnlyQuaternion;
 import com.ardor3d.math.type.ReadOnlyVector3;
 import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.IndexMode;
 import com.ardor3d.renderer.Renderer;
 import com.ardor3d.scenegraph.Line;
 import com.ardor3d.scenegraph.Mesh;
@@ -80,6 +82,17 @@ public class ScaleGizmo extends AbstractGizmo {
   public static final double MIN_DISPLAY_STRETCH = 0.32;
   public static final double MAX_DISPLAY_STRETCH = 8.0;
 
+  /** Snap tick crossbars along the axis: half length across the axis, half thickness along it, units. */
+  public static final double SNAP_TICK_HALF = 0.05;
+  public static final double SNAP_TICK_THICK = 0.01;
+  public static final float SNAP_TICK_ALPHA = 0.9f;
+  /** Cap on snap ticks and how far along the axis they run, in local units. Scale is one-sided. */
+  public static final int SNAP_TICK_MAX = 24;
+  public static final double SNAP_TICK_MAX_EXTENT = 7.0;
+  /** On-screen tick spacing (px) below which ticks fade fully out, and above which they are full. */
+  public static final double SNAP_TICK_MIN_SCREEN_SPACING = 10;
+  public static final double SNAP_TICK_FULL_SCREEN_SPACING = 24;
+
   /** The dragged axis' shaft and tip, stretched during drags to track the applied scale. */
   protected final EnumMap<GizmoPart, Line> _axisShafts = new EnumMap<>(GizmoPart.class);
   protected final EnumMap<GizmoPart, Mesh> _axisTips = new EnumMap<>(GizmoPart.class);
@@ -87,6 +100,14 @@ public class ScaleGizmo extends AbstractGizmo {
 
   /** State scale captured when a drag started, for measuring the applied ratio. */
   protected Vector3 _dragStartScale = null;
+
+  /** Snap tick crossbars along the active axis, shown while a snapping axis drag is active. */
+  protected final Mesh _snapTicks;
+  protected final FloatBuffer _snapTickBuffer = BufferUtils.createVector3Buffer(ScaleGizmo.SNAP_TICK_MAX * 6);
+  /** Last snapped factor step index, to pulse when it changes; Long.MIN_VALUE when not snapping. */
+  protected long _lastSnapStep = Long.MIN_VALUE;
+  /** The dragged axis' applied factor (current / start scale), captured each frame for the pulse. */
+  protected double _snapActiveFactor = 1.0;
 
   /** Formats the scale factor readout - see {@link ScaleGizmo#setReadoutFormatter}. */
   @FunctionalInterface
@@ -108,6 +129,18 @@ public class ScaleGizmo extends AbstractGizmo {
 
   public ScaleGizmo() {
     super("scaleGizmo");
+
+    // Snap tick crossbars along the active axis, shown while a snapping axis drag is active;
+    // updateSnapTicks() rewrites them each frame. Non-indexed triangles, two per tick.
+    _snapTicks = new Mesh("snapTicks");
+    _snapTicks.getMeshData().setVertexBuffer(_snapTickBuffer);
+    _snapTicks.getMeshData().setIndexMode(IndexMode.Triangles);
+    LightProperties.setLightReceiver(_snapTicks, false);
+    _snapTicks.getSceneHints().setAllPickingHints(false);
+    _snapTicks.getSceneHints().setCullHint(CullHint.Always);
+    GizmoGeometry.disableDepthWrite(_snapTicks);
+    _handle.attachChild(_snapTicks);
+    MaterialUtil.autoMaterials(_snapTicks);
   }
 
   /** Add the full set of handles: three axis cubes and the uniform center cube. */
@@ -319,14 +352,16 @@ public class ScaleGizmo extends AbstractGizmo {
   protected void updateShaftStretch(final InteractManager manager) {
     GizmoPart activePart = null;
     double stretch = 1.0;
+    // The active axis' factor also drives the snap-tick pulse, even at rest length (stretch 1.0).
+    _snapActiveFactor = 1.0;
     if (_dragState != DragState.NONE && _dragStartScale != null && manager.getSpatialTarget() != null) {
       final GizmoHandle handle = findGizmoHandle(_lastDragSpatial);
       if (handle != null) {
         final ReadOnlyVector3 scale = manager.getSpatialState().getTransform().getScale();
         switch (handle.getPart()) {
-          case AxisX -> stretch = scale.getX() / _dragStartScale.getX();
-          case AxisY -> stretch = scale.getY() / _dragStartScale.getY();
-          case AxisZ -> stretch = scale.getZ() / _dragStartScale.getZ();
+          case AxisX -> _snapActiveFactor = stretch = scale.getX() / _dragStartScale.getX();
+          case AxisY -> _snapActiveFactor = stretch = scale.getY() / _dragStartScale.getY();
+          case AxisZ -> _snapActiveFactor = stretch = scale.getZ() / _dragStartScale.getZ();
           default -> {
           }
         }
@@ -373,9 +408,107 @@ public class ScaleGizmo extends AbstractGizmo {
   }
 
   @Override
+  protected void updateCameraFacingHandles(final Camera camera) {
+    updateSnapTicks(camera);
+  }
+
+  /**
+   * Rebuild the snap tick crossbars along the active axis at the factor increment, or hide them
+   * when no snapping axis drag is active. Pulses when the snapped factor steps. The ticks mark
+   * where the tip cube clicks to: the cube sits at TIP_CENTER at the start scale (factor 1), so a
+   * factor of k*inc maps to TIP_CENTER * k*inc along the axis - a fixed on-screen spacing whatever
+   * the camera distance, since the gizmo holds a constant screen size.
+   */
+  protected void updateSnapTicks(final Camera camera) {
+    final GizmoHandle active = _dragState != DragState.NONE ? findGizmoHandle(_lastDragSpatial) : null;
+    final boolean axisDrag = active != null && switch (active.getPart()) {
+      case AxisX, AxisY, AxisZ -> true;
+      default -> false;
+    };
+    final double inc = activeSnapIncrement();
+    if (!axisDrag || inc <= 0) {
+      hideSnapTicks();
+      return;
+    }
+
+    // One factor increment is this far along the axis in local units; fade the ticks out as that
+    // on-screen spacing gets too small to read.
+    final double spacing = ScaleGizmo.TIP_CENTER * inc;
+    final double density = GizmoMath.fadeAlpha(spacing * _pixelSize * _appliedDpiScale,
+        ScaleGizmo.SNAP_TICK_MIN_SCREEN_SPACING, ScaleGizmo.SNAP_TICK_FULL_SCREEN_SPACING);
+    if (density <= 0) {
+      hideSnapTicks();
+      return;
+    }
+
+    // Pulse when the snapped factor steps to a new increment.
+    final long step = Math.round(_snapActiveFactor / inc);
+    if (_lastSnapStep != Long.MIN_VALUE && step != _lastSnapStep) {
+      triggerSnapPulse();
+    }
+    _lastSnapStep = step;
+
+    final ReadOnlyVector3 axis = active.getAxis();
+    // Crossbar direction: perpendicular to the axis, facing the camera. The axis is faded out when
+    // near edge-on, so it is well-conditioned during a real drag; guard the degenerate case anyway.
+    final Vector3 camDir = _handle.getRotation().applyPre(camera.getDirection(), _calcVec3A);
+    final Vector3 perp = axis.cross(camDir, _calcVec3B);
+    if (perp.lengthSquared() < 1e-10) {
+      axis.cross(Vector3.UNIT_Y, perp);
+      if (perp.lengthSquared() < 1e-10) {
+        axis.cross(Vector3.UNIT_X, perp);
+      }
+    }
+    perp.normalizeLocal();
+
+    // Ticks run outward from the origin (factor 0) to the display cap; scale is one-sided.
+    final int count =
+        Math.min(ScaleGizmo.SNAP_TICK_MAX, (int) Math.floor(ScaleGizmo.SNAP_TICK_MAX_EXTENT / spacing));
+    _snapTickBuffer.clear();
+    for (int k = 1; k <= count; k++) {
+      putTick(axis, perp, k * spacing);
+    }
+    _snapTickBuffer.flip();
+    _snapTicks.getMeshData().updateVertexCount();
+    _snapTicks.getMeshData().markBufferDirty(MeshData.KEY_VertexCoords);
+    _snapTicks.updateModelBound();
+
+    final ReadOnlyColorRGBA base = active.getBaseColor();
+    final float p = (float) getSnapPulse();
+    _snapTicks.setDefaultColor(base.getRed() + (1f - base.getRed()) * p, base.getGreen() + (1f - base.getGreen()) * p,
+        base.getBlue() + (1f - base.getBlue()) * p, ScaleGizmo.SNAP_TICK_ALPHA * (float) density);
+    _snapTicks.getSceneHints().setCullHint(CullHint.Never);
+  }
+
+  private void hideSnapTicks() {
+    if (_snapTicks.getSceneHints().getCullHint() != CullHint.Always) {
+      _snapTicks.getSceneHints().setCullHint(CullHint.Always);
+    }
+    _lastSnapStep = Long.MIN_VALUE;
+  }
+
+  /** Append one tick crossbar (two triangles) centered at axis*along, spanning perp. */
+  private void putTick(final ReadOnlyVector3 axis, final ReadOnlyVector3 perp, final double along) {
+    final double t = ScaleGizmo.SNAP_TICK_THICK, h = ScaleGizmo.SNAP_TICK_HALF;
+    final double ax = axis.getX(), ay = axis.getY(), az = axis.getZ();
+    final double px = perp.getX(), py = perp.getY(), pz = perp.getZ();
+    final float c0x = (float) (ax * (along - t) - px * h), c0y = (float) (ay * (along - t) - py * h),
+        c0z = (float) (az * (along - t) - pz * h);
+    final float c1x = (float) (ax * (along + t) - px * h), c1y = (float) (ay * (along + t) - py * h),
+        c1z = (float) (az * (along + t) - pz * h);
+    final float c2x = (float) (ax * (along + t) + px * h), c2y = (float) (ay * (along + t) + py * h),
+        c2z = (float) (az * (along + t) + pz * h);
+    final float c3x = (float) (ax * (along - t) + px * h), c3y = (float) (ay * (along - t) + py * h),
+        c3z = (float) (az * (along - t) + pz * h);
+    _snapTickBuffer.put(c0x).put(c0y).put(c0z).put(c1x).put(c1y).put(c1z).put(c2x).put(c2y).put(c2z);
+    _snapTickBuffer.put(c0x).put(c0y).put(c0z).put(c2x).put(c2y).put(c2z).put(c3x).put(c3y).put(c3z);
+  }
+
+  @Override
   public void endDrag(final InteractManager manager, final MouseState current) {
     super.endDrag(manager, current);
     // Shafts return to rest length on the next render, where no drag is active anymore.
     _dragStartScale = null;
+    _lastSnapStep = Long.MIN_VALUE;
   }
 }

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
@@ -88,6 +88,24 @@ public class ScaleGizmo extends AbstractGizmo {
   /** State scale captured when a drag started, for measuring the applied ratio. */
   protected Vector3 _dragStartScale = null;
 
+  /** Formats the scale factor readout - see {@link ScaleGizmo#setReadoutFormatter}. */
+  @FunctionalInterface
+  public interface ReadoutFormatter {
+    /**
+     * @param factor
+     *          the per-axis scale factor applied since the drag began.
+     * @param manager
+     *          the interact manager (for the target, etc.).
+     * @return the readout text, or null to show nothing.
+     */
+    String format(ReadOnlyVector3 factor, InteractManager manager);
+  }
+
+  /** Custom formatter for the scale readout; the built-in factor text is used when null. */
+  protected ReadoutFormatter _readoutFormatter;
+  /** Scratch for the per-axis factor handed to the formatter. */
+  protected final Vector3 _calcFactor = new Vector3();
+
   public ScaleGizmo() {
     super("scaleGizmo");
   }
@@ -258,6 +276,40 @@ public class ScaleGizmo extends AbstractGizmo {
     updateShaftStretch(manager);
     super.render(renderer, manager);
   }
+
+  @Override
+  protected String getReadoutText(final InteractManager manager) {
+    if (_dragStartScale == null) {
+      return null;
+    }
+    final GizmoHandle handle = findGizmoHandle(_lastDragSpatial);
+    if (handle == null) {
+      return null;
+    }
+    // Per-axis factor applied since the drag began, read back from the state so any snap shows true.
+    final ReadOnlyVector3 scale = manager.getSpatialState().getTransform().getScale();
+    final double fx = scale.getX() / _dragStartScale.getX();
+    final double fy = scale.getY() / _dragStartScale.getY();
+    final double fz = scale.getZ() / _dragStartScale.getZ();
+    if (_readoutFormatter != null) {
+      return _readoutFormatter.format(_calcFactor.set(fx, fy, fz), manager);
+    }
+    // Built-in: the dragged axis' factor (uniform cube uses X). ASCII 'x', not the multiply glyph.
+    final double ratio = switch (handle.getPart()) {
+      case AxisY -> fy;
+      case AxisZ -> fz;
+      default -> fx;
+    };
+    return String.format("%.2fx", ratio);
+  }
+
+  public ReadoutFormatter getReadoutFormatter() { return _readoutFormatter; }
+
+  /**
+   * Set a custom formatter for the scale readout (e.g. per-axis, or percentages). Pass null to
+   * restore the built-in factor text.
+   */
+  public void setReadoutFormatter(final ReadoutFormatter formatter) { _readoutFormatter = formatter; }
 
   /**
    * While an axis drag is active, stretch that axis' shaft and tip to track the scale actually

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmo.java
@@ -179,6 +179,11 @@ public class ScaleGizmo extends AbstractGizmo {
 
     captureDpiScaleProvider(source);
 
+    // Escape aborts a drag in progress, restoring the target to its pre-drag transform.
+    if (cancelDragIfRequested(inputStates.getCurrent().getKeyboardState(), current, inputConsumed, manager)) {
+      return;
+    }
+
     // first process mouse over state
     checkMouseOver(source, current, manager);
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
@@ -66,6 +66,24 @@ public class TranslateGizmo extends AbstractGizmo {
 
   protected final Quaternion _calcQuat = new Quaternion();
 
+  /** Formats the translation readout - see {@link TranslateGizmo#setReadoutFormatter}. */
+  @FunctionalInterface
+  public interface ReadoutFormatter {
+    /**
+     * @param delta
+     *          translation applied since the drag began, in the target's parent frame.
+     * @param position
+     *          the target's current local translation.
+     * @param manager
+     *          the interact manager (for the target, etc.).
+     * @return the readout text, or null to show nothing.
+     */
+    String format(ReadOnlyVector3 delta, ReadOnlyVector3 position, InteractManager manager);
+  }
+
+  /** Custom formatter for the translation readout; the built-in delta text is used when null. */
+  protected ReadoutFormatter _readoutFormatter;
+
   public TranslateGizmo() {
     super("translateGizmo");
   }
@@ -225,6 +243,31 @@ public class TranslateGizmo extends AbstractGizmo {
     // apply our filters, if any, now that we've made updates.
     applyFilters(manager);
   }
+
+  @Override
+  protected String getReadoutText(final InteractManager manager) {
+    if (!_hasDragStartTransform || manager.getSpatialTarget() == null) {
+      return null;
+    }
+    final ReadOnlyVector3 now = manager.getSpatialTarget().getTranslation();
+    final ReadOnlyVector3 start = _dragStartTransform.getTranslation();
+    final double dx = now.getX() - start.getX();
+    final double dy = now.getY() - start.getY();
+    final double dz = now.getZ() - start.getZ();
+    if (_readoutFormatter != null) {
+      return _readoutFormatter.format(new Vector3(dx, dy, dz), now, manager);
+    }
+    // Built-in: signed delta from where the drag began (ASCII; the signs read as a delta).
+    return String.format("%+.2f, %+.2f, %+.2f", dx, dy, dz);
+  }
+
+  public ReadoutFormatter getReadoutFormatter() { return _readoutFormatter; }
+
+  /**
+   * Set a custom formatter for the translation readout (e.g. converted to cm/m, or absolute
+   * position instead of delta). Pass null to restore the built-in delta text.
+   */
+  public void setReadoutFormatter(final ReadoutFormatter formatter) { _readoutFormatter = formatter; }
 
   /**
    * Work out the translation delta, in the target's parent coordinate space, described by the

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
@@ -198,6 +198,11 @@ public class TranslateGizmo extends AbstractGizmo {
 
     captureDpiScaleProvider(source);
 
+    // Escape aborts a drag in progress, restoring the target to its pre-drag transform.
+    if (cancelDragIfRequested(inputStates.getCurrent().getKeyboardState(), current, inputConsumed, manager)) {
+      return;
+    }
+
     // first process mouse over state
     checkMouseOver(source, current, manager);
 

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
@@ -10,9 +10,12 @@
 
 package com.ardor3d.extension.interact.widget.gizmo;
 
+import java.nio.FloatBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.ardor3d.buffer.BufferUtils;
 import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.DragState;
 import com.ardor3d.extension.interact.widget.gizmo.GizmoHandle.FadeMode;
 import com.ardor3d.framework.Canvas;
 import com.ardor3d.input.logical.TwoInputStates;
@@ -29,7 +32,10 @@ import com.ardor3d.math.type.ReadOnlyQuaternion;
 import com.ardor3d.math.type.ReadOnlyVector3;
 import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.renderer.Camera;
+import com.ardor3d.renderer.IndexMode;
 import com.ardor3d.scenegraph.Line;
+import com.ardor3d.scenegraph.Mesh;
+import com.ardor3d.scenegraph.MeshData;
 import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.hint.CullHint;
 import com.ardor3d.scenegraph.shape.Cylinder;
@@ -62,9 +68,27 @@ public class TranslateGizmo extends AbstractGizmo {
   public static final int CIRCLE_SAMPLES = 48;
   public static final float PLANE_FILL_ALPHA = 0.45f;
 
+  /** Snap tick crossbars on the axis: half length across the axis, half thickness along it, units. */
+  public static final double SNAP_TICK_HALF = 0.05;
+  public static final double SNAP_TICK_THICK = 0.01;
+  public static final float SNAP_TICK_ALPHA = 0.9f;
+  /** Cap on snap ticks per side of the origin, and how far along the axis they run, in local units. */
+  public static final int SNAP_TICK_MAX_PER_SIDE = 10;
+  public static final double SNAP_TICK_MAX_EXTENT = 6.0;
+  /** On-screen tick spacing (px) below which ticks fade fully out, and above which they are full. */
+  public static final double SNAP_TICK_MIN_SCREEN_SPACING = 10;
+  public static final double SNAP_TICK_FULL_SCREEN_SPACING = 24;
+
   protected GizmoHandle _centerHandle;
 
   protected final Quaternion _calcQuat = new Quaternion();
+
+  /** Snap tick crossbars along the active axis, shown while a snapping axis drag is active. */
+  protected final Mesh _snapTicks;
+  protected final FloatBuffer _snapTickBuffer =
+      BufferUtils.createVector3Buffer((2 * TranslateGizmo.SNAP_TICK_MAX_PER_SIDE + 1) * 6);
+  /** Last snapped translation, to pulse when it steps; null when not snapping. */
+  protected Vector3 _lastSnapTranslation = null;
 
   /** Formats the translation readout - see {@link TranslateGizmo#setReadoutFormatter}. */
   @FunctionalInterface
@@ -86,6 +110,18 @@ public class TranslateGizmo extends AbstractGizmo {
 
   public TranslateGizmo() {
     super("translateGizmo");
+
+    // Snap tick crossbars along the active axis, shown while a snapping axis drag is active;
+    // updateSnapTicks() rewrites them each frame. Non-indexed triangles, two per tick.
+    _snapTicks = new Mesh("snapTicks");
+    _snapTicks.getMeshData().setVertexBuffer(_snapTickBuffer);
+    _snapTicks.getMeshData().setIndexMode(IndexMode.Triangles);
+    LightProperties.setLightReceiver(_snapTicks, false);
+    _snapTicks.getSceneHints().setAllPickingHints(false);
+    _snapTicks.getSceneHints().setCullHint(CullHint.Always);
+    GizmoGeometry.disableDepthWrite(_snapTicks);
+    _handle.attachChild(_snapTicks);
+    MaterialUtil.autoMaterials(_snapTicks);
   }
 
   /** Add the full set of handles: axis arrows, plane quads and the view-plane center disk. */
@@ -196,6 +232,7 @@ public class TranslateGizmo extends AbstractGizmo {
 
   @Override
   protected void updateCameraFacingHandles(final Camera camera) {
+    updateSnapTicks(camera);
     if (_centerHandle == null) {
       return;
     }
@@ -204,6 +241,100 @@ public class TranslateGizmo extends AbstractGizmo {
     _handle.getRotation().applyPre(_calcVec3A, _calcVec3A);
     _calcQuat.fromVectorToVector(Vector3.UNIT_Z, _calcVec3A);
     _centerHandle.getRoot().setRotation(_calcQuat);
+  }
+
+  /**
+   * Rebuild the snap tick crossbars along the active axis at the grid increment, or hide them when
+   * no snapping axis drag is active. Pulses when the snapped position steps to a new grid cell. The
+   * grid is in world units while the gizmo holds a constant screen size, so the increment is divided
+   * by the gizmo's scale to get its length in the local frame the ticks live in.
+   */
+  protected void updateSnapTicks(final Camera camera) {
+    final GizmoHandle active = _dragState != DragState.NONE ? findGizmoHandle(_lastDragSpatial) : null;
+    final boolean axisDrag = active != null && switch (active.getPart()) {
+      case AxisX, AxisY, AxisZ -> true;
+      default -> false;
+    };
+    final double inc = activeSnapIncrement();
+    if (!axisDrag || inc <= 0) {
+      hideSnapTicks();
+      return;
+    }
+
+    // The grid is world-spaced but the gizmo holds a constant screen size, so a coarse grid seen
+    // from far away crowds many ticks into the gizmo. Convert the increment to the local frame the
+    // ticks live in (1 local unit is ~the gizmo's pixel footprint on screen) and fade the ticks out
+    // as that on-screen spacing gets too small to read.
+    final double spacing = inc / _handle.getScale().getX();
+    final double density = GizmoMath.fadeAlpha(spacing * _pixelSize * _appliedDpiScale,
+        TranslateGizmo.SNAP_TICK_MIN_SCREEN_SPACING, TranslateGizmo.SNAP_TICK_FULL_SCREEN_SPACING);
+    if (density <= 0) {
+      hideSnapTicks();
+      return;
+    }
+
+    // Pulse when the snapped gizmo position steps to a new grid cell.
+    final ReadOnlyVector3 pos = _handle.getTranslation();
+    if (_lastSnapTranslation == null) {
+      _lastSnapTranslation = new Vector3(pos);
+    } else if (!_lastSnapTranslation.equals(pos)) {
+      triggerSnapPulse();
+      _lastSnapTranslation.set(pos);
+    }
+
+    final ReadOnlyVector3 axis = active.getAxis();
+    // Crossbar direction: perpendicular to the axis, facing the camera. The axis is faded out when
+    // near edge-on, so it is well-conditioned during a real drag; guard the degenerate case anyway.
+    final Vector3 camDir = _handle.getRotation().applyPre(camera.getDirection(), _calcVec3A);
+    final Vector3 perp = axis.cross(camDir, _calcVec3B);
+    if (perp.lengthSquared() < 1e-10) {
+      axis.cross(Vector3.UNIT_Y, perp);
+      if (perp.lengthSquared() < 1e-10) {
+        axis.cross(Vector3.UNIT_X, perp);
+      }
+    }
+    perp.normalizeLocal();
+
+    final int perSide = Math.min(TranslateGizmo.SNAP_TICK_MAX_PER_SIDE,
+        (int) Math.floor(TranslateGizmo.SNAP_TICK_MAX_EXTENT / spacing));
+    _snapTickBuffer.clear();
+    for (int k = -perSide; k <= perSide; k++) {
+      putTick(axis, perp, k * spacing);
+    }
+    _snapTickBuffer.flip();
+    _snapTicks.getMeshData().updateVertexCount();
+    _snapTicks.getMeshData().markBufferDirty(MeshData.KEY_VertexCoords);
+    _snapTicks.updateModelBound();
+
+    final ReadOnlyColorRGBA base = active.getBaseColor();
+    final float p = (float) getSnapPulse();
+    _snapTicks.setDefaultColor(base.getRed() + (1f - base.getRed()) * p, base.getGreen() + (1f - base.getGreen()) * p,
+        base.getBlue() + (1f - base.getBlue()) * p, TranslateGizmo.SNAP_TICK_ALPHA * (float) density);
+    _snapTicks.getSceneHints().setCullHint(CullHint.Never);
+  }
+
+  private void hideSnapTicks() {
+    if (_snapTicks.getSceneHints().getCullHint() != CullHint.Always) {
+      _snapTicks.getSceneHints().setCullHint(CullHint.Always);
+    }
+    _lastSnapTranslation = null;
+  }
+
+  /** Append one tick crossbar (two triangles) centered at axis*along, spanning perp. */
+  private void putTick(final ReadOnlyVector3 axis, final ReadOnlyVector3 perp, final double along) {
+    final double t = TranslateGizmo.SNAP_TICK_THICK, h = TranslateGizmo.SNAP_TICK_HALF;
+    final double ax = axis.getX(), ay = axis.getY(), az = axis.getZ();
+    final double px = perp.getX(), py = perp.getY(), pz = perp.getZ();
+    final float c0x = (float) (ax * (along - t) - px * h), c0y = (float) (ay * (along - t) - py * h),
+        c0z = (float) (az * (along - t) - pz * h);
+    final float c1x = (float) (ax * (along + t) - px * h), c1y = (float) (ay * (along + t) - py * h),
+        c1z = (float) (az * (along + t) - pz * h);
+    final float c2x = (float) (ax * (along + t) + px * h), c2y = (float) (ay * (along + t) + py * h),
+        c2z = (float) (az * (along + t) + pz * h);
+    final float c3x = (float) (ax * (along - t) + px * h), c3y = (float) (ay * (along - t) + py * h),
+        c3z = (float) (az * (along - t) + pz * h);
+    _snapTickBuffer.put(c0x).put(c0y).put(c0z).put(c1x).put(c1y).put(c1z).put(c2x).put(c2y).put(c2z);
+    _snapTickBuffer.put(c0x).put(c0y).put(c0z).put(c2x).put(c2y).put(c2z).put(c3x).put(c3y).put(c3z);
   }
 
   @Override

--- a/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
+++ b/ardor3d-extras/src/main/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmo.java
@@ -11,6 +11,7 @@
 package com.ardor3d.extension.interact.widget.gizmo;
 
 import java.nio.FloatBuffer;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.ardor3d.buffer.BufferUtils;
@@ -80,8 +81,6 @@ public class TranslateGizmo extends AbstractGizmo {
   public static final double SNAP_TICK_FULL_SCREEN_SPACING = 24;
 
   protected GizmoHandle _centerHandle;
-
-  protected final Quaternion _calcQuat = new Quaternion();
 
   /** Snap tick crossbars along the active axis, shown while a snapping axis drag is active. */
   protected final Mesh _snapTicks;
@@ -388,8 +387,10 @@ public class TranslateGizmo extends AbstractGizmo {
     if (_readoutFormatter != null) {
       return _readoutFormatter.format(new Vector3(dx, dy, dz), now, manager);
     }
-    // Built-in: signed delta from where the drag began (ASCII; the signs read as a delta).
-    return String.format("%+.2f, %+.2f, %+.2f", dx, dy, dz);
+    // Built-in: signed delta from where the drag began (ASCII; the signs read as a delta). Format
+    // with a fixed locale: this readout uses ", " to separate the components, so a comma-decimal
+    // locale would collide the decimal and the delimiter into an unreadable string.
+    return String.format(Locale.ROOT, "%+.2f, %+.2f, %+.2f", dx, dy, dz);
   }
 
   public ReadoutFormatter getReadoutFormatter() { return _readoutFormatter; }

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
@@ -307,6 +307,25 @@ public class SnapFilterTest {
   }
 
   @Test
+  public void testScaleSnapSurvivesZeroTargetScale() {
+    // A degenerate target scale of 0 on an axis would divide to Infinity and poison the running
+    // per-axis factor; the guard keeps it finite. (Asserted on _accumulated - where the poison
+    // lands - since the axis' output is 0 either way; this test shares the filter's package.)
+    startScale(0, 1, 1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.beginDrag(_manager, _widget, null);
+
+    _manager.getSpatialState().getTransform().setScale(0.001, 2.0, 1); // X clamped off 0; Y grown 2x
+    filter.applyFilter(_manager, _widget);
+
+    assertTrue("a zero target scale must not poison the accumulated factor",
+        Double.isFinite(filter._accumulated.getX()) && Double.isFinite(filter._accumulated.getY())
+            && Double.isFinite(filter._accumulated.getZ()));
+    assertEquals("the touched axis still snaps", 2.0,
+        _manager.getSpatialState().getTransform().getScale().getY(), EPS);
+  }
+
+  @Test
   public void testScaleSnapFloorsAtOneStep() {
     // Shrinking below half a step would round the factor to zero; it floors at one step instead.
     startScale(1, 1, 1);

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
@@ -27,7 +27,7 @@ import com.ardor3d.scenegraph.Node;
 
 public class SnapFilterTest {
 
-  private static final double EPS = 1e-9;
+  private static final double EPS = MathUtils.ZERO_TOLERANCE;
 
   private Node _target;
   private InteractManager _manager;
@@ -55,7 +55,7 @@ public class SnapFilterTest {
   private static void assertMatrixEquals(final ReadOnlyMatrix3 expected, final ReadOnlyMatrix3 actual) {
     for (int r = 0; r < 3; r++) {
       for (int c = 0; c < 3; c++) {
-        assertEquals("[" + r + "," + c + "]", expected.getValue(r, c), actual.getValue(r, c), 1e-9);
+        assertEquals("[" + r + "," + c + "]", expected.getValue(r, c), actual.getValue(r, c), EPS);
       }
     }
   }

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/filter/SnapFilterTest.java
@@ -240,4 +240,127 @@ public class SnapFilterTest {
 
     assertTrue(filter.isEnabled());
   }
+
+  // --- ScaleSnapFilter ---
+
+  private void startScale(final double x, final double y, final double z) {
+    _target.setScale(x, y, z);
+    _target.updateGeometricState(0);
+    _manager.getSpatialState().copyState(_target);
+  }
+
+  @Test
+  public void testScaleSnapRoundsFactor() {
+    startScale(1, 1, 1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.beginDrag(_manager, _widget, null);
+
+    // Drag has grown X by 1.37x: snaps to 1.25x. Y and Z are untouched, so they stay put.
+    _manager.getSpatialState().getTransform().setScale(1.37, 1, 1);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.25, 1.0, 1.0, _manager.getSpatialState().getTransform().getScale());
+  }
+
+  @Test
+  public void testScaleSnapStepsFromDragStart() {
+    // Snapping is relative to the start scale, so the factor - not the absolute scale - lands on a
+    // clean multiple: a 2.0-scaled object snapped to a 1.25x factor ends at 2.5, not 1.25.
+    startScale(2, 2, 2);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.beginDrag(_manager, _widget, null);
+
+    _manager.getSpatialState().getTransform().setScale(2.74, 2, 2); // 1.37x
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(2.5, 2.0, 2.0, _manager.getSpatialState().getTransform().getScale());
+  }
+
+  @Test
+  public void testScaleSnapLeavesUntouchedAxesExactlyAlone() {
+    // Y and Z start off any grid; an X-only drag must not nudge them onto the factor grid.
+    startScale(1, 1.1, 1.1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.beginDrag(_manager, _widget, null);
+
+    _manager.getSpatialState().getTransform().setScale(2.0, 1.1, 1.1);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(2.0, 1.1, 1.1, _manager.getSpatialState().getTransform().getScale());
+  }
+
+  @Test
+  public void testScaleSnapAccumulatesAcrossInputCycles() {
+    startScale(1, 1, 1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.beginDrag(_manager, _widget, null);
+
+    // The manager copies the state from the target before every input event, so each event's raw
+    // factor (1.1x here) alone rounds back to 1.0x and would lose the drag. Ten of them must
+    // compound to 1.1^10 ~= 2.59x and snap to 2.5x - not round away to nothing cycle after cycle.
+    for (int i = 0; i < 10; i++) {
+      _manager.getSpatialState().copyState(_target);
+      final ReadOnlyVector3 s = _manager.getSpatialState().getTransform().getScale();
+      _manager.getSpatialState().getTransform().setScale(s.getX() * 1.1, s.getY(), s.getZ());
+      filter.applyFilter(_manager, _widget);
+      _manager.getSpatialState().applyState(_target);
+    }
+
+    assertVectorEquals(2.5, 1.0, 1.0, _target.getScale());
+  }
+
+  @Test
+  public void testScaleSnapFloorsAtOneStep() {
+    // Shrinking below half a step would round the factor to zero; it floors at one step instead.
+    startScale(1, 1, 1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.beginDrag(_manager, _widget, null);
+
+    _manager.getSpatialState().getTransform().setScale(0.05, 1, 1);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(0.25, 1.0, 1.0, _manager.getSpatialState().getTransform().getScale());
+  }
+
+  @Test
+  public void testScaleSnapExactStepUnchanged() {
+    startScale(1, 1, 1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.beginDrag(_manager, _widget, null);
+
+    _manager.getSpatialState().getTransform().setScale(1.5, 1, 1); // exactly 6 steps
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.5, 1.0, 1.0, _manager.getSpatialState().getTransform().getScale());
+    assertTrue(filter.isEnabled());
+  }
+
+  @Test
+  public void testScaleSnapDisabled() {
+    startScale(1, 1, 1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.setEnabled(false);
+    filter.beginDrag(_manager, _widget, null);
+
+    _manager.getSpatialState().getTransform().setScale(1.37, 1, 1);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.37, 1.0, 1.0, _manager.getSpatialState().getTransform().getScale());
+  }
+
+  @Test
+  public void testScaleSnapWithoutDragIsANoOp() {
+    startScale(1, 1, 1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    // no beginDrag
+    _manager.getSpatialState().getTransform().setScale(1.37, 1, 1);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.37, 1.0, 1.0, _manager.getSpatialState().getTransform().getScale());
+  }
+
+  @Test
+  public void testScaleSnapEndDragClearsCapture() {
+    startScale(1, 1, 1);
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    filter.beginDrag(_manager, _widget, null);
+    filter.endDrag(_manager, _widget, null);
+
+    _manager.getSpatialState().getTransform().setScale(1.37, 1, 1);
+    filter.applyFilter(_manager, _widget);
+    assertVectorEquals(1.37, 1.0, 1.0, _manager.getSpatialState().getTransform().getScale());
+  }
 }

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoCancelDragTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoCancelDragTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.DragState;
+import com.ardor3d.input.keyboard.Key;
+import com.ardor3d.input.keyboard.KeyboardState;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.math.Vector2;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.scenegraph.Node;
+
+/**
+ * Headless tests of the shared gizmo drag-cancel behavior: Escape during a drag restores the
+ * target to its pre-drag transform and ends the interaction. Uses a synthetic camera aimed at the
+ * gizmo center so a real pick starts the drag, then drives the actual beginDrag / cancelDrag path.
+ */
+public class GizmoCancelDragTest {
+
+  private static final double EPS = 1e-9;
+
+  private Node _target;
+  private InteractManager _manager;
+  private TestGizmo _gizmo;
+  private Camera _camera;
+
+  /** Drives the real drag-begin (via a pick) and cancel seams for testing. */
+  private static class TestGizmo extends TranslateGizmo {
+    void seedDrag(final Vector2 mouse, final Camera camera, final InteractManager manager) {
+      // Mirror what the input trigger does before a widget sees input: sync state from the target.
+      manager.getSpatialState().copyState(manager.getSpatialTarget());
+      findPick(mouse, camera);
+      beginDrag(manager, new MouseState((int) mouse.getX(), (int) mouse.getY(), 0, 0, 0, null, null));
+      setDragState(DragState.DRAG);
+    }
+
+    boolean cancelIfEsc(final KeyboardState keys, final InteractManager manager) {
+      return cancelDragIfRequested(keys, new MouseState(0, 0, 0, 0, 0, null, null), new AtomicBoolean(false), manager);
+    }
+
+    boolean hasSnapshot() { return _hasDragStartTransform; }
+  }
+
+  @Before
+  public void setup() {
+    _target = new Node("target");
+    _target.setTranslation(5, 2, -3);
+    _target.updateGeometricState(0);
+
+    _manager = new InteractManager();
+    _gizmo = new TestGizmo();
+    _gizmo.withAllHandles();
+    _manager.addWidget(_gizmo);
+    _manager.setSpatialTarget(_target);
+
+    // Camera looking straight at the target, so a ray through the screen center strikes the gizmo.
+    _camera = new Camera(100, 100);
+    _camera.setFrustumPerspective(90, 1, 1, 1000);
+    _camera.setLocation(5, 2, 7);
+    _camera.lookAt(5, 2, -3, Vector3.UNIT_Y);
+
+    _gizmo.getHandle().setTranslation(_target.getWorldTranslation());
+    _gizmo.getHandle().updateGeometricState(0);
+  }
+
+  private static KeyboardState keys(final Key... down) {
+    final EnumSet<Key> set = EnumSet.noneOf(Key.class);
+    for (final Key key : down) {
+      set.add(key);
+    }
+    return new KeyboardState(set, null);
+  }
+
+  @Test
+  public void testEscapeCancelsDragAndRestoresPreDragTransform() {
+    _gizmo.seedDrag(new Vector2(50, 50), _camera, _manager);
+    assertTrue("a handle should have been picked at the gizmo center", _gizmo.getDragState() != DragState.NONE);
+    assertTrue("the pre-drag transform should be snapshotted", _gizmo.hasSnapshot());
+
+    // Simulate the drag having moved the target well away from where it started.
+    _target.setTranslation(20, -8, 14);
+    _target.updateGeometricState(0);
+
+    final boolean cancelled = _gizmo.cancelIfEsc(keys(Key.ESCAPE), _manager);
+
+    assertTrue("Escape during a drag should cancel it", cancelled);
+    assertEquals("the drag should have ended", DragState.NONE, _gizmo.getDragState());
+    assertEquals(5.0, _target.getTranslation().getX(), EPS);
+    assertEquals(2.0, _target.getTranslation().getY(), EPS);
+    assertEquals(-3.0, _target.getTranslation().getZ(), EPS);
+  }
+
+  @Test
+  public void testEscapeWithoutADragDoesNothing() {
+    final boolean cancelled = _gizmo.cancelIfEsc(keys(Key.ESCAPE), _manager);
+    assertFalse("Escape with no active drag is not a cancel", cancelled);
+    assertEquals(DragState.NONE, _gizmo.getDragState());
+  }
+
+  @Test
+  public void testDragContinuesWhenEscapeIsNotHeld() {
+    _gizmo.seedDrag(new Vector2(50, 50), _camera, _manager);
+    final boolean cancelled = _gizmo.cancelIfEsc(keys(), _manager);
+    assertFalse("no cancel without Escape", cancelled);
+    assertTrue("the drag should still be active", _gizmo.getDragState() != DragState.NONE);
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoCancelDragTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoCancelDragTest.java
@@ -27,6 +27,7 @@ import com.ardor3d.input.keyboard.KeyboardState;
 import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.math.Vector2;
 import com.ardor3d.math.Vector3;
+import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.renderer.Camera;
 import com.ardor3d.scenegraph.Node;
 
@@ -37,7 +38,7 @@ import com.ardor3d.scenegraph.Node;
  */
 public class GizmoCancelDragTest {
 
-  private static final double EPS = 1e-9;
+  private static final double EPS = MathUtils.ZERO_TOLERANCE;
 
   private Node _target;
   private InteractManager _manager;

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoCursorFeedbackTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoCursorFeedbackTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.widget.SetCursorCallback;
+import com.ardor3d.input.mouse.MouseCursor;
+
+/**
+ * The opt-in cursor feedback: a gizmo wires a {@link SetCursorCallback} for the shared
+ * {@link AbstractGizmo#DEFAULT_CURSOR} when one is set, and none when it is not.
+ */
+public class GizmoCursorFeedbackTest {
+
+  @After
+  public void clearDefaultCursor() {
+    // Static opt-in - reset so it does not leak into other tests in the same JVM.
+    AbstractGizmo.DEFAULT_CURSOR = null;
+  }
+
+  @Test
+  public void testDefaultCursorWiresMouseOverCallback() {
+    AbstractGizmo.DEFAULT_CURSOR = MouseCursor.SYSTEM_DEFAULT;
+    final TranslateGizmo gizmo = new TranslateGizmo();
+    assertTrue("a set DEFAULT_CURSOR should wire a SetCursorCallback",
+        gizmo.getMouseOverCallback() instanceof SetCursorCallback);
+  }
+
+  @Test
+  public void testNoDefaultCursorLeavesCallbackUnset() {
+    AbstractGizmo.DEFAULT_CURSOR = null;
+    final TranslateGizmo gizmo = new TranslateGizmo();
+    assertNull("no DEFAULT_CURSOR should leave the mouse-over callback unset", gizmo.getMouseOverCallback());
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoDragFocusTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoDragFocusTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.FloatBuffer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.widget.DragState;
+import com.ardor3d.scenegraph.Line;
+import com.ardor3d.scenegraph.hint.CullHint;
+
+/**
+ * Headless tests of the drag-focus axis guide gating: the guide line shows along the dragged axis
+ * during a single-axis drag and stays hidden for plane, center and ring drags or when idle. The
+ * alpha dim of the inactive handles is a rendered effect, covered by the GL gizmo smoke test.
+ */
+public class GizmoDragFocusTest {
+
+  private static final double EPS = 1e-9;
+  private static final float L = (float) AbstractGizmo.AXIS_GUIDE_HALF_LENGTH;
+
+  private TestGizmo _gizmo;
+
+  /** Forces a drag on a chosen handle (no GL / picking) and exposes the guide refresh. */
+  private static class TestGizmo extends TranslateGizmo {
+    void forceDrag(final GizmoPart part) {
+      for (final GizmoHandle handle : getGizmoHandles()) {
+        if (handle.getPart() == part) {
+          _lastDragSpatial = handle.getMeshes().get(0);
+          setDragState(DragState.DRAG);
+          return;
+        }
+      }
+      throw new IllegalArgumentException("no handle for " + part);
+    }
+
+    void refreshGuide() {
+      updateAxisGuide();
+    }
+  }
+
+  @Before
+  public void setup() {
+    _gizmo = new TestGizmo();
+    _gizmo.withAllHandles();
+  }
+
+  private CullHint guideCull() {
+    return _gizmo.getAxisGuide().getSceneHints().getCullHint();
+  }
+
+  @Test
+  public void testAxisDragShowsGuideAlongThatAxis() {
+    // Y so the endpoints prove a real reorient off the guide's built-along-X rest state.
+    _gizmo.forceDrag(GizmoPart.AxisY);
+    _gizmo.refreshGuide();
+
+    assertEquals(CullHint.Never, guideCull());
+    final Line guide = _gizmo.getAxisGuide();
+    final FloatBuffer verts = guide.getMeshData().getVertexBuffer();
+    assertEquals(0.0f, verts.get(0), EPS);
+    assertEquals(-L, verts.get(1), EPS);
+    assertEquals(0.0f, verts.get(2), EPS);
+    assertEquals(0.0f, verts.get(3), EPS);
+    assertEquals(L, verts.get(4), EPS);
+    assertEquals(0.0f, verts.get(5), EPS);
+  }
+
+  @Test
+  public void testPlaneDragHidesGuide() {
+    _gizmo.forceDrag(GizmoPart.PlaneXY);
+    _gizmo.refreshGuide();
+    assertEquals(CullHint.Always, guideCull());
+  }
+
+  @Test
+  public void testCenterDragHidesGuide() {
+    _gizmo.forceDrag(GizmoPart.Center);
+    _gizmo.refreshGuide();
+    assertEquals(CullHint.Always, guideCull());
+  }
+
+  @Test
+  public void testGuideHiddenWhenIdle() {
+    _gizmo.refreshGuide();
+    assertEquals(CullHint.Always, guideCull());
+  }
+
+  @Test
+  public void testGuideHidesAgainAfterAxisDragEnds() {
+    _gizmo.forceDrag(GizmoPart.AxisX);
+    _gizmo.refreshGuide();
+    assertEquals(CullHint.Never, guideCull());
+
+    _gizmo.setDragState(DragState.NONE);
+    _gizmo.refreshGuide();
+    assertEquals(CullHint.Always, guideCull());
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoDragFocusTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoDragFocusTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.ardor3d.extension.interact.widget.DragState;
+import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.scenegraph.Line;
 import com.ardor3d.scenegraph.hint.CullHint;
 
@@ -28,7 +29,7 @@ import com.ardor3d.scenegraph.hint.CullHint;
  */
 public class GizmoDragFocusTest {
 
-  private static final double EPS = 1e-9;
+  private static final double EPS = MathUtils.ZERO_TOLERANCE;
   private static final float L = (float) AbstractGizmo.AXIS_GUIDE_HALF_LENGTH;
 
   private TestGizmo _gizmo;

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMathTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoMathTest.java
@@ -193,4 +193,53 @@ public class GizmoMathTest {
     assertEquals(1.0, GizmoMath.fadeAlpha(full, hide, full), EPS);
     assertEquals(1.0, GizmoMath.fadeAlpha(MathUtils.HALF_PI, hide, full), EPS);
   }
+
+  // --- approach ---
+
+  @Test
+  public void testApproachSnapsWhenTauNonPositive() {
+    assertEquals(5.0, GizmoMath.approach(2.0, 5.0, 0.016, 0.0), EPS);
+    assertEquals(5.0, GizmoMath.approach(2.0, 5.0, 0.016, -1.0), EPS);
+  }
+
+  @Test
+  public void testApproachUnchangedWhenNoTimePasses() {
+    assertEquals(2.0, GizmoMath.approach(2.0, 5.0, 0.0, 0.05), EPS);
+    assertEquals(2.0, GizmoMath.approach(2.0, 5.0, -0.01, 0.05), EPS);
+  }
+
+  @Test
+  public void testApproachCoversOneMinusInverseEAfterOneTau() {
+    // After dt == tau, exactly (1 - 1/e) of the gap toward the target is covered.
+    assertEquals(1.0 - 1.0 / Math.E, GizmoMath.approach(0.0, 1.0, 0.05, 0.05), 1e-12);
+  }
+
+  @Test
+  public void testApproachConvergesMonotonicallyWithoutOvershoot() {
+    double v = 0.0;
+    for (int i = 0; i < 100; i++) {
+      final double next = GizmoMath.approach(v, 1.0, 0.016, 0.05);
+      assertTrue("must not overshoot the target", next <= 1.0 + EPS);
+      assertTrue("must move toward the target", next >= v);
+      v = next;
+    }
+    assertEquals("should be nearly converged after ~1.6s at tau=0.05", 1.0, v, 1e-6);
+  }
+
+  @Test
+  public void testApproachIsSymmetricDecreasing() {
+    // Falling toward a target mirrors rising toward it.
+    final double up = GizmoMath.approach(0.0, 1.0, 0.05, 0.05);
+    final double down = GizmoMath.approach(1.0, 0.0, 0.05, 0.05);
+    assertEquals(up, 1.0 - down, 1e-12);
+  }
+
+  @Test
+  public void testApproachIsFrameRateIndependent() {
+    // One step of 0.1s lands where two steps of 0.05s do - exponential smoothing composes.
+    final double oneBig = GizmoMath.approach(0.0, 1.0, 0.1, 0.05);
+    double two = GizmoMath.approach(0.0, 1.0, 0.05, 0.05);
+    two = GizmoMath.approach(two, 1.0, 0.05, 0.05);
+    assertEquals(oneBig, two, 1e-12);
+  }
 }

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoOriginGhostTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoOriginGhostTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.widget.DragState;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.math.type.ReadOnlyVector3;
+import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.hint.CullHint;
+
+/**
+ * Headless tests of the origin-ghost gating and placement: the faint start-point marker appears
+ * only during a drag that has actually moved the gizmo origin (a translate drag), and anchors at
+ * the captured start position. The ghost's rendered appearance is covered by the interactive probe.
+ */
+public class GizmoOriginGhostTest {
+
+  private static final double EPS = MathUtils.ZERO_TOLERANCE;
+
+  /** Drives the origin ghost headlessly (no GL / picking). */
+  private static class GhostProbe extends TranslateGizmo {
+    void forceDrag(final double sx, final double sy, final double sz) {
+      _dragStartWorldTranslation.set(sx, sy, sz);
+      _hasOriginGhost = true;
+      setDragState(DragState.DRAG);
+    }
+
+    /** Move the gizmo origin, standing in for render()'s per-frame follow of the target. */
+    void setOrigin(final double x, final double y, final double z) {
+      getHandle().setTranslation(x, y, z);
+      getHandle().updateGeometricState(0);
+    }
+
+    void ghost(final Camera camera) {
+      updateOriginGhost(camera);
+    }
+
+    Node ghostNode() {
+      return _originGhost;
+    }
+  }
+
+  private static Camera threeQuarterCamera() {
+    final Camera camera = new Camera(100, 100);
+    camera.setFrustumPerspective(90, 1, 1, 1000);
+    camera.setLocation(0, 5, 10);
+    camera.lookAt(0, 0, 0, Vector3.UNIT_Y);
+    return camera;
+  }
+
+  private static void assertVectorEquals(final double x, final double y, final double z, final ReadOnlyVector3 v) {
+    assertEquals(x, v.getX(), EPS);
+    assertEquals(y, v.getY(), EPS);
+    assertEquals(z, v.getZ(), EPS);
+  }
+
+  @Test
+  public void testGhostHiddenWhenNotDragging() {
+    final GhostProbe gizmo = new GhostProbe();
+    gizmo.withAllHandles();
+    final Camera camera = threeQuarterCamera();
+    gizmo.setOrigin(5, 0, 0);
+    gizmo.ghost(camera);
+    assertEquals(CullHint.Always, gizmo.ghostNode().getSceneHints().getCullHint());
+  }
+
+  @Test
+  public void testGhostShownAndAnchoredWhenOriginMoved() {
+    final GhostProbe gizmo = new GhostProbe();
+    gizmo.withAllHandles();
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceDrag(0, 0, 0);
+    gizmo.setOrigin(5, 0, 0); // dragged 5 units along +X
+    gizmo.ghost(camera);
+    assertEquals(CullHint.Never, gizmo.ghostNode().getSceneHints().getCullHint());
+    // The ghost anchors at the captured drag-start origin, not the current one.
+    assertVectorEquals(0, 0, 0, gizmo.ghostNode().getTranslation());
+  }
+
+  @Test
+  public void testGhostHiddenWhenOriginUnmoved() {
+    // A rotate or scale drag never moves the origin, so the ghost stays hidden.
+    final GhostProbe gizmo = new GhostProbe();
+    gizmo.withAllHandles();
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceDrag(2, 3, 4);
+    gizmo.setOrigin(2, 3, 4); // origin unchanged from the start
+    gizmo.ghost(camera);
+    assertEquals(CullHint.Always, gizmo.ghostNode().getSceneHints().getCullHint());
+  }
+
+  @Test
+  public void testGhostRespectsDisableFlag() {
+    final GhostProbe gizmo = new GhostProbe();
+    gizmo.withAllHandles();
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceDrag(0, 0, 0);
+    gizmo.setOrigin(5, 0, 0);
+    gizmo.setShowOriginGhost(false);
+    gizmo.ghost(camera);
+    assertEquals(CullHint.Always, gizmo.ghostNode().getSceneHints().getCullHint());
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoReadoutTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoReadoutTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Locale;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -102,6 +104,27 @@ public class GizmoReadoutTest {
     final String moved = _gizmo.readout(_manager);
     assertNotNull(moved);
     assertNotEquals("readout tracks the moving target", atStart, moved);
+  }
+
+  @Test
+  public void testBuiltInReadoutIsLocaleIndependent() {
+    // The built-in delta text uses ", " between components, so a comma-decimal locale must not turn
+    // the decimals into commas and collide with the delimiters. Formatting is pinned to a fixed
+    // locale, so the output stays dot-decimal whatever the JVM default is.
+    final Locale previous = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.GERMANY); // comma as the decimal separator
+      _gizmo.seedDrag(new Vector2(50, 50), _camera, _manager);
+      _target.setTranslation(6.5, 2, -3); // dx = 1.5 from the (5, 2, -3) start
+      _target.updateGeometricState(0);
+
+      final String readout = _gizmo.readout(_manager);
+      assertTrue("built-in readout should use dot decimals regardless of locale: " + readout,
+          readout.contains("+1.50"));
+      assertEquals("exactly two component delimiters", 2, readout.chars().filter(c -> c == ',').count());
+    } finally {
+      Locale.setDefault(previous);
+    }
   }
 
   @Test

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoReadoutTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoReadoutTest.java
@@ -24,6 +24,7 @@ import com.ardor3d.extension.interact.widget.DragState;
 import com.ardor3d.input.mouse.MouseState;
 import com.ardor3d.math.Vector2;
 import com.ardor3d.math.Vector3;
+import com.ardor3d.math.util.MathUtils;
 import com.ardor3d.renderer.Camera;
 import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.hint.CullHint;
@@ -35,7 +36,7 @@ import com.ardor3d.scenegraph.hint.CullHint;
  */
 public class GizmoReadoutTest {
 
-  private static final double EPS = 1e-9;
+  private static final double EPS = MathUtils.ZERO_TOLERANCE;
 
   private Node _target;
   private InteractManager _manager;

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoReadoutTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoReadoutTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.InteractManager;
+import com.ardor3d.extension.interact.widget.DragState;
+import com.ardor3d.input.mouse.MouseState;
+import com.ardor3d.math.Vector2;
+import com.ardor3d.math.Vector3;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.scenegraph.Node;
+import com.ardor3d.scenegraph.hint.CullHint;
+
+/**
+ * Headless tests of the shared drag readout's content and gating, on the translate gizmo:
+ * getReadoutText is null unless a drag is active and reflects the delta from the drag's start once
+ * it is. On-screen positioning needs the current camera and is covered by the GL gizmo smoke test.
+ */
+public class GizmoReadoutTest {
+
+  private static final double EPS = 1e-9;
+
+  private Node _target;
+  private InteractManager _manager;
+  private TestGizmo _gizmo;
+  private Camera _camera;
+
+  /** Drives a real pick-started drag (no GL) and exposes the readout content. */
+  private static class TestGizmo extends TranslateGizmo {
+    void seedDrag(final Vector2 mouse, final Camera camera, final InteractManager manager) {
+      manager.getSpatialState().copyState(manager.getSpatialTarget());
+      findPick(mouse, camera);
+      beginDrag(manager, new MouseState((int) mouse.getX(), (int) mouse.getY(), 0, 0, 0, null, null));
+      setDragState(DragState.DRAG);
+    }
+
+    String readout(final InteractManager manager) {
+      return getReadoutText(manager);
+    }
+  }
+
+  @Before
+  public void setup() {
+    _target = new Node("target");
+    _target.setTranslation(5, 2, -3);
+    _target.updateGeometricState(0);
+
+    _manager = new InteractManager();
+    _gizmo = new TestGizmo();
+    _gizmo.withAllHandles();
+    _manager.addWidget(_gizmo);
+    _manager.setSpatialTarget(_target);
+
+    _camera = new Camera(100, 100);
+    _camera.setFrustumPerspective(90, 1, 1, 1000);
+    _camera.setLocation(5, 2, 7);
+    _camera.lookAt(5, 2, -3, Vector3.UNIT_Y);
+
+    _gizmo.getHandle().setTranslation(_target.getWorldTranslation());
+    _gizmo.getHandle().updateGeometricState(0);
+  }
+
+  @Test
+  public void testReadoutHiddenInitially() {
+    assertEquals(CullHint.Always, _gizmo.getReadout().getSceneHints().getCullHint());
+  }
+
+  @Test
+  public void testReadoutNullWithoutADrag() {
+    assertNull("no readout without a drag", _gizmo.readout(_manager));
+  }
+
+  @Test
+  public void testReadoutReflectsTranslationDeltaDuringDrag() {
+    _gizmo.seedDrag(new Vector2(50, 50), _camera, _manager);
+    final String atStart = _gizmo.readout(_manager);
+    assertNotNull("readout shows during a drag", atStart);
+    // ASCII only (no delta glyph in the readout font); a three-component vector.
+    assertTrue("readout is a vector", atStart.chars().filter(c -> c == ',').count() == 2);
+
+    // Move the target: the readout must change to reflect the new delta from the drag start.
+    _target.setTranslation(9, 2, 1);
+    _target.updateGeometricState(0);
+    final String moved = _gizmo.readout(_manager);
+    assertNotNull(moved);
+    assertNotEquals("readout tracks the moving target", atStart, moved);
+  }
+
+  @Test
+  public void testReadoutNullAfterDragEnds() {
+    _gizmo.seedDrag(new Vector2(50, 50), _camera, _manager);
+    assertNotNull(_gizmo.readout(_manager));
+    _gizmo.endDrag(_manager, null);
+    assertNull("no readout once the drag ends", _gizmo.readout(_manager));
+  }
+
+  @Test
+  public void testFormatterOverridesDefaultAndReceivesDeltaAndPosition() {
+    final double[] got = new double[6]; // dx, dy, dz, px, py, pz
+    _gizmo.setReadoutFormatter((delta, position, manager) -> {
+      got[0] = delta.getX();
+      got[1] = delta.getY();
+      got[2] = delta.getZ();
+      got[3] = position.getX();
+      got[4] = position.getY();
+      got[5] = position.getZ();
+      return "custom";
+    });
+
+    _gizmo.seedDrag(new Vector2(50, 50), _camera, _manager);
+    _target.setTranslation(9, 2, 1); // from (5, 2, -3): delta (4, 0, 4), position (9, 2, 1)
+    _target.updateGeometricState(0);
+
+    assertEquals("formatter overrides the built-in text", "custom", _gizmo.readout(_manager));
+    assertEquals(4.0, got[0], EPS);
+    assertEquals(0.0, got[1], EPS);
+    assertEquals(4.0, got[2], EPS);
+    assertEquals(9.0, got[3], EPS);
+    assertEquals(2.0, got[4], EPS);
+    assertEquals(1.0, got[5], EPS);
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoSnapTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoSnapTest.java
@@ -18,7 +18,12 @@ import org.junit.Test;
 
 import com.ardor3d.extension.interact.filter.AngleSnapFilter;
 import com.ardor3d.extension.interact.filter.GridSnapFilter;
+import com.ardor3d.extension.interact.widget.DragState;
+import com.ardor3d.math.Vector3;
 import com.ardor3d.math.util.MathUtils;
+import com.ardor3d.renderer.Camera;
+import com.ardor3d.scenegraph.Mesh;
+import com.ardor3d.scenegraph.hint.CullHint;
 
 /**
  * Headless tests of the snap-tick wiring: the snap filters report themselves as SnapSources, and a
@@ -34,6 +39,96 @@ public class GizmoSnapTest {
     double snapIncrement() {
       return activeSnapIncrement();
     }
+  }
+
+  /** Drives translate snap ticks headlessly (no GL / picking). */
+  private static class TranslateProbe extends TranslateGizmo {
+    void forceAxisDrag() {
+      for (final GizmoHandle handle : getGizmoHandles()) {
+        if (handle.getPart() == GizmoPart.AxisX) {
+          _lastDragSpatial = handle.getMeshes().get(0);
+          setDragState(DragState.DRAG);
+          return;
+        }
+      }
+    }
+
+    void ticks(final Camera camera) {
+      updateSnapTicks(camera);
+    }
+
+    Mesh tickMesh() {
+      return _snapTicks;
+    }
+  }
+
+  private static Camera threeQuarterCamera() {
+    final Camera camera = new Camera(100, 100);
+    camera.setFrustumPerspective(90, 1, 1, 1000);
+    camera.setLocation(0, 5, 10);
+    camera.lookAt(0, 0, 0, Vector3.UNIT_Y);
+    return camera;
+  }
+
+  @Test
+  public void testTranslateTicksShowOnlyWhileSnappingAnAxisDrag() {
+    final TranslateProbe gizmo = new TranslateProbe();
+    gizmo.withAllHandles();
+    gizmo.getHandle().setScale(1.0);
+    gizmo.getHandle().updateGeometricState(0);
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceAxisDrag();
+
+    // Dragging an axis, but no snap filter -> ticks stay hidden.
+    gizmo.ticks(camera);
+    assertEquals(CullHint.Always, gizmo.tickMesh().getSceneHints().getCullHint());
+
+    // With grid snap active, the ticks appear along the axis.
+    gizmo.addFilter(new GridSnapFilter(1.0));
+    gizmo.ticks(camera);
+    assertEquals(CullHint.Never, gizmo.tickMesh().getSceneHints().getCullHint());
+    assertTrue("ticks should have geometry", gizmo.tickMesh().getMeshData().getVertexCount() > 0);
+  }
+
+  @Test
+  public void testTranslateTicksFadeOutWhenGridTooDenseOnScreen() {
+    final TranslateProbe gizmo = new TranslateProbe();
+    gizmo.withAllHandles();
+    gizmo.getHandle().updateGeometricState(0);
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceAxisDrag();
+    gizmo.addFilter(new GridSnapFilter(1.0));
+
+    // Normal zoom (scale 1): a 1-unit grid is ~100px on screen, so the ticks show.
+    gizmo.getHandle().setScale(1.0);
+    gizmo.getHandle().updateGeometricState(0);
+    gizmo.ticks(camera);
+    assertEquals(CullHint.Never, gizmo.tickMesh().getSceneHints().getCullHint());
+
+    // Zoomed way out (large gizmo scale): the grid is sub-threshold on screen, so ticks hide.
+    gizmo.getHandle().setScale(500.0);
+    gizmo.getHandle().updateGeometricState(0);
+    gizmo.ticks(camera);
+    assertEquals(CullHint.Always, gizmo.tickMesh().getSceneHints().getCullHint());
+  }
+
+  @Test
+  public void testTranslateSnapPulsesWhenTheSnappedPositionSteps() {
+    final TranslateProbe gizmo = new TranslateProbe();
+    gizmo.withAllHandles();
+    gizmo.getHandle().setScale(1.0);
+    gizmo.getHandle().updateGeometricState(0);
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceAxisDrag();
+    gizmo.addFilter(new GridSnapFilter(1.0));
+
+    // First frame records the position; no pulse yet.
+    gizmo.ticks(camera);
+    // A step to a new grid cell re-arms the pulse.
+    gizmo.getHandle().setTranslation(1, 0, 0);
+    gizmo.getHandle().updateGeometricState(0);
+    gizmo.ticks(camera);
+    assertTrue("stepping to a new grid cell pulses", gizmo.getSnapPulse() > 0.5);
   }
 
   @Test

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoSnapTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoSnapTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.extension.interact.widget.gizmo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ardor3d.extension.interact.filter.AngleSnapFilter;
+import com.ardor3d.extension.interact.filter.GridSnapFilter;
+import com.ardor3d.math.util.MathUtils;
+
+/**
+ * Headless tests of the snap-tick wiring: the snap filters report themselves as SnapSources, and a
+ * gizmo finds the active snap increment from its filters. The tick geometry and pulse are rendered
+ * effects, covered by the interactive probe.
+ */
+public class GizmoSnapTest {
+
+  private static final double EPS = MathUtils.ZERO_TOLERANCE;
+
+  /** Exposes the protected snap lookup. */
+  private static class TestGizmo extends RotateGizmo {
+    double snapIncrement() {
+      return activeSnapIncrement();
+    }
+  }
+
+  @Test
+  public void testAngleSnapFilterIsSnapSource() {
+    final AngleSnapFilter filter = new AngleSnapFilter(15 * MathUtils.DEG_TO_RAD);
+    assertTrue(filter.isSnapping());
+    assertEquals(15 * MathUtils.DEG_TO_RAD, filter.getSnapIncrement(), EPS);
+    filter.setEnabled(false);
+    assertFalse("disabled filter does not snap", filter.isSnapping());
+  }
+
+  @Test
+  public void testGridSnapFilterIsSnapSource() {
+    final GridSnapFilter filter = new GridSnapFilter(2.0);
+    assertTrue(filter.isSnapping());
+    assertEquals(2.0, filter.getSnapIncrement(), EPS);
+    filter.setEnabled(false);
+    assertFalse("disabled filter does not snap", filter.isSnapping());
+  }
+
+  @Test
+  public void testActiveSnapIncrementFindsEnabledSnapFilter() {
+    final TestGizmo gizmo = new TestGizmo();
+    gizmo.withAllHandles();
+    assertEquals("no snap filter attached", 0.0, gizmo.snapIncrement(), EPS);
+
+    final AngleSnapFilter filter = new AngleSnapFilter(0.5);
+    gizmo.addFilter(filter);
+    assertEquals(0.5, gizmo.snapIncrement(), EPS);
+
+    filter.setEnabled(false);
+    assertEquals("disabled snap reports no increment", 0.0, gizmo.snapIncrement(), EPS);
+  }
+}

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoSnapTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/GizmoSnapTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import com.ardor3d.extension.interact.filter.AngleSnapFilter;
 import com.ardor3d.extension.interact.filter.GridSnapFilter;
+import com.ardor3d.extension.interact.filter.ScaleSnapFilter;
 import com.ardor3d.extension.interact.widget.DragState;
 import com.ardor3d.math.Vector3;
 import com.ardor3d.math.util.MathUtils;
@@ -51,6 +52,32 @@ public class GizmoSnapTest {
           return;
         }
       }
+    }
+
+    void ticks(final Camera camera) {
+      updateSnapTicks(camera);
+    }
+
+    Mesh tickMesh() {
+      return _snapTicks;
+    }
+  }
+
+  /** Drives scale snap ticks headlessly (no GL / picking). */
+  private static class ScaleProbe extends ScaleGizmo {
+    void forceAxisDrag() {
+      for (final GizmoHandle handle : getGizmoHandles()) {
+        if (handle.getPart() == GizmoPart.AxisX) {
+          _lastDragSpatial = handle.getMeshes().get(0);
+          setDragState(DragState.DRAG);
+          return;
+        }
+      }
+    }
+
+    /** Set the dragged axis' applied factor directly - normally captured from the state in render. */
+    void setActiveFactor(final double factor) {
+      _snapActiveFactor = factor;
     }
 
     void ticks(final Camera camera) {
@@ -147,6 +174,76 @@ public class GizmoSnapTest {
     assertEquals(2.0, filter.getSnapIncrement(), EPS);
     filter.setEnabled(false);
     assertFalse("disabled filter does not snap", filter.isSnapping());
+  }
+
+  @Test
+  public void testScaleSnapFilterIsSnapSource() {
+    final ScaleSnapFilter filter = new ScaleSnapFilter(0.25);
+    assertTrue(filter.isSnapping());
+    assertEquals(0.25, filter.getSnapIncrement(), EPS);
+    filter.setEnabled(false);
+    assertFalse("disabled filter does not snap", filter.isSnapping());
+  }
+
+  @Test
+  public void testScaleTicksShowOnlyWhileSnappingAnAxisDrag() {
+    final ScaleProbe gizmo = new ScaleProbe();
+    gizmo.withAllHandles();
+    gizmo.getHandle().setScale(1.0);
+    gizmo.getHandle().updateGeometricState(0);
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceAxisDrag();
+
+    // Dragging an axis, but no snap filter -> ticks stay hidden.
+    gizmo.ticks(camera);
+    assertEquals(CullHint.Always, gizmo.tickMesh().getSceneHints().getCullHint());
+
+    // With scale snap active, the ticks appear along the axis.
+    gizmo.addFilter(new ScaleSnapFilter(0.25));
+    gizmo.ticks(camera);
+    assertEquals(CullHint.Never, gizmo.tickMesh().getSceneHints().getCullHint());
+    assertTrue("ticks should have geometry", gizmo.tickMesh().getMeshData().getVertexCount() > 0);
+  }
+
+  @Test
+  public void testScaleTicksFadeOutWhenStepTooFineOnScreen() {
+    final ScaleProbe gizmo = new ScaleProbe();
+    gizmo.withAllHandles();
+    gizmo.getHandle().setScale(1.0);
+    gizmo.getHandle().updateGeometricState(0);
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceAxisDrag();
+
+    // A quarter step spans ~22px between ticks on screen (the factor grid is fixed to the gizmo's
+    // pixel footprint, not the camera distance), so the ticks show.
+    gizmo.addFilter(new ScaleSnapFilter(0.25));
+    gizmo.ticks(camera);
+    assertEquals(CullHint.Never, gizmo.tickMesh().getSceneHints().getCullHint());
+
+    // A tiny 0.02 step packs the ticks a couple of pixels apart: sub-threshold, so they hide.
+    gizmo.clearFilters();
+    gizmo.addFilter(new ScaleSnapFilter(0.02));
+    gizmo.ticks(camera);
+    assertEquals(CullHint.Always, gizmo.tickMesh().getSceneHints().getCullHint());
+  }
+
+  @Test
+  public void testScaleSnapPulsesWhenTheSnappedFactorSteps() {
+    final ScaleProbe gizmo = new ScaleProbe();
+    gizmo.withAllHandles();
+    gizmo.getHandle().setScale(1.0);
+    gizmo.getHandle().updateGeometricState(0);
+    final Camera camera = threeQuarterCamera();
+    gizmo.forceAxisDrag();
+    gizmo.addFilter(new ScaleSnapFilter(0.25));
+
+    // First frame records the factor step; no pulse yet.
+    gizmo.setActiveFactor(1.0);
+    gizmo.ticks(camera);
+    // Stepping to the next quarter re-arms the pulse.
+    gizmo.setActiveFactor(1.25);
+    gizmo.ticks(camera);
+    assertTrue("stepping to a new factor pulses", gizmo.getSnapPulse() > 0.5);
   }
 
   @Test

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmoDragTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/ScaleGizmoDragTest.java
@@ -33,7 +33,7 @@ import com.ardor3d.scenegraph.Node;
  */
 public class ScaleGizmoDragTest {
 
-  private static final double EPS = 1e-9;
+  private static final double EPS = MathUtils.ZERO_TOLERANCE;
 
   private Node _target;
   private InteractManager _manager;

--- a/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmoDragTest.java
+++ b/ardor3d-extras/src/test/java/com/ardor3d/extension/interact/widget/gizmo/TranslateGizmoDragTest.java
@@ -34,7 +34,7 @@ import com.ardor3d.scenegraph.Node;
  */
 public class TranslateGizmoDragTest {
 
-  private static final double EPS = 1e-9;
+  private static final double EPS = MathUtils.ZERO_TOLERANCE;
 
   private Node _parent;
   private Node _target;

--- a/ardor3d-lwjgl3/src/main/java/com/ardor3d/framework/lwjgl3/GLFWCanvas.java
+++ b/ardor3d-lwjgl3/src/main/java/com/ardor3d/framework/lwjgl3/GLFWCanvas.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -38,6 +38,7 @@ import com.ardor3d.image.Image;
 import com.ardor3d.image.ImageDataFormat;
 import com.ardor3d.image.PixelDataType;
 import com.ardor3d.input.focus.FocusWrapper;
+import com.ardor3d.input.glfw.GLFWMouseManager;
 import com.ardor3d.input.mouse.MouseManager;
 import com.ardor3d.util.Ardor3dException;
 import com.ardor3d.util.Constants;
@@ -202,6 +203,10 @@ public class GLFWCanvas implements NativeCanvas, FocusWrapper {
 
   @Override
   public void close() {
+    // Destroy any cached native cursors while the window (and GLFW) are still up.
+    if (_manager instanceof GLFWMouseManager) {
+      ((GLFWMouseManager) _manager).cleanup();
+    }
     if (_windowId != 0) {
       Callbacks.glfwFreeCallbacks(_windowId);
       GLFW.glfwDestroyWindow(_windowId);

--- a/ardor3d-lwjgl3/src/main/java/com/ardor3d/input/glfw/GLFWMouseManager.java
+++ b/ardor3d-lwjgl3/src/main/java/com/ardor3d/input/glfw/GLFWMouseManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008-2024 Bird Dog Games, Inc.
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
  *
  * This file is part of Ardor3D.
  *
@@ -10,8 +10,13 @@
 
 package com.ardor3d.input.glfw;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWImage;
+import org.lwjgl.system.MemoryStack;
 
 import com.ardor3d.framework.lwjgl3.GLFWCanvas;
 import com.ardor3d.input.mouse.GrabbedState;
@@ -20,9 +25,25 @@ import com.ardor3d.input.mouse.MouseManager;
 
 public class GLFWMouseManager implements MouseManager {
 
+  private static final Logger logger = Logger.getLogger(GLFWMouseManager.class.getName());
+
   private final GLFWCanvas _canvas;
 
   private GrabbedState _grabbedState;
+
+  /**
+   * Native GLFW cursor handle per {@link MouseCursor}, so a repeated setCursor reuses the handle
+   * instead of creating (and leaking) a fresh one every call. GLFW cursor objects are
+   * process-global, not window-bound, so they survive resizes; they are dropped if the window they
+   * were built under is gone (see the window-change guard in {@link #setCursor}) and destroyed by
+   * {@link #cleanup()}.
+   */
+  private final Map<MouseCursor, Long> _cursorCache = new HashMap<>();
+  /** The window id the cached handles were created under; a change means the old GLFW context, and
+   * with it those handles, are gone. */
+  private long _cacheWindowId = 0;
+  /** The cursor currently applied to the window, to skip redundant native calls. */
+  private MouseCursor _currentCursor;
 
   public GLFWMouseManager(final GLFWCanvas canvas) {
     _canvas = canvas;
@@ -30,16 +51,81 @@ public class GLFWMouseManager implements MouseManager {
 
   @Override
   public void setCursor(final MouseCursor cursor) {
-    if (cursor == MouseCursor.SYSTEM_DEFAULT || cursor == null) {
-      GLFW.glfwSetCursor(_canvas.getWindowId(), 0);
+    final long windowId = _canvas.getWindowId();
+    if (windowId == 0) {
+      // No window (not created yet, or already closed) - nothing to apply a cursor to.
       return;
     }
 
-    final GLFWImage glfwImage = GLFWImage.create();
-    glfwImage.set(cursor.getWidth(), cursor.getHeight(), cursor.getImage().getData(0));
+    // If the window was recreated, GLFW was torn down and rebuilt, so any handles we cached were
+    // freed with it. Drop them WITHOUT destroying (that would double-free) and rebuild under the
+    // new window on demand below.
+    if (windowId != _cacheWindowId) {
+      _cursorCache.clear();
+      _currentCursor = null;
+      _cacheWindowId = windowId;
+    }
 
-    final long cptr = GLFW.glfwCreateCursor(glfwImage, cursor.getHotspotX(), cursor.getHotspotY());
-    GLFW.glfwSetCursor(_canvas.getWindowId(), cptr);
+    if (cursor == _currentCursor) {
+      return;
+    }
+
+    if (cursor == null || cursor == MouseCursor.SYSTEM_DEFAULT) {
+      GLFW.glfwSetCursor(windowId, 0);
+      _currentCursor = cursor;
+      return;
+    }
+
+    Long cached = _cursorCache.get(cursor);
+    if (cached == null) {
+      final long created = createCursor(cursor);
+      if (created == 0) {
+        // Creation failed - leave the current cursor in place rather than blanking it, and do not
+        // cache the failure so a later call can retry.
+        return;
+      }
+      cached = created;
+      _cursorCache.put(cursor, cached);
+    }
+
+    GLFW.glfwSetCursor(windowId, cached);
+    _currentCursor = cursor;
+  }
+
+  /** Create a native GLFW cursor from the given cursor's image, or 0 if GLFW could not create one. */
+  private long createCursor(final MouseCursor cursor) {
+    try (MemoryStack stack = MemoryStack.stackPush()) {
+      final GLFWImage image = GLFWImage.malloc(stack);
+      image.set(cursor.getWidth(), cursor.getHeight(), cursor.getImage().getData(0));
+      final long cptr = GLFW.glfwCreateCursor(image, cursor.getHotspotX(), cursor.getHotspotY());
+      if (cptr == 0) {
+        logger.warning("glfwCreateCursor failed for cursor '" + cursor.getName() + "'");
+      }
+      return cptr;
+    }
+  }
+
+  /**
+   * Destroy every cached native cursor and forget them. Call before the window and GLFW are torn
+   * down ({@link GLFWCanvas#close()} does). Safe to call more than once; a no-op once the window is
+   * already gone, so it never touches native state after GLFW has terminated.
+   */
+  public void cleanup() {
+    if (_canvas.getWindowId() == 0) {
+      // Window (and possibly GLFW) already gone - the handles, if any, went with it. Just forget.
+      _cursorCache.clear();
+      _cacheWindowId = 0;
+      _currentCursor = null;
+      return;
+    }
+    for (final long cptr : _cursorCache.values()) {
+      if (cptr != 0) {
+        GLFW.glfwDestroyCursor(cptr);
+      }
+    }
+    _cursorCache.clear();
+    _cacheWindowId = 0;
+    _currentCursor = null;
   }
 
   @Override

--- a/ardor3d-lwjgl3/src/test/java/com/ardor3d/renderer/lwjgl3/GlGizmoRenderSmokeTest.java
+++ b/ardor3d-lwjgl3/src/test/java/com/ardor3d/renderer/lwjgl3/GlGizmoRenderSmokeTest.java
@@ -147,7 +147,7 @@ public class GlGizmoRenderSmokeTest {
     double dragAngleDeg, readoutDeg, targetAngleDeg;
     // Scale gizmo: shafts at rest, then mid-drag (drag-focus dims the inactive Y/Z shafts).
     int scRestGreen, scRestBlue, scRed, scGreen, scBlue;
-    double targetScaleX;
+    double targetScaleX, scReadout;
 
     void setCanvas(final Canvas canvas) { _canvas = canvas; }
 
@@ -254,7 +254,7 @@ public class GlGizmoRenderSmokeTest {
             rotGreen = _green;
             rotBlue = _blue;
             dragAngleDeg = Math.abs(_rotate.getDragAngle()) * MathUtils.RAD_TO_DEG;
-            readoutDeg = Math.abs(parseReadout(_rotate.getAngleReadout().getText()));
+            readoutDeg = Math.abs(parseReadout(_rotate.getReadout().getText()));
             targetAngleDeg = new Quaternion().fromRotationMatrix(_target.getRotation()).toAngleAxis(new Vector3())
                 * MathUtils.RAD_TO_DEG;
             enter(Phase.SCALE);
@@ -273,6 +273,7 @@ public class GlGizmoRenderSmokeTest {
             scGreen = _green;
             scBlue = _blue;
             targetScaleX = _target.getScale().getX();
+            scReadout = parseReadout(_scale.getReadout().getText());
             enter(Phase.DONE);
             done = true;
           }
@@ -452,7 +453,7 @@ public class GlGizmoRenderSmokeTest {
           + scene.rotGreen + " b=" + scene.rotBlue + " dragAngle=" + scene.dragAngleDeg + " readout=" + scene.readoutDeg
           + " target=" + scene.targetAngleDeg + "]"
           + " scale[rest g=" + scene.scRestGreen + " b=" + scene.scRestBlue + "; drag r=" + scene.scRed + " g="
-          + scene.scGreen + " b=" + scene.scBlue + " sx=" + scene.targetScaleX + "]");
+          + scene.scGreen + " b=" + scene.scBlue + " sx=" + scene.targetScaleX + " readout=" + scene.scReadout + "]");
 
       final String on = " on '" + scene.glRenderer + "'";
 
@@ -479,9 +480,10 @@ public class GlGizmoRenderSmokeTest {
       assertEquals("drag angle and applied target rotation disagree" + on, scene.dragAngleDeg, scene.targetAngleDeg,
           6.0);
 
-      // 4. A +X scale drag grows the target's X scale into a sane range.
+      // 4. A +X scale drag grows the target's X scale into a sane range, and the readout agrees.
       assertTrue("scale drag did not grow target X scale (was " + scene.targetScaleX + ")" + on,
           scene.targetScaleX > 1.1 && scene.targetScaleX < 20.0);
+      assertEquals("scale readout disagrees with applied X factor" + on, scene.targetScaleX, scene.scReadout, 0.02);
 
       // 5. Drag-focus dims the inactive handles: mid-drag, the Y/Z rings and shafts (not the dragged
       // axis) fade well below their resting counts as they blend toward the background.

--- a/ardor3d-lwjgl3/src/test/java/com/ardor3d/renderer/lwjgl3/GlGizmoRenderSmokeTest.java
+++ b/ardor3d-lwjgl3/src/test/java/com/ardor3d/renderer/lwjgl3/GlGizmoRenderSmokeTest.java
@@ -142,11 +142,11 @@ public class GlGizmoRenderSmokeTest {
     int txRed, txGreen, txBlue, txHighlight;
     // Translate gizmo with the +X arrow hovered.
     int hoverRed, hoverHighlight;
-    // Rotate gizmo mid-drag.
-    int rotRed, rotGreen, rotBlue;
+    // Rotate gizmo: rings at rest, then mid-drag (drag-focus dims the inactive Y/Z rings).
+    int rotRestGreen, rotRestBlue, rotRed, rotGreen, rotBlue;
     double dragAngleDeg, readoutDeg, targetAngleDeg;
-    // Scale gizmo mid-drag.
-    int scRed, scGreen, scBlue;
+    // Scale gizmo: shafts at rest, then mid-drag (drag-focus dims the inactive Y/Z shafts).
+    int scRestGreen, scRestBlue, scRed, scGreen, scBlue;
     double targetScaleX;
 
     void setCanvas(final Canvas canvas) { _canvas = canvas; }
@@ -242,6 +242,12 @@ public class GlGizmoRenderSmokeTest {
           }
         }
         case ROTATE -> {
+          if (_phaseFrame == 0) {
+            // Rings at rest (no drag yet): the AA-stroke pipeline rasterizes all three ring colors.
+            classify(renderer);
+            rotRestGreen = _green;
+            rotRestBlue = _blue;
+          }
           if (_phaseFrame == DRAG_STEPS) {
             classify(renderer);
             rotRed = _red;
@@ -255,6 +261,12 @@ public class GlGizmoRenderSmokeTest {
           }
         }
         case SCALE -> {
+          if (_phaseFrame == 0) {
+            // Shafts at rest (no drag yet): all three axis-shaft colors rasterize.
+            classify(renderer);
+            scRestGreen = _green;
+            scRestBlue = _blue;
+          }
           if (_phaseFrame == DRAG_STEPS) {
             classify(renderer);
             scRed = _red;
@@ -436,16 +448,21 @@ public class GlGizmoRenderSmokeTest {
       System.out.println("GIZMO SMOKE on '" + scene.glRenderer + "'"
           + " translate[r=" + scene.txRed + " g=" + scene.txGreen + " b=" + scene.txBlue + " hi=" + scene.txHighlight
           + "] hover[r=" + scene.hoverRed + " hi=" + scene.hoverHighlight + "]"
-          + " rotate[r=" + scene.rotRed + " g=" + scene.rotGreen + " b=" + scene.rotBlue
-          + " dragAngle=" + scene.dragAngleDeg + " readout=" + scene.readoutDeg + " target=" + scene.targetAngleDeg + "]"
-          + " scale[r=" + scene.scRed + " g=" + scene.scGreen + " b=" + scene.scBlue + " sx=" + scene.targetScaleX + "]");
+          + " rotate[rest g=" + scene.rotRestGreen + " b=" + scene.rotRestBlue + "; drag r=" + scene.rotRed + " g="
+          + scene.rotGreen + " b=" + scene.rotBlue + " dragAngle=" + scene.dragAngleDeg + " readout=" + scene.readoutDeg
+          + " target=" + scene.targetAngleDeg + "]"
+          + " scale[rest g=" + scene.scRestGreen + " b=" + scene.scRestBlue + "; drag r=" + scene.scRed + " g="
+          + scene.scGreen + " b=" + scene.scBlue + " sx=" + scene.targetScaleX + "]");
 
       final String on = " on '" + scene.glRenderer + "'";
 
-      // 1. Every gizmo's three axis colors rasterize (the AA-stroke line pipeline works).
+      // 1. Every gizmo's three axis colors rasterize at rest (the AA-stroke line pipeline works):
+      // the translate arrows, the rotate rings, and the scale shafts each build their own geometry.
       assertTrue("translate X (red) did not render" + on, scene.txRed > 40);
       assertTrue("translate Y (green) did not render" + on, scene.txGreen > 40);
       assertTrue("translate Z (blue) did not render" + on, scene.txBlue > 40);
+      assertTrue("rotate rings did not render at rest" + on, scene.rotRestGreen > 40 && scene.rotRestBlue > 40);
+      assertTrue("scale shafts did not render at rest" + on, scene.scRestGreen > 40 && scene.scRestBlue > 40);
 
       // 2. Hovering the +X arrow lights it up - a distinct highlight render path. A chromatic
       // handle brightens toward white rather than toward the yellow highlight tint, so its pixels
@@ -454,20 +471,24 @@ public class GlGizmoRenderSmokeTest {
       assertTrue("hovering the +X arrow did not change its pixels (highlight path)" + on,
           scene.hoverRed < scene.txRed - 150);
 
-      // 3. The rotate rings render and a ring drag leaves drag angle, readout and applied rotation
-      // all agreeing on a clearly nonzero sweep.
-      assertTrue("rotate rings did not render" + on, scene.rotRed > 40 && scene.rotGreen > 40 && scene.rotBlue > 40);
+      // 3. A ring drag leaves drag angle, readout and applied rotation all agreeing on a clearly
+      // nonzero sweep, and the swept pie wedge (its red edges) rasterizes.
+      assertTrue("rotate pie wedge did not render" + on, scene.rotRed > 40);
       assertTrue("ring drag produced no rotation" + on, scene.targetAngleDeg > 15);
       assertEquals("drag angle and readout disagree" + on, scene.dragAngleDeg, scene.readoutDeg, 3.0);
       assertEquals("drag angle and applied target rotation disagree" + on, scene.dragAngleDeg, scene.targetAngleDeg,
           6.0);
 
-      // 4. The scale gizmo renders and a +X drag grows the target's X scale into a sane range. The
-      // dragged X axis is the active handle, so it is highlighted out of the red bucket (like the
-      // hovered arrow above); the resting Y and Z axes show the stroke pipeline still rasterizes.
-      assertTrue("scale gizmo did not render" + on, scene.scGreen > 40 && scene.scBlue > 40);
+      // 4. A +X scale drag grows the target's X scale into a sane range.
       assertTrue("scale drag did not grow target X scale (was " + scene.targetScaleX + ")" + on,
           scene.targetScaleX > 1.1 && scene.targetScaleX < 20.0);
+
+      // 5. Drag-focus dims the inactive handles: mid-drag, the Y/Z rings and shafts (not the dragged
+      // axis) fade well below their resting counts as they blend toward the background.
+      assertTrue("drag-focus did not dim the inactive rotate rings" + on,
+          scene.rotGreen < scene.rotRestGreen / 2 && scene.rotBlue < scene.rotRestBlue / 2);
+      assertTrue("drag-focus did not dim the inactive scale shafts" + on,
+          scene.scGreen < scene.scRestGreen / 2 && scene.scBlue < scene.scRestBlue / 2);
     } finally {
       canvas.close();
     }

--- a/ardor3d-lwjgl3/src/test/java/com/ardor3d/renderer/lwjgl3/GlGizmoRenderSmokeTest.java
+++ b/ardor3d-lwjgl3/src/test/java/com/ardor3d/renderer/lwjgl3/GlGizmoRenderSmokeTest.java
@@ -55,6 +55,7 @@ import com.ardor3d.renderer.Renderer;
 import com.ardor3d.renderer.material.MaterialManager;
 import com.ardor3d.scenegraph.Node;
 import com.ardor3d.scenegraph.SceneIndexer;
+import com.ardor3d.util.ReadOnlyTimer;
 import com.ardor3d.util.resource.ResourceLocatorTool;
 import com.ardor3d.util.resource.SimpleResourceLocator;
 
@@ -81,6 +82,29 @@ public class GlGizmoRenderSmokeTest {
 
   private static final int SIZE = 256;
   private static final ColorRGBA CLEAR_COLOR = new ColorRGBA(0.1f, 0.15f, 0.3f, 1f);
+
+  // A fixed 50ms-per-frame timer so each scripted frame is a faithful update()+render() pair. The
+  // gizmos advance their eased hover highlight in update(); four frames at this step (200ms) take
+  // the highlight well past its ~100ms ease, matching what the interactive example shows.
+  private static final ReadOnlyTimer FIXED_TIMER = new ReadOnlyTimer() {
+    @Override
+    public double getTimeInSeconds() { return 0; }
+
+    @Override
+    public long getTime() { return 0; }
+
+    @Override
+    public long getResolution() { return 1_000_000_000L; }
+
+    @Override
+    public double getFrameRate() { return 20.0; }
+
+    @Override
+    public double getTimePerFrame() { return 0.05; }
+
+    @Override
+    public long getPreviousFrameTime() { return 0; }
+  };
 
   // How far a synthetic drag is walked, in per-frame steps, once it has started.
   private static final int DRAG_STEPS = 16;
@@ -150,6 +174,10 @@ public class GlGizmoRenderSmokeTest {
       cam.apply(renderer);
       _root.onDraw(renderer);
       renderer.renderBuckets();
+
+      // Advance the gizmo's animation for the frame (eased hover highlight, etc.), reacting to the
+      // hover/drag state the previous frame's input left, exactly like the example's update pass.
+      _manager.update(FIXED_TIMER);
 
       // Inject the phase's synthetic input before the gizmo draws, so the render reflects it.
       switch (_phase) {


### PR DESCRIPTION
## Summary

Builds on the v2 interact gizmos (#141–#144) with a set of micro-interactions that make the translate/rotate/scale gizmos feel responsive and legible during a drag. All behavior lives in `ardor3d-extras` (with a small reusable cursor helper in `ardor3d-awt`); `InteractGizmoExample` only wires it up.

## What's included

**Hover & drag feedback**
- Eased hover highlight that brightens the handle under the cursor and thickens its stroke in place (no geometry shift).
- Drag-focus: while dragging, the other handles dim and an axis guide line extends the constraint across the viewport.
- Escape cancels an in-progress drag, restoring the target to where the drag began.
- A generalized screen-space numeric readout (translation delta / rotation angle / scale factor) with a per-gizmo formatter callback.

**Snapping visuals** (shown only while a snap filter is active)
- Snap tick marks + a snap pulse on all three gizmos: radial notches on the rotate ring, crossbars along the translate axis (world grid; fades out when it gets too dense on zoom-out), and crossbars along the scale axis at factor gridlines.
- New `ScaleSnapFilter` — the scale counterpart to the grid/angle snap filters; snaps the per-axis drag factor to fixed steps and leaves untouched axes exactly alone.

**Origin ghost**
- A faint camera-facing marker left at the world origin where a drag began — a "moved from here" anchor. Self-gates to translate drags (rotate/scale don't move the origin).

**Cursor feedback**
- Opt-in cursor feedback via the existing mouse-over callback: `AbstractGizmo.DEFAULT_CURSOR` for one shared cursor, or a per-instance `SetCursorCallback` for distinct per-gizmo cursors.
- New `CursorFactory` in `ardor3d-awt` generates crisp move / rotate / scale cursors (white fill + dark outline) with Java2D — no bundled assets, each cached as a stable instance. The example wires translate→move, rotate→rotate, scale→scale.
- Also closes a native GLFW cursor leak: `GLFWMouseManager` now caches cursor handles (stack-allocated image), detects window loss, and destroys them on `close()`.

**Housekeeping**
- Removed a per-frame `Vector3` allocation in the gizmo's constant-screen-size sizing math.
- Pointed the new interact tests at `MathUtils.ZERO_TOLERANCE` instead of bare literals.

## Testing
- An expanded headless test suite across the interact package — snap filters, tick wiring, drag focus/cancel, readouts, origin-ghost gating, cursor wiring — plus a new `CursorFactory` test and the existing `GlGizmoRenderSmokeTest` on a real GL context.
- Rendered effects (ticks, ghost, cursors) were verified through the example's synthetic-drag screenshot probes (`-Dgizmo.drag=movex|ringx|scalex`) and behavioral readback (applied translation / angle / scale). Note: on-screen pixels weren't captured because full-window framebuffer readback is unreliable on this WSLg/D3D12 setup — the small-window smoke test reads back fine, and the cursor art was previewed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime cursor factory that generates and caches crisp move, scale, and rotate cursors.
  * Improved gizmo UX with animated hover/drag visuals, axis guide + origin ghost, snap-tick rendering, and customizable drag readouts.
  * Introduced snap-source support (including a new scale snapping filter) so enabled snapping is reflected in gizmo UI.
* **Bug Fixes**
  * Strengthened cursor caching/cleanup and refined native cursor switching.
  * Improved gizmo escape-to-cancel handling and drag-state cleanup.
* **Tests**
  * Expanded cursor, gizmo cancel/ghost/readout/snap-tick coverage plus deterministic GL smoke assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->