### PR TITLE
Wire the v2 transform gizmos into the editor

### DIFF
--- a/ardor3d-editor/README.md
+++ b/ardor3d-editor/README.md
@@ -40,7 +40,8 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
   edits to every selected mesh, and light edits to every selected light - each gesture is one
   merged undo step. Transform fields show a dash where the selection disagrees.
 - **Viewport** — WASD + drag fly camera, mouse-wheel dolly, primitive-accurate click selection,
-  interact-widget gizmos for translate/rotate/scale, per-light overlay gizmos, reference grid.
+  v2 transform gizmos for translate/rotate/scale (eased hover highlight, per-gizmo cursors,
+  Ctrl-snap, Escape to cancel a drag), per-light overlay gizmos, reference grid.
 - **Undo/redo everywhere** — every mutation goes through a command stack
   (`com.ardor3d.editor.command`). Continuous gestures (slider drags, typing, gizmo drags)
   coalesce into single undo steps. `Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y`.
@@ -59,6 +60,8 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
 | Key | Action |
 | --- | --- |
 | `1` / `2` / `3` | Translate / Rotate / Scale mode (viewport focused) |
+| `R` | Toggle world / local gizmo frame (viewport focused) |
+| `Ctrl` (hold while dragging a gizmo) | Snap: translate to 1 unit, rotate to 15°, scale to ¼ |
 | `F` | Frame selection (viewport focused) |
 | `Delete` | Delete selection (viewport focused) |
 | `Escape` | Clear selection (viewport focused) |
@@ -104,7 +107,6 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
   there, unlike the transform fields).
 - Window-wide shortcuts (Ctrl+Z/D/N/O/S) fire even while a text field has focus — same seam as
   the pre-existing undo/redo binding; Compose offers no clean focus check at the Window level.
-- Scale gizmo is uniform-only (`SimpleScaleWidget`).
 - Rotation is edited as XYZ Euler angles. The inspector keeps the angles you type (even at the
   attitude ±90° singularity, where the decomposition isn't unique) and only re-derives them from
   the matrix after a gizmo drag or undo — after one of those, an equivalent-but-different

--- a/ardor3d-editor/README.md
+++ b/ardor3d-editor/README.md
@@ -61,7 +61,7 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
 | --- | --- |
 | `1` / `2` / `3` | Translate / Rotate / Scale mode (viewport focused) |
 | `R` | Toggle world / local gizmo frame (viewport focused) |
-| `Ctrl` (hold while dragging a gizmo) | Snap: translate to 1 unit, rotate to 15°, scale to ¼ |
+| `Ctrl` / `Cmd` (hold while dragging a gizmo) | Snap: translate to 1 unit, rotate to 15°, scale to ¼ |
 | `F` | Frame selection (viewport focused) |
 | `Delete` | Delete selection (viewport focused) |
 | `Escape` | Clear selection (viewport focused) |

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -22,18 +22,26 @@ import com.ardor3d.editor.util.SelectionUtil
 import com.ardor3d.editor.interact.GizmoUndoFilter
 import com.ardor3d.editor.menu.ShapeType
 import com.ardor3d.extension.interact.InteractManager
-import com.ardor3d.extension.interact.widget.MoveWidget
-import com.ardor3d.extension.interact.widget.RotateWidget
-import com.ardor3d.extension.interact.widget.SimpleScaleWidget
+import com.ardor3d.extension.interact.filter.AngleSnapFilter
+import com.ardor3d.extension.interact.filter.GridSnapFilter
+import com.ardor3d.extension.interact.filter.ScaleSnapFilter
+import com.ardor3d.extension.interact.widget.InteractMatrix
+import com.ardor3d.extension.interact.widget.SetCursorCallback
+import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo
+import com.ardor3d.extension.interact.widget.gizmo.ScaleGizmo
+import com.ardor3d.extension.interact.widget.gizmo.TranslateGizmo
 import com.ardor3d.framework.Scene
 import com.ardor3d.framework.Updater
 import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
 import com.ardor3d.framework.lwjgl3.awt.Lwjgl3AwtCanvas
+import com.ardor3d.image.util.awt.CursorFactory
 import com.ardor3d.input.PhysicalLayer
 import com.ardor3d.input.control.FirstPersonControl
 import com.ardor3d.input.keyboard.Key as ArdorKey
 import com.ardor3d.input.logical.InputTrigger
+import com.ardor3d.input.logical.KeyHeldCondition
 import com.ardor3d.input.logical.KeyPressedCondition
+import com.ardor3d.input.logical.KeyReleasedCondition
 import com.ardor3d.input.logical.LogicalLayer
 import com.ardor3d.input.logical.MouseButtonClickedCondition
 import com.ardor3d.input.logical.MouseWheelMovedCondition
@@ -109,11 +117,11 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
     private var lastWidth = 0
     private var lastHeight = 0
 
-    // Interact manager and widgets for transform gizmos
+    // Interact manager and v2 transform gizmos
     private var interactManager: InteractManager? = null
-    private var moveWidget: MoveWidget? = null
-    private var rotateWidget: RotateWidget? = null
-    private var scaleWidget: SimpleScaleWidget? = null
+    private var translateGizmo: TranslateGizmo? = null
+    private var rotateGizmo: RotateGizmo? = null
+    private var scaleGizmo: ScaleGizmo? = null
     private var lastTransformMode: TransformMode? = null
 
     // Reconciliation caches used by update() to notify the UI only on real changes.
@@ -130,21 +138,56 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
      * Sets up the interact manager and transform widgets.
      */
     fun setupInteractManager(canvas: Lwjgl3AwtCanvas, physicalLayer: PhysicalLayer, logicalLayer: LogicalLayer) {
-        interactManager = InteractManager()
-        interactManager?.setupInput(canvas, physicalLayer, logicalLayer)
+        val manager = InteractManager()
+        interactManager = manager
+        manager.setupInput(canvas, physicalLayer, logicalLayer)
 
-        // Create transform widgets
-        moveWidget = MoveWidget().withXAxis().withYAxis().withZAxis()
-        rotateWidget = RotateWidget().withXAxis().withYAxis().withZAxis()
-        // SimpleScaleWidget only supports one axis - use Y for uniform scaling
-        scaleWidget = SimpleScaleWidget().withArrow(Vector3.UNIT_Y, ColorRGBA(0f, 1f, 0f, 0.65f))
+        // v2 transform gizmos, each with its full handle set. The scale gizmo drives all three
+        // axes (the old SimpleScaleWidget was uniform-Y only).
+        val translate = TranslateGizmo().withAllHandles()
+        val rotate = RotateGizmo().withAllHandles()
+        val scale = ScaleGizmo().withAllHandles()
+        translateGizmo = translate
+        rotateGizmo = rotate
+        scaleGizmo = scale
+        manager.addWidget(translate)
+        manager.addWidget(rotate)
+        manager.addWidget(scale)
 
-        interactManager?.addWidget(moveWidget)
-        interactManager?.addWidget(rotateWidget)
-        interactManager?.addWidget(scaleWidget)
+        // Per-gizmo cursor feedback: the cursor swaps to match the hovered or dragged gizmo.
+        translate.setMouseOverCallback(SetCursorCallback(CursorFactory.move()))
+        rotate.setMouseOverCallback(SetCursorCallback(CursorFactory.rotate()))
+        scale.setMouseOverCallback(SetCursorCallback(CursorFactory.scale()))
+
+        // Hold Ctrl to snap: translate to a 1-unit grid, rotate to 15-degree steps, scale to
+        // quarter steps. The filters are registered disabled and toggled by the Ctrl held/released
+        // triggers below, on the manager's own logical layer so they still fire mid-drag.
+        val gridSnap = GridSnapFilter(1.0).apply { isEnabled = false }
+        val angleSnap = AngleSnapFilter(Math.toRadians(15.0)).apply { isEnabled = false }
+        val scaleSnap = ScaleSnapFilter(0.25).apply { isEnabled = false }
+        translate.addFilter(gridSnap)
+        rotate.addFilter(angleSnap)
+        scale.addFilter(scaleSnap)
+        val setSnap = { enabled: Boolean ->
+            gridSnap.isEnabled = enabled
+            angleSnap.isEnabled = enabled
+            scaleSnap.isEnabled = enabled
+        }
+        manager.logicalLayer.registerTrigger(
+            InputTrigger(KeyHeldCondition(ArdorKey.LEFT_CONTROL)) { _, _, _ -> setSnap(true) })
+        manager.logicalLayer.registerTrigger(
+            InputTrigger(KeyReleasedCondition(ArdorKey.LEFT_CONTROL)) { _, _, _ -> setSnap(false) })
+
+        // R toggles the world/local interact frame (the scale gizmo is always local).
+        manager.logicalLayer.registerTrigger(InputTrigger(KeyPressedCondition(ArdorKey.R)) { _, _, _ ->
+            val next = if (translate.interactMatrix == InteractMatrix.World) InteractMatrix.Local else InteractMatrix.World
+            translate.interactMatrix = next
+            rotate.interactMatrix = next
+            manager.fireTargetDataUpdated()
+        })
 
         // Record completed gizmo drags in the undo history
-        interactManager?.addFilterToWidgets(GizmoUndoFilter(editorState))
+        manager.addFilterToWidgets(GizmoUndoFilter(editorState))
 
         // Set default widget based on editor state
         updateActiveWidget()
@@ -155,9 +198,9 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
      */
     fun updateActiveWidget() {
         val widget = when (editorState.transformMode) {
-            TransformMode.TRANSLATE -> moveWidget
-            TransformMode.ROTATE -> rotateWidget
-            TransformMode.SCALE -> scaleWidget
+            TransformMode.TRANSLATE -> translateGizmo
+            TransformMode.ROTATE -> rotateGizmo
+            TransformMode.SCALE -> scaleGizmo
         }
         interactManager?.setActiveWidget(widget)
     }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -888,9 +888,6 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         renderer.draw(root)
         renderer.draw(overlayRoot)
 
-        // Render interact widgets (transform gizmos)
-        interactManager?.render(renderer)
-
         // Draw selection highlight (bounding box) for selected objects. The gizmo target
         // already has a widget on it, so skip its bounds.
         val gizmoTarget = interactManager?.spatialTarget
@@ -899,6 +896,16 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
                 Debugger.drawBounds(selected, renderer, false)
             }
         }
+
+        // Flush the scene + bounds so their depth is in the buffer before the gizmo draws.
+        // draw() only queues into render buckets (nothing rasterizes until renderBuckets/
+        // flushFrame), but the gizmo handles are Skip-bucket and render immediately - so without
+        // this flush the gizmo would draw against an empty depth buffer and then be painted over
+        // by the deferred scene flush (the occlusion we started with). With the scene depth
+        // present, the gizmo's own two-pass x-ray shows its occluded parts ghosted (dimmed) and
+        // its front parts at full strength, instead of being hidden.
+        renderer.renderBuckets()
+        interactManager?.render(renderer)
 
         return true
     }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -45,6 +45,7 @@ import com.ardor3d.input.logical.KeyReleasedCondition
 import com.ardor3d.input.logical.LogicalLayer
 import com.ardor3d.input.logical.MouseButtonClickedCondition
 import com.ardor3d.input.logical.MouseWheelMovedCondition
+import com.ardor3d.input.logical.TwoInputStates
 import com.ardor3d.input.mouse.MouseButton
 import com.ardor3d.intersection.PickingUtil
 import com.ardor3d.intersection.PrimitivePickResults
@@ -159,24 +160,27 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         rotate.setMouseOverCallback(SetCursorCallback(CursorFactory.rotate()))
         scale.setMouseOverCallback(SetCursorCallback(CursorFactory.scale()))
 
-        // Hold Ctrl to snap: translate to a 1-unit grid, rotate to 15-degree steps, scale to
-        // quarter steps. The filters are registered disabled and toggled by the Ctrl held/released
-        // triggers below, on the manager's own logical layer so they still fire mid-drag.
+        // Hold Ctrl/Cmd to snap: translate to a 1-unit grid, rotate to 15-degree steps, scale to
+        // quarter steps. Snap tracks whether any Ctrl/Meta key is down - matching the editor's
+        // selection modifier (setupPickingTrigger) and staying correct when one of two held
+        // modifiers is released. Wired on the manager's own logical layer so it also fires mid-drag.
         val gridSnap = GridSnapFilter(1.0).apply { isEnabled = false }
         val angleSnap = AngleSnapFilter(Math.toRadians(15.0)).apply { isEnabled = false }
         val scaleSnap = ScaleSnapFilter(0.25).apply { isEnabled = false }
         translate.addFilter(gridSnap)
         rotate.addFilter(angleSnap)
         scale.addFilter(scaleSnap)
-        val setSnap = { enabled: Boolean ->
-            gridSnap.isEnabled = enabled
-            angleSnap.isEnabled = enabled
-            scaleSnap.isEnabled = enabled
+        val syncSnap = { states: TwoInputStates ->
+            val on = states.current.keyboardState.isAtLeastOneDown(
+                ArdorKey.LEFT_CONTROL, ArdorKey.RIGHT_CONTROL, ArdorKey.LEFT_META, ArdorKey.RIGHT_META)
+            gridSnap.isEnabled = on
+            angleSnap.isEnabled = on
+            scaleSnap.isEnabled = on
         }
-        manager.logicalLayer.registerTrigger(
-            InputTrigger(KeyHeldCondition(ArdorKey.LEFT_CONTROL)) { _, _, _ -> setSnap(true) })
-        manager.logicalLayer.registerTrigger(
-            InputTrigger(KeyReleasedCondition(ArdorKey.LEFT_CONTROL)) { _, _, _ -> setSnap(false) })
+        for (key in listOf(ArdorKey.LEFT_CONTROL, ArdorKey.RIGHT_CONTROL, ArdorKey.LEFT_META, ArdorKey.RIGHT_META)) {
+            manager.logicalLayer.registerTrigger(InputTrigger(KeyHeldCondition(key)) { _, states, _ -> syncSnap(states) })
+            manager.logicalLayer.registerTrigger(InputTrigger(KeyReleasedCondition(key)) { _, states, _ -> syncSnap(states) })
+        }
 
         // R toggles the world/local interact frame (the scale gizmo is always local).
         manager.logicalLayer.registerTrigger(InputTrigger(KeyPressedCondition(ArdorKey.R)) { _, _, _ ->


### PR DESCRIPTION
## What

The editor's viewport still drove the **v1** transform widgets (`MoveWidget` / `RotateWidget` / `SimpleScaleWidget`), so none of the v2 gizmo work from #141–#145 actually reached it. This swaps in the **v2 gizmos** (`TranslateGizmo` / `RotateGizmo` / `ScaleGizmo`) in `EditorScene.setupInteractManager`:

- All three use their full handle set; the **scale gizmo now drives all three axes** (`SimpleScaleWidget` was uniform-Y only).
- **Per-gizmo cursor feedback** — the cursor swaps to match the hovered/dragged gizmo (`SetCursorCallback` + `CursorFactory`).
- **Ctrl-snap** — hold Ctrl to snap translate to a 1-unit grid, rotate to 15°, scale to ¼, via `Grid/Angle/ScaleSnapFilter` toggled by Ctrl held/released triggers on the manager's own logical layer (so they still fire mid-drag).
- **`R` toggles the world/local interact frame.**

The gizmos are `AbstractInteractWidget` subclasses, so the manager wiring and `GizmoUndoFilter` (each drag → one undoable transform command) are unchanged. The editor's existing `1`/`2`/`3` mode keys already drive the active gizmo via `editorState.transformMode`.

**Deferred:** the screen-space numeric drag readout. It lives in an ortho root the app renders itself, and the editor has no ortho pass yet — a separate, small follow-up.

## Verification

- Editor module compiles clean (no warnings, no unused imports); full editor test suite green.
- The wiring mirrors `InteractGizmoExample`, which is covered by the GL gizmo smoke test (#143).
- ⚠️ Interactive behavior (hover highlight, drag, snap, cursor swap, frame toggle) can't be driven headlessly in CI/WSL, so it wants a quick **manual viewport smoke**: select an object, confirm the gizmo appears, drag each mode, hold Ctrl to snap, press `R` to flip frames, `Esc` to cancel a drag.

## Stacking

Stacked on #146 (the `NativeEditorApp` split — `setupInteractManager` now lives in `EditorScene.kt`). Base will retarget to `master` once #146 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated viewport transform gizmos for translating, rotating, and scaling objects.
  * Added hover-based cursor feedback for gizmo handles.
  * Press `R` to switch between world and local gizmo frames.
  * Hold `Ctrl`/`Cmd` while dragging to enable position, angle, or scale snapping.
  * Press `Escape` to cancel an active gizmo interaction.
  * Gizmo handles now remain clearly visible during scene interaction.

* **Documentation**
  * Updated feature descriptions, keyboard shortcuts, modifier guidance, and scale gizmo information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->