### PR TITLE
Show the transform-gizmo drag readout in the editor

### DIFF
--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -19,6 +19,7 @@ import com.ardor3d.editor.command.SetterCommand
 import com.ardor3d.editor.io.ModelImport
 import com.ardor3d.editor.util.Insertion
 import com.ardor3d.editor.util.SelectionUtil
+import com.ardor3d.editor.interact.GizmoReadoutFormat
 import com.ardor3d.editor.interact.GizmoUndoFilter
 import com.ardor3d.editor.menu.ShapeType
 import com.ardor3d.extension.interact.InteractManager
@@ -30,10 +31,10 @@ import com.ardor3d.extension.interact.widget.SetCursorCallback
 import com.ardor3d.extension.interact.widget.gizmo.RotateGizmo
 import com.ardor3d.extension.interact.widget.gizmo.ScaleGizmo
 import com.ardor3d.extension.interact.widget.gizmo.TranslateGizmo
+import com.ardor3d.framework.Canvas
 import com.ardor3d.framework.Scene
 import com.ardor3d.framework.Updater
 import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
-import com.ardor3d.framework.lwjgl3.awt.Lwjgl3AwtCanvas
 import com.ardor3d.image.util.awt.CursorFactory
 import com.ardor3d.input.PhysicalLayer
 import com.ardor3d.input.control.FirstPersonControl
@@ -54,6 +55,7 @@ import com.ardor3d.light.Light
 import com.ardor3d.light.PointLight
 import com.ardor3d.light.SpotLight
 import com.ardor3d.math.*
+import com.ardor3d.renderer.Camera
 import com.ardor3d.renderer.ContextManager
 import com.ardor3d.renderer.Renderer
 import com.ardor3d.renderer.queue.RenderBucketType
@@ -87,6 +89,12 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
     private val overlayRoot = Node("EditorOverlay")
     private val gridNode = createGrid()
 
+    // Screen-space root + camera for the transform gizmos' drag readouts: an ExampleBase-style
+    // second pass drawn after the gizmo, so the numeric readout sits over the scene in pixel
+    // coordinates. The camera is created lazily once the canvas reports a real size.
+    private val orthoRoot = Node("EditorOrtho")
+    private var orthoCam: Camera? = null
+
     // One overlay gizmo per light in the document, refreshed on structure changes.
     private val lightGizmos = mutableMapOf<Light, Node>()
     private var lastStructureVersion = -1L
@@ -112,7 +120,7 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
             }
         }
     var canvasRenderer: Lwjgl3CanvasRenderer? = null
-    var canvas: Lwjgl3AwtCanvas? = null
+    var canvas: Canvas? = null
     private var firstPersonControl: FirstPersonControl? = null
     private var initialized = false
     private var lastWidth = 0
@@ -124,6 +132,10 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
     private var rotateGizmo: RotateGizmo? = null
     private var scaleGizmo: ScaleGizmo? = null
     private var lastTransformMode: TransformMode? = null
+
+    /** Test seam: the interact manager driving the gizmos, so the headless GL readout test can
+     * reach the active gizmo to script a drag. Not part of the editor's public surface. */
+    internal val interactManagerForTest: InteractManager? get() = interactManager
 
     // Reconciliation caches used by update() to notify the UI only on real changes.
     private var lastSelection: Spatial? = null
@@ -138,7 +150,7 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
     /**
      * Sets up the interact manager and transform widgets.
      */
-    fun setupInteractManager(canvas: Lwjgl3AwtCanvas, physicalLayer: PhysicalLayer, logicalLayer: LogicalLayer) {
+    fun setupInteractManager(canvas: Canvas, physicalLayer: PhysicalLayer, logicalLayer: LogicalLayer) {
         val manager = InteractManager()
         interactManager = manager
         manager.setupInput(canvas, physicalLayer, logicalLayer)
@@ -154,6 +166,19 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         manager.addWidget(translate)
         manager.addWidget(rotate)
         manager.addWidget(scale)
+
+        // The drag readout is screen-space UI: each gizmo positions and fills its own BasicText,
+        // which lives in the editor's ortho root and is drawn in the second pass (see render()).
+        orthoRoot.attachChild(translate.readout)
+        orthoRoot.attachChild(rotate.readout)
+        orthoRoot.attachChild(scale.readout)
+
+        // Axis-aware readout text: name the axis (or axes) the active handle manipulates so the
+        // value is unambiguous without relying on the red/green/blue = X/Y/Z coloring. Wired through
+        // the gizmos' own formatter hooks, so no gizmo-library change is needed.
+        translate.setReadoutFormatter { delta, _, _ -> GizmoReadoutFormat.translate(delta, translate.activeHandle?.part) }
+        rotate.setReadoutFormatter { angleRadians, _ -> GizmoReadoutFormat.rotate(angleRadians, rotate.activeHandle?.part) }
+        scale.setReadoutFormatter { factor, _ -> GizmoReadoutFormat.scale(factor, scale.activeHandle?.part) }
 
         // Per-gizmo cursor feedback: the cursor swaps to match the hovered or dragged gizmo.
         translate.setMouseOverCallback(SetCursorCallback(CursorFactory.move()))
@@ -370,6 +395,9 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
             node.setRenderState(zBuffer)
             node.sceneHints.renderBucketType = RenderBucketType.Opaque
         }
+
+        // The screen-space readout root draws in pixel order (no depth), like any HUD overlay.
+        orthoRoot.sceneHints.renderBucketType = RenderBucketType.OrthoOrder
 
         // Editor overlay: grid (light gizmos are added per light as the scene changes)
         gridNode.sceneHints.setPickingHint(PickingHint.Pickable, false)
@@ -907,6 +935,20 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         renderer.renderBuckets()
         interactManager?.render(renderer)
 
+        // Screen-space pass: the active gizmo's drag readout lives in the ortho root. Draw it after
+        // the gizmo in pixel coordinates, then restore the perspective camera. This is the
+        // ExampleBase.renderExample ortho pattern. The ortho camera is created lazily once the
+        // canvas reports a real size; its own resize listener keeps it in sync thereafter.
+        if (orthoCam == null && cvs != null && cvs.contentWidth > 0 && cvs.contentHeight > 0) {
+            orthoCam = Camera.newOrthoCamera(cvs)
+        }
+        orthoCam?.let { oc ->
+            oc.apply(renderer)
+            renderer.draw(orthoRoot)
+            renderer.renderBuckets()
+            camera?.apply(renderer)
+        }
+
         return true
     }
 
@@ -974,9 +1016,10 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
                 if (light.sceneHints.cullHint == CullHint.Always) CullHint.Always else CullHint.Inherit
         }
 
-        // Update geometric state for the document and the editor overlay
+        // Update geometric state for the document, the editor overlay, and the readout root
         root.updateGeometricState(timer.timePerFrame, true)
         overlayRoot.updateGeometricState(timer.timePerFrame, true)
+        orthoRoot.updateGeometricState(timer.timePerFrame, true)
 
         // Status bar FPS, refreshed twice a second
         fpsAccumulatedTime += timer.timePerFrame

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/NativeEditorApp.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/NativeEditorApp.kt
@@ -41,6 +41,7 @@ import com.ardor3d.editor.viewport.ViewportToolbar
 import com.ardor3d.framework.FrameHandler
 import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
 import com.ardor3d.framework.lwjgl3.awt.Lwjgl3AwtCanvas
+import com.ardor3d.image.util.awt.AWTImageLoader
 import com.ardor3d.input.PhysicalLayer
 import com.ardor3d.input.awt.AwtFocusWrapper
 import com.ardor3d.input.awt.AwtKeyboardWrapper
@@ -66,6 +67,11 @@ private val logger = Logger.getLogger("com.ardor3d.editor")
  */
 private fun addDefaultResourceLocators() {
     try {
+        // Image loading: register the AWT/ImageIO loader for PNG, JPG, etc. Without it only the
+        // built-in DDS/HDR/TGA/ABI handlers exist, so texture PNGs (e.g. the gizmo readout's bitmap
+        // font atlas) fail to decode and fall back to the magenta "missing texture" image.
+        AWTImageLoader.registerLoader()
+
         // Material resources
         ResourceLocatorTool.addResourceLocator(
             ResourceLocatorTool.TYPE_MATERIAL,

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/interact/GizmoReadoutFormat.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/interact/GizmoReadoutFormat.kt
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.interact
+
+import com.ardor3d.extension.interact.widget.gizmo.GizmoPart
+import com.ardor3d.math.type.ReadOnlyVector3
+import java.util.Locale
+
+/**
+ * Axis-aware text for the transform gizmos' drag readouts. Naming the axis - and showing only the
+ * components the active handle actually manipulates - keeps the readout legible and, more to the
+ * point, disambiguates the axis for viewers who cannot rely on the red/green/blue = X/Y/Z handle
+ * coloring (the red/green X/Y pair is exactly the deuteranopia-confusable one). These feed the
+ * gizmos' own ReadoutFormatter hooks, so no gizmo-library change is needed.
+ *
+ * [part] is the active handle's GizmoPart (from AbstractGizmo.getActiveHandle), or null when it
+ * cannot be resolved - in which case each formatter falls back to its fullest labelled form.
+ *
+ * All formatting is pinned to [Locale.ROOT]: the strings use '.' decimals and, for translation, a
+ * space delimiter, so a comma-decimal JVM locale can neither swap the separator nor collide it with
+ * the delimiter.
+ */
+internal object GizmoReadoutFormat {
+
+    /** Signed translation delta, per axis, in world units. */
+    fun translate(delta: ReadOnlyVector3, part: GizmoPart?): String = when (part) {
+        GizmoPart.AxisX -> component("X", delta.x)
+        GizmoPart.AxisY -> component("Y", delta.y)
+        GizmoPart.AxisZ -> component("Z", delta.z)
+        GizmoPart.PlaneXY -> component("X", delta.x) + GAP + component("Y", delta.y)
+        GizmoPart.PlaneXZ -> component("X", delta.x) + GAP + component("Z", delta.z)
+        GizmoPart.PlaneYZ -> component("Y", delta.y) + GAP + component("Z", delta.z)
+        // Center (view-plane) drag, or an unresolved handle: label all three.
+        else -> component("X", delta.x) + GAP + component("Y", delta.y) + GAP + component("Z", delta.z)
+    }
+
+    /** Drag angle in degrees (ASCII 'deg'; the readout font carries no degree glyph). */
+    fun rotate(angleRadians: Double, part: GizmoPart?): String {
+        val deg = String.format(Locale.ROOT, "%.1f deg", Math.toDegrees(angleRadians))
+        return when (part) {
+            GizmoPart.RingX -> "X $deg"
+            GizmoPart.RingY -> "Y $deg"
+            GizmoPart.RingZ -> "Z $deg"
+            // Screen-space ring rotates about the view direction - no world axis to name.
+            else -> deg
+        }
+    }
+
+    /** Scale factor since the drag began (ASCII 'x', not the multiply glyph). */
+    fun scale(factor: ReadOnlyVector3, part: GizmoPart?): String = when (part) {
+        GizmoPart.AxisX -> factorText("X", factor.x)
+        GizmoPart.AxisY -> factorText("Y", factor.y)
+        GizmoPart.AxisZ -> factorText("Z", factor.z)
+        // Uniform scale: every axis shares the factor, so name none (matches the built-in text).
+        else -> String.format(Locale.ROOT, "%.2fx", factor.x)
+    }
+
+    /** Two spaces between per-axis components, so they stay readable in the centered label. */
+    private const val GAP = "  "
+
+    private fun component(axis: String, value: Double) = String.format(Locale.ROOT, "%s %+.2f", axis, value)
+
+    private fun factorText(axis: String, value: Double) = String.format(Locale.ROOT, "%s %.2fx", axis, value)
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/EditorReadoutRenderSmokeTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/EditorReadoutRenderSmokeTest.kt
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor
+
+import com.ardor3d.bounding.BoundingBox
+import com.ardor3d.buffer.BufferUtils
+import com.ardor3d.extension.interact.InteractManager
+import com.ardor3d.extension.interact.widget.gizmo.AbstractGizmo
+import com.ardor3d.framework.DisplaySettings
+import com.ardor3d.framework.Scene
+import com.ardor3d.framework.lwjgl3.GLFWCanvas
+import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
+import com.ardor3d.image.ImageDataFormat
+import com.ardor3d.image.util.awt.AWTImageLoader
+import com.ardor3d.input.InputState
+import com.ardor3d.input.PhysicalLayer
+import com.ardor3d.input.character.CharacterInputState
+import com.ardor3d.input.controller.ControllerState
+import com.ardor3d.input.gesture.GestureState
+import com.ardor3d.input.keyboard.KeyboardState
+import com.ardor3d.input.logical.LogicalLayer
+import com.ardor3d.input.logical.TwoInputStates
+import com.ardor3d.input.mouse.ButtonState
+import com.ardor3d.input.mouse.MouseButton
+import com.ardor3d.input.mouse.MouseState
+import com.ardor3d.intersection.PickResults
+import com.ardor3d.math.Ray3
+import com.ardor3d.math.Vector3
+import com.ardor3d.math.type.ReadOnlyVector3
+import com.ardor3d.renderer.Renderer
+import com.ardor3d.renderer.material.MaterialManager
+import com.ardor3d.scenegraph.shape.Box
+import com.ardor3d.util.ReadOnlyTimer
+import com.ardor3d.util.resource.ResourceLocatorTool
+import com.ardor3d.util.resource.SimpleResourceLocator
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.ByteBuffer
+import java.util.EnumMap
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.imageio.ImageIO
+
+/**
+ * GL smoke test for the editor's transform-gizmo drag readout. It drives the real [EditorScene]
+ * through a headless GLFW canvas, selects a box, scripts a drag of the +X translate arrow, and reads
+ * the framebuffer back to assert the readout actually rasterizes - the on-screen ortho pass this
+ * scene adds ([EditorScene.render]) is the first place the readout is drawn to pixels anywhere, so
+ * nothing else covers it. It also confirms the axis-aware editor formatter is wired: a +X drag reads
+ * out as "X ...", not the gizmo library's default "+dx, +dy, +dz" triple.
+ *
+ * Like the gizmo-library GL smoke test this SKIPS when no usable GL context or framebuffer readback
+ * is available (e.g. WSLg's D3D12 driver returns zeros from default-framebuffer readback), so it
+ * cannot break builds over infrastructure. Set ARDOR3D_REQUIRE_GL_SMOKE=1 (as CI does, under Xvfb +
+ * llvmpipe) to turn those skips into failures. Pass -Dreadout.shot.dir=<dir> to also dump the
+ * captured frame as a PNG for eyeballing.
+ */
+class EditorReadoutRenderSmokeTest {
+
+    private companion object {
+        const val W = 480
+        const val H = 320
+        const val FRAMES = 10
+        const val DRAG_START = 4
+        const val BEFORE_FRAME = 2 // gizmo shown, no drag yet: baseline with no readout
+        val CLEAR = intArrayOf(38, 41, 51) // EditorScene background (0.15, 0.16, 0.2) * 255
+
+        val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
+            override fun getTimeInSeconds() = 0.0
+            override fun getTime() = 0L
+            override fun getResolution() = 1_000_000_000L
+            override fun getFrameRate() = 20.0
+            override fun getTimePerFrame() = 0.05
+            override fun getPreviousFrameTime() = 0L
+        }
+    }
+
+    /** Wraps the editor scene so the framebuffer can be grabbed inside render() - context current,
+     * before the buffer swap - which is the only point a readback sees the finished frame. */
+    private class Capturer(val inner: EditorScene) : Scene {
+        var grab: ((Renderer) -> Unit)? = null
+        override fun render(renderer: Renderer): Boolean {
+            inner.render(renderer)
+            grab?.invoke(renderer)
+            return true
+        }
+        override fun doPick(pickRay: Ray3): PickResults = inner.doPick(pickRay)
+    }
+
+    private var lastDragMouse: MouseState? = null
+
+    @Test
+    fun readoutRendersDuringATranslateDrag() {
+        setupResourceLocators()
+
+        val state = EditorState()
+        val scene = EditorScene(state)
+        val capturer = Capturer(scene)
+        val canvasRenderer = Lwjgl3CanvasRenderer(capturer)
+
+        var canvas: GLFWCanvas? = null
+        try {
+            canvas = GLFWCanvas(DisplaySettings(W, H, 24, 0), canvasRenderer)
+            canvas.init()
+        } catch (t: Throwable) {
+            skipOrFail("Could not create a GL context here: $t")
+            return
+        }
+
+        try {
+            scene.canvasRenderer = canvasRenderer
+            scene.canvas = canvas
+            scene.setupInteractManager(canvas, PhysicalLayer.Builder().build(), LogicalLayer())
+
+            // Select a box at the origin and stay in the default translate mode.
+            val box = Box("DragMe", Vector3.ZERO, 0.5, 0.5, 0.5).apply {
+                modelBound = BoundingBox()
+                updateModelBound()
+            }
+            state.sceneRoot.attachChild(box)
+            state.select(box)
+            state.transformMode = TransformMode.TRANSLATE
+
+            val latest = arrayOfNulls<ByteBuffer>(1)
+            capturer.grab = { r ->
+                val buf = BufferUtils.createByteBuffer(W * H * 3)
+                r.grabScreenContents(buf, ImageDataFormat.RGB, 0, 0, W, H)
+                latest[0] = buf
+            }
+
+            // Warm-up draw sets up the camera, background and scene registration; one update() then
+            // syncs the gizmo target (the selected box) and the active widget. After that we drive
+            // the drag directly and do NOT call update() again: its input-trigger pass feeds the
+            // dummy physical layer's button-up state, which would end the drag between frames.
+            canvas.draw(null)
+            scene.update(TIMER)
+
+            val mgr = scene.interactManagerForTest!!
+            var bandBefore = -1
+            var bgPixels = 0
+            for (frame in 0 until FRAMES) {
+                if (frame >= DRAG_START) {
+                    dragXArrow(mgr, canvas, box, frame - DRAG_START)
+                }
+                canvas.draw(null)
+                if (frame == BEFORE_FRAME) {
+                    bandBefore = readoutBandBright(latest[0]!!) // gizmo only, no readout yet
+                    bgPixels = countBackground(latest[0]!!)
+                }
+            }
+
+            val glRenderer = org.lwjgl.opengl.GL11C.glGetString(org.lwjgl.opengl.GL11C.GL_RENDERER)
+            if (bgPixels < W * H / 2) {
+                skipOrFail("Framebuffer readback unusable on '$glRenderer' ($bgPixels/${W * H} background pixels)")
+                return
+            }
+
+            val bandDuring = readoutBandBright(latest[0]!!)
+            val readoutText = (mgr.activeWidget as AbstractGizmo).readout.text
+            System.out.println("EDITOR READOUT SMOKE on '$glRenderer'" +
+                " bandBefore=$bandBefore bandDuring=$bandDuring readout='$readoutText'")
+
+            val shotDir = System.getProperty("readout.shot.dir") ?: System.getenv("READOUT_SHOT_DIR")
+            if (shotDir != null) {
+                writePng(latest[0]!!, File(shotDir, "editor-readout.png"))
+            }
+
+            // Assert the readout rasterizes and is axis-aware. We count bright pixels in the readout's
+            // top-center band rather than exact-match white: the outlined, anti-aliased glyphs blend
+            // toward the dark background at their edges, so only the glyph cores are pure white.
+            val on = " on '$glRenderer'"
+            assertTrue("readout should be axis-aware ('X ...'), was '$readoutText'$on",
+                readoutText != null && readoutText.startsWith("X "))
+            assertTrue("readout did not rasterize in its screen band (before=$bandBefore during=$bandDuring)$on",
+                bandDuring > bandBefore + 40)
+        } finally {
+            canvas.close()
+        }
+    }
+
+    /** One frame of a held left-button drag of the +X translate arrow, walked outward along X. */
+    private fun dragXArrow(manager: InteractManager, canvas: GLFWCanvas, box: Box, step: Int) {
+        val gizmo = manager.activeWidget as AbstractGizmo
+        val cam = canvas.canvasRenderer.camera
+        val handleScale = gizmo.handle.scale.x
+        // Start mid-shaft on the +X arrow (so the pick grabs AxisX), then walk outward.
+        val dist = (0.6 + step * 0.15) * handleScale
+        val onAxis = Vector3(dist, 0.0, 0.0).addLocal(box.worldTranslation)
+        val screen = cam.getScreenCoordinates(onAxis)
+        applyDrag(gizmo, screen, canvas, manager, box)
+    }
+
+    private fun applyDrag(gizmo: AbstractGizmo, screen: ReadOnlyVector3, canvas: GLFWCanvas,
+                          manager: InteractManager, box: Box) {
+        val x = screen.x.toInt()
+        val y = screen.y.toInt()
+        val buttons = EnumMap<MouseButton, ButtonState>(MouseButton::class.java)
+        buttons[MouseButton.LEFT] = ButtonState.DOWN
+        // First frame's previous state has the button up at the same spot, starting the drag there.
+        val previous = lastDragMouse ?: MouseState(x, y, 0, 0, 0, null, null)
+        val current = MouseState(x, y, x - previous.x, y - previous.y, 0, buttons, null)
+        lastDragMouse = current
+
+        val prevState = InputState(KeyboardState.NOTHING, previous, ControllerState.NOTHING,
+            GestureState.NOTHING, CharacterInputState.NOTHING)
+        val curState = InputState(KeyboardState.NOTHING, current, ControllerState.NOTHING,
+            GestureState.NOTHING, CharacterInputState.NOTHING)
+        gizmo.processInput(canvas, TwoInputStates(prevState, curState), AtomicBoolean(false), manager)
+        manager.spatialState.applyState(box)
+    }
+
+    /**
+     * Count bright (channel sum > 500) pixels in the top band where the readout floats - above the
+     * gizmo's own footprint, so its gray center handle and saturated axis colors don't register.
+     * The readout's white outlined glyphs are the only bright thing up there. yTop is from the top.
+     */
+    private fun readoutBandBright(buf: ByteBuffer): Int {
+        var n = 0
+        for (yTop in 15 until 110) {
+            val row = H - 1 - yTop
+            for (col in 0 until W) {
+                val i = (row * W + col) * 3
+                val sum = (buf.get(i).toInt() and 0xFF) + (buf.get(i + 1).toInt() and 0xFF) +
+                    (buf.get(i + 2).toInt() and 0xFF)
+                if (sum > 500) n++
+            }
+        }
+        return n
+    }
+
+    private fun countBackground(buf: ByteBuffer): Int {
+        var n = 0
+        for (i in 0 until W * H) {
+            val r = buf.get(i * 3).toInt() and 0xFF
+            val g = buf.get(i * 3 + 1).toInt() and 0xFF
+            val b = buf.get(i * 3 + 2).toInt() and 0xFF
+            if (Math.abs(r - CLEAR[0]) < 25 && Math.abs(g - CLEAR[1]) < 25 && Math.abs(b - CLEAR[2]) < 25) n++
+        }
+        return n
+    }
+
+    /** Writes the RGB readback (GL origin bottom-left) to a PNG, flipped to top-left rows. */
+    private fun writePng(buf: ByteBuffer, file: File) {
+        val img = BufferedImage(W, H, BufferedImage.TYPE_INT_RGB)
+        for (y in 0 until H) {
+            val srcRow = H - 1 - y
+            for (x in 0 until W) {
+                val i = (srcRow * W + x) * 3
+                val r = buf.get(i).toInt() and 0xFF
+                val g = buf.get(i + 1).toInt() and 0xFF
+                val b = buf.get(i + 2).toInt() and 0xFF
+                img.setRGB(x, y, (r shl 16) or (g shl 8) or b)
+            }
+        }
+        file.parentFile?.mkdirs()
+        ImageIO.write(img, "png", file)
+    }
+
+    private fun setupResourceLocators() {
+        // Register the AWT/ImageIO image loader so the readout's PNG font atlas decodes (as the
+        // editor itself does) - without it the text falls back to the magenta missing-texture image.
+        AWTImageLoader.registerLoader()
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
+    }
+
+    private fun skipOrFail(reason: String) {
+        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
+            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
+        }
+        Assume.assumeTrue(reason, false)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/EditorReadoutRenderSmokeTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/EditorReadoutRenderSmokeTest.kt
@@ -113,6 +113,7 @@ class EditorReadoutRenderSmokeTest {
             canvas = GLFWCanvas(DisplaySettings(W, H, 24, 0), canvasRenderer)
             canvas.init()
         } catch (t: Throwable) {
+            canvas?.close() // constructed but init() failed - release it before we bail
             skipOrFail("Could not create a GL context here: $t")
             return
         }

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/interact/GizmoReadoutFormatTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/interact/GizmoReadoutFormatTest.kt
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.interact
+
+import com.ardor3d.extension.interact.widget.gizmo.GizmoPart
+import com.ardor3d.math.Vector3
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * The gizmo drag readout must name the axis (or axes) the active handle actually manipulates, so
+ * the value is unambiguous without leaning on the red/green/blue handle coloring. Single-axis
+ * handles show one labelled component, planes show two, and a center/free drag (or an unresolved
+ * handle) labels all three. Rotate rings and per-axis scale name their axis; the screen-space ring
+ * and uniform scale have no single axis to name.
+ */
+class GizmoReadoutFormatTest {
+
+    private val delta = Vector3(1.2, -3.4, 0.5)
+
+    @Test
+    fun translateSingleAxisNamesOnlyThatComponent() {
+        assertEquals("X +1.20", GizmoReadoutFormat.translate(delta, GizmoPart.AxisX))
+        assertEquals("Y -3.40", GizmoReadoutFormat.translate(delta, GizmoPart.AxisY))
+        assertEquals("Z +0.50", GizmoReadoutFormat.translate(delta, GizmoPart.AxisZ))
+    }
+
+    @Test
+    fun translatePlaneNamesItsTwoComponents() {
+        assertEquals("X +1.20  Y -3.40", GizmoReadoutFormat.translate(delta, GizmoPart.PlaneXY))
+        assertEquals("X +1.20  Z +0.50", GizmoReadoutFormat.translate(delta, GizmoPart.PlaneXZ))
+        assertEquals("Y -3.40  Z +0.50", GizmoReadoutFormat.translate(delta, GizmoPart.PlaneYZ))
+    }
+
+    @Test
+    fun translateCenterOrUnknownLabelsAllThree() {
+        val expected = "X +1.20  Y -3.40  Z +0.50"
+        assertEquals(expected, GizmoReadoutFormat.translate(delta, GizmoPart.Center))
+        assertEquals(expected, GizmoReadoutFormat.translate(delta, null))
+    }
+
+    @Test
+    fun rotateRingNamesItsAxis() {
+        val quarter = Math.toRadians(45.0)
+        assertEquals("X 45.0 deg", GizmoReadoutFormat.rotate(quarter, GizmoPart.RingX))
+        assertEquals("Y 45.0 deg", GizmoReadoutFormat.rotate(quarter, GizmoPart.RingY))
+        assertEquals("Z 45.0 deg", GizmoReadoutFormat.rotate(quarter, GizmoPart.RingZ))
+    }
+
+    @Test
+    fun rotateScreenRingHasNoAxisLabel() {
+        assertEquals("45.0 deg", GizmoReadoutFormat.rotate(Math.toRadians(45.0), GizmoPart.RingView))
+        assertEquals("45.0 deg", GizmoReadoutFormat.rotate(Math.toRadians(45.0), null))
+    }
+
+    @Test
+    fun scaleSingleAxisNamesThatAxisFactor() {
+        val factor = Vector3(1.5, 2.0, 0.25)
+        assertEquals("X 1.50x", GizmoReadoutFormat.scale(factor, GizmoPart.AxisX))
+        assertEquals("Y 2.00x", GizmoReadoutFormat.scale(factor, GizmoPart.AxisY))
+        assertEquals("Z 0.25x", GizmoReadoutFormat.scale(factor, GizmoPart.AxisZ))
+    }
+
+    @Test
+    fun scaleUniformIsUnlabelled() {
+        // Uniform scale carries the same factor on every axis; the built-in text uses X.
+        val factor = Vector3(1.5, 1.5, 1.5)
+        assertEquals("1.50x", GizmoReadoutFormat.scale(factor, GizmoPart.Center))
+        assertEquals("1.50x", GizmoReadoutFormat.scale(factor, null))
+    }
+
+    @Test
+    fun formattingIsLocaleIndependent() {
+        // A comma-decimal locale must not swap '.' for ',' (which, for translate, would also collide
+        // the decimal with the space delimiter's neighbours). Everything is pinned to Locale.ROOT.
+        val previous = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.GERMANY)
+            assertEquals("X +1.20", GizmoReadoutFormat.translate(delta, GizmoPart.AxisX))
+            assertEquals("X 45.0 deg", GizmoReadoutFormat.rotate(Math.toRadians(45.0), GizmoPart.RingX))
+            assertEquals("X 1.50x", GizmoReadoutFormat.scale(Vector3(1.5, 1.0, 1.0), GizmoPart.AxisX))
+        } finally {
+            Locale.setDefault(previous)
+        }
+    }
+}


### PR DESCRIPTION
Wires the transform gizmos' screen-space drag readout into the editor, gives it axis-aware text, and fixes the image-loader gap that was making it (and any future editor texture) render as the magenta "missing texture" fallback.

## What's here

**Ortho readout pass** — `EditorScene` gains an `orthoRoot` (OrthoOrder bucket) and a lazily-created `Camera.newOrthoCamera(canvas)`. The three gizmos' `getReadout()`s are attached to it, and a second pass after the gizmo draws them in pixel space (`orthoCam.apply → draw(orthoRoot) → renderBuckets → restore perspective`) — the `ExampleBase.renderExample` pattern.

**Axis-aware labels** — `GizmoReadoutFormat` (new, pure) names the axis the active handle manipulates: single-axis → `X +1.20`, plane → its two axes, free/center → all three; rotate rings → `X 45.0 deg`; per-axis scale → `X 1.50x`. This keeps the value unambiguous without relying on the red/green/blue = X/Y/Z coloring (the R/G confusable pair is the deuteranopia case). Wired through each gizmo's own `setReadoutFormatter` hook — no gizmo-library change.

**Image-loader fix** — the editor never registered a PNG/JPG `ImageLoader`, so `ImageLoaderUtil` only had its built-in DDS/HDR/TGA/ABI handlers and the readout's bitmap-font atlas decoded to the magenta default texture. It was dormant until now because the readout is the editor's first *textured* element (shapes, grid, gizmos are untextured). Fixed with `AWTImageLoader.registerLoader()` in the fail-fast bootstrap, matching `ExampleBase`.

## For reviewers

- `EditorScene.canvas` and `setupInteractManager` are widened from the concrete `Lwjgl3AwtCanvas` to the `Canvas` interface (nothing used AWT specifics; `InteractManager.setupInput` already takes `Canvas`). `NativeEditorApp` is unchanged — it still passes a `Lwjgl3AwtCanvas`, which is a `Canvas`. This is what lets a headless GLFW canvas drive the scene in the test.
- One `internal interactManagerForTest` seam on `EditorScene`.

## Testing

- `GizmoReadoutFormatTest` — 8 cases over the formatter, incl. locale independence.
- `EditorReadoutRenderSmokeTest` — drives the real `EditorScene` through a headless GLFW canvas, scripts a +X translate drag, and reads the framebuffer back to assert the readout rasterizes in its screen band and reads `X ...`. This is the **first pixel-level render of the readout anywhere** (the gizmo-library smoke test only checks `getReadout().getText()`), and it's what surfaced the image-loader gap. Skips without usable GL; `ARDOR3D_REQUIRE_GL_SMOKE=1` hardens skips to failures (as CI does under xvfb + llvmpipe).
- All 65 editor tests green. Verified visually via offscreen capture: the readout renders crisp white `X +3.02` above the gizmo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved on-screen readouts for translate, rotate, and scale gizmo drag interactions, with axis-aware labeling.
  * Enabled default support for common image formats (PNG/JPG/etc.) via the editor’s startup resource loading.

* **Bug Fixes**
  * Enhanced gizmo readout rendering to reliably appear during active drags using a dedicated screen-space overlay pass.
  * Ensured gizmo readout numbers format consistently regardless of system locale.

* **Tests**
  * Added GL smoke coverage for readout rendering and unit tests for readout formatting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->