### PR TITLE
Add editor play mode: snapshot boundary, game-behavior SPI, and a playable checkers sample

### DIFF
--- a/ardor3d-editor/README.md
+++ b/ardor3d-editor/README.md
@@ -57,9 +57,10 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
 - **Sample game: checkers** — Game > Play Checkers launches a full game of American/English
   draughts (`com.ardor3d.editor.checkers`): a pure, unit-tested rules engine (`Board`) as the
   model, a `CheckersView` as its scene view, and a `CheckersGame` (`GameMode`) tying clicks to
-  moves. Click a piece to see its legal moves highlighted, click a square to move (jumps play their
-  whole mandatory chain); the status bar shows whose turn it is and the result. A worked example of
-  the state/view split the play framework is built around.
+  moves. Hover a movable piece to preview its legal moves; click to select it (it stays lit, and the
+  destination under the pointer highlights distinctly); click a destination to move (jumps play their
+  whole mandatory chain); click elsewhere to clear. The status bar shows whose turn it is and the
+  result. A worked example of the state/view split the play framework is built around.
 - **Undo/redo everywhere** — every mutation goes through a command stack
   (`com.ardor3d.editor.command`). Continuous gestures (slider drags, typing, gizmo drags)
   coalesce into single undo steps. `Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y`.

--- a/ardor3d-editor/README.md
+++ b/ardor3d-editor/README.md
@@ -21,7 +21,7 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
 
 ### Tests
 
-```
+```bash
 LIBGL_ALWAYS_SOFTWARE=1 ./gradlew :ardor3d-editor:test
 ```
 

--- a/ardor3d-editor/README.md
+++ b/ardor3d-editor/README.md
@@ -48,7 +48,18 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
   The viewport toolbar's **Play** button (green ▶) renders the scene through the selected camera
   object — or the first one if none is selected — filling the panel with that camera's view and
   hiding all editor overlays; **Stop** (red ■) restores the editor fly camera exactly where it
-  was. Play mode is view state only: it never touches the undo history or the dirty flag.
+  was.
+- **Edit/play boundary** — entering Play snapshots the document (via the binary serializer) and
+  Stop restores it, so anything a running game does to the scene is discarded on Stop (entering
+  Play is a history boundary). Play mode never touches the dirty flag. Code lives in
+  `com.ardor3d.editor.play`: `PlaySession` (snapshot/restore), a small `GameMode` /
+  `GameContext` / `GameInput` behaviour SPI, and `GameInputController` (play-mode input routing).
+- **Sample game: checkers** — Game > Play Checkers launches a full game of American/English
+  draughts (`com.ardor3d.editor.checkers`): a pure, unit-tested rules engine (`Board`) as the
+  model, a `CheckersView` as its scene view, and a `CheckersGame` (`GameMode`) tying clicks to
+  moves. Click a piece to see its legal moves highlighted, click a square to move (jumps play their
+  whole mandatory chain); the status bar shows whose turn it is and the result. A worked example of
+  the state/view split the play framework is built around.
 - **Undo/redo everywhere** — every mutation goes through a command stack
   (`com.ardor3d.editor.command`). Continuous gestures (slider drags, typing, gizmo drags)
   coalesce into single undo steps. `Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y`.
@@ -122,9 +133,12 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
 - A camera object's stored aspect ratio is nominal — play mode always renders with the viewport's
   own aspect (fitting the camera's vertical field of view to the panel), and the frustum gizmo is
   drawn with the camera's stored aspect. There is no explicit aspect control in the inspector.
-- Play mode drives a single camera and does not run any game logic — it is a viewpoint preview,
-  not a runtime. There is no in-viewport control of the played camera (WASD is suspended);
-  animate or move the `CameraNode` to change the view.
+- Play mode renders through a single camera object; there is no in-viewport fly control of it
+  (WASD is suspended). A running `GameMode` receives input and drives the scene, but a game is
+  launched from code/menu (e.g. Game > Play Checkers) — there is no in-editor game picker, and
+  `activeGameMode` is a one-shot per play session (cleared on Stop).
+- The checkers sample builds its board and pieces procedurally (no imported art) and animates
+  moves with a simple linear slide; PBR models and richer animation are later-phase work.
 - Model import covers OBJ and COLLADA (static geometry; COLLADA cameras and animations are not
   brought into the editor). Other formats in `ardor3d-extras` could be added to
   `com.ardor3d.editor.io.ModelImport` the same way.

--- a/ardor3d-editor/README.md
+++ b/ardor3d-editor/README.md
@@ -41,16 +41,23 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
   merged undo step. Transform fields show a dash where the selection disagrees.
 - **Viewport** — WASD + drag fly camera, mouse-wheel dolly, primitive-accurate click selection,
   v2 transform gizmos for translate/rotate/scale (eased hover highlight, per-gizmo cursors,
-  Ctrl-snap, Escape to cancel a drag), per-light overlay gizmos, reference grid.
+  Ctrl-snap, Escape to cancel a drag), per-light and per-camera overlay gizmos, reference grid.
+- **Camera objects & play mode** — GameObject > Camera adds a `CameraNode` (a movable scene
+  object carrying its own frustum), shown as a wireframe frustum gizmo that reflects its field of
+  view and points where it looks. The inspector edits field of view and the near/far clip planes.
+  The viewport toolbar's **Play** button (green ▶) renders the scene through the selected camera
+  object — or the first one if none is selected — filling the panel with that camera's view and
+  hiding all editor overlays; **Stop** (red ■) restores the editor fly camera exactly where it
+  was. Play mode is view state only: it never touches the undo history or the dirty flag.
 - **Undo/redo everywhere** — every mutation goes through a command stack
   (`com.ardor3d.editor.command`). Continuous gestures (slider drags, typing, gizmo drags)
   coalesce into single undo steps. `Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y`.
 - **Persistence** — File > New / Open / Save / Save As using Ardor3D's binary format (`.a3d`),
   plus Wavefront OBJ and COLLADA (`.dae`) import. Unsaved changes are flagged in the title bar
   and confirmed before being discarded.
-- **Object creation** — GameObject menu: 13 primitive shapes, empty nodes, and
-  point/directional/spot lights. New objects are created under the selected Node (or the scene
-  root).
+- **Object creation** — GameObject menu: 16 primitive shapes, empty nodes,
+  point/directional/spot lights, and camera objects. New objects are created under the selected
+  Node (or the scene root).
 - **Visibility** — per-row eye toggle in the hierarchy hides/shows a subtree (undoable). Hidden
   objects are culled and unpickable, so viewport clicks pass through them, and every light in the
   hidden subtree is disabled so it stops illuminating the scene (restored on show/undo).
@@ -68,6 +75,7 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
 | `W A S D` + right-drag | Fly camera (viewport focused) |
 | `Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y` | Undo / Redo (window-wide) |
 | `Ctrl+D` | Duplicate selection (window-wide) |
+| `Ctrl+P` | Toggle play mode (window-wide) |
 | `Ctrl+N` / `Ctrl+O` / `Ctrl+S` / `Ctrl+Shift+S` | New / Open / Save / Save As (window-wide) |
 
 ## Architecture notes
@@ -111,7 +119,12 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
   attitude ±90° singularity, where the decomposition isn't unique) and only re-derives them from
   the matrix after a gizmo drag or undo — after one of those, an equivalent-but-different
   triplet may be shown.
-- No camera objects or play mode.
-- Model import covers OBJ and COLLADA (static geometry; COLLADA animations are not brought into
-  the editor). Other formats in `ardor3d-extras` could be added to
+- A camera object's stored aspect ratio is nominal — play mode always renders with the viewport's
+  own aspect (fitting the camera's vertical field of view to the panel), and the frustum gizmo is
+  drawn with the camera's stored aspect. There is no explicit aspect control in the inspector.
+- Play mode drives a single camera and does not run any game logic — it is a viewpoint preview,
+  not a runtime. There is no in-viewport control of the played camera (WASD is suspended);
+  animate or move the `CameraNode` to change the view.
+- Model import covers OBJ and COLLADA (static geometry; COLLADA cameras and animations are not
+  brought into the editor). Other formats in `ardor3d-extras` could be added to
   `com.ardor3d.editor.io.ModelImport` the same way.

--- a/ardor3d-editor/README.md
+++ b/ardor3d-editor/README.md
@@ -19,6 +19,18 @@ Note: on WSLg (and Mesa drivers generally), lit meshes were historically invisib
 an engine bug (two shadow-sampler types sharing a texture unit; strict drivers reject the draw),
 fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under WSLg.
 
+### Tests
+
+```
+LIBGL_ALWAYS_SOFTWARE=1 ./gradlew :ardor3d-editor:test
+```
+
+Some tests create a real GL context; on WSL the default driver can crash the forked test JVM,
+while software GL is reliable (and plenty fast) there. Gradle does not forward `-D` system
+properties to test JVMs — use environment variables. On a `/mnt/c` checkout, pointing the
+project cache at a Linux-side directory (`--project-cache-dir <linux path>`) avoids
+Windows-filesystem cache corruption.
+
 ## Features
 
 - **Hierarchy panel** — live scene tree with selection, right-click context menu
@@ -116,6 +128,13 @@ fixed in `LightManager`/`Lwjgl3ShaderUtils`. The editor now renders fully under 
 - **Commands** — `EditorCommand` / `CommandStack` in `com.ardor3d.editor.command`. UI code
   builds `SetterCommand`s with merge keys for coalescing; gizmo drags are captured by
   `GizmoUndoFilter`, an interact-system `UpdateFilter` that records one command per drag.
+- **Game behavior (play SPI)** — a `GameMode` runs only between Play and Stop: it receives a
+  `GameContext` (live scene root, play camera, picking, status line) at start and a `GameInput`
+  each frame. The design contract is *state vs. view*: the game owns a plain, engine-free model
+  and syncs the scene graph from it, never treating the scene as the source of truth — in the
+  checkers sample, `Board` is pure logic and `CheckersView` is its renderer. Because entering
+  Play snapshots the document, `onStart` may freely clear or rebuild the scene; Stop restores
+  the pre-play document exactly.
 - **Serialization** — scenes save with `BinaryExporter`. Render materials are not serialized;
   they are re-derived on load with `MaterialUtil.autoMaterials`. `ColorSurface` properties,
   render states, lights and transforms round-trip (covered by `SceneRoundTripTest`).

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorOverlays.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorOverlays.kt
@@ -12,6 +12,7 @@ package com.ardor3d.editor
 
 import com.ardor3d.math.ColorRGBA
 import com.ardor3d.math.Vector3
+import com.ardor3d.renderer.Camera
 import com.ardor3d.scenegraph.Line
 import com.ardor3d.scenegraph.Node
 import com.ardor3d.scenegraph.shape.Box
@@ -119,6 +120,61 @@ internal fun createLightGizmo(): Node {
         ray.lineWidth = 2.0f
         gizmoNode.attachChild(ray)
     }
+
+    return gizmoNode
+}
+
+/**
+ * Creates a wireframe frustum gizmo for a camera object. The apex sits at the local origin and
+ * the frustum opens along local +Z, matching [com.ardor3d.scenegraph.extension.CameraNode]'s
+ * axis mapping (world-rotation column 2 is the view direction). The rectangle is drawn to a
+ * fixed display distance - scaled to the camera's field of view and aspect - so a camera with a
+ * far plane of 1000 doesn't draw a kilometre-long cone; only the shape (fov, aspect) is
+ * reflected, not the absolute near/far distances.
+ */
+internal fun createCameraGizmo(camera: Camera): Node {
+    val gizmoNode = Node("CameraGizmo")
+    val color = ColorRGBA(0.3f, 0.85f, 1f, 1f)  // cyan, distinct from the yellow light gizmo
+
+    // Small body box marking the camera position/orientation.
+    val body = Box("CameraBody", Vector3.ZERO, 0.15, 0.15, 0.2)
+    body.setDefaultColor(color)
+    gizmoNode.attachChild(body)
+
+    // Half-extents of the frustum rectangle at the display distance. tan(fov/2) == top/near and
+    // tan(fov/2)*aspect == right/near, so the frustum's proportions come straight from the planes.
+    val d = 1.5
+    val near = camera.frustumNear
+    val halfHeight = if (near > 0.0) d * camera.frustumTop / near else d * 0.5
+    val halfWidth = if (near > 0.0) d * camera.frustumRight / near else d * 0.5
+
+    val corners = arrayOf(
+        Vector3(-halfWidth, -halfHeight, d),
+        Vector3(halfWidth, -halfHeight, d),
+        Vector3(halfWidth, halfHeight, d),
+        Vector3(-halfWidth, halfHeight, d)
+    )
+
+    val verts = mutableListOf<Vector3>()
+    // Four edges from the apex to the far-plane corners.
+    for (corner in corners) {
+        verts.add(Vector3())
+        verts.add(Vector3(corner))
+    }
+    // The far-plane rectangle.
+    for (i in corners.indices) {
+        verts.add(Vector3(corners[i]))
+        verts.add(Vector3(corners[(i + 1) % 4]))
+    }
+    // A small "up" triangle above the top edge so roll is legible at a glance.
+    val tipY = halfHeight + halfHeight * 0.5
+    verts.add(Vector3(-halfWidth * 0.4, halfHeight, d)); verts.add(Vector3(0.0, tipY, d))
+    verts.add(Vector3(0.0, tipY, d)); verts.add(Vector3(halfWidth * 0.4, halfHeight, d))
+
+    val frustum = Line("CameraFrustum", verts.toTypedArray(), null, null, null)
+    frustum.setDefaultColor(color)
+    frustum.lineWidth = 1.5f
+    gizmoNode.attachChild(frustum)
 
     return gizmoNode
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -1049,7 +1049,15 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
     fun startCheckers() {
         if (editorState.playing) return
         activeGameMode = com.ardor3d.editor.checkers.CheckersGame()
-        if (playCameraCandidate() == null) addCamera()
+        if (playCameraCandidate() == null) {
+            // Auto-add a camera framed on the board (an existing camera is left as the user set it).
+            addCamera()
+            (editorState.primarySelection as? CameraNode)?.camera?.let { cam ->
+                cam.setLocation(Vector3(5.5, 5.0, 8.5))
+                cam.lookAt(Vector3.ZERO, Vector3.UNIT_Y)
+            }
+            (editorState.primarySelection as? CameraNode)?.updateFromCamera()
+        }
         enterPlayMode()
     }
 

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -1036,10 +1036,21 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         // (which syncPlayCamera drives to match the play camera each frame). Whatever onStart does to
         // the scene is inside the snapshot boundary, so Stop discards it.
         activeGameMode?.let { game ->
-            val context = SceneGameContext(root, render)
+            val context = SceneGameContext(root, render) { status -> editorState.updateGameStatus(status) }
             gameContext = context
             game.onStart(context)
         }
+    }
+
+    /**
+     * Launches a game of checkers: sets it as the active game mode and enters play. Ensures a camera
+     * exists first (adding one framing the board), since play renders through a camera object.
+     */
+    fun startCheckers() {
+        if (editorState.playing) return
+        activeGameMode = com.ardor3d.editor.checkers.CheckersGame()
+        if (playCameraCandidate() == null) addCamera()
+        enterPlayMode()
     }
 
     /**
@@ -1057,9 +1068,12 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
             if (!editorState.playing) return@add
 
             // Stop the game while the play scene is still live (references still valid), before the
-            // snapshot restore throws its scene away.
+            // snapshot restore throws its scene away. Each launch is a one-shot game: clear it so
+            // the next plain Play is view-only again.
             activeGameMode?.onStop()
+            activeGameMode = null
             gameContext = null
+            editorState.updateGameStatus(null)
 
             val render = canvasRenderer?.camera
             if (render != null && hasSavedEditorCamera) {

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -22,7 +22,12 @@ import com.ardor3d.editor.util.SelectionUtil
 import com.ardor3d.editor.interact.GizmoReadoutFormat
 import com.ardor3d.editor.interact.GizmoUndoFilter
 import com.ardor3d.editor.menu.ShapeType
+import com.ardor3d.editor.play.GameContext
+import com.ardor3d.editor.play.GameInput
+import com.ardor3d.editor.play.GameInputController
+import com.ardor3d.editor.play.GameMode
 import com.ardor3d.editor.play.PlaySession
+import com.ardor3d.editor.play.SceneGameContext
 import com.ardor3d.editor.util.CameraObjectUtil
 import com.ardor3d.extension.interact.InteractManager
 import com.ardor3d.extension.interact.filter.AngleSnapFilter
@@ -111,6 +116,13 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
     // exactly where the user was looking.
     private val playSession = PlaySession()
     private var playCamera: CameraNode? = null
+
+    // The game driven by play mode, if any. Null means Play is just "view through the camera" - the
+    // behavior before Phase 2. Set by the code that starts a game (a sample game, a test). The
+    // context is built on enter and lives for the play session; input is drained per play frame.
+    var activeGameMode: GameMode? = null
+    private var gameContext: GameContext? = null
+    private var gameInputController: GameInputController? = null
     private val savedEditorLocation = Vector3()
     private val savedEditorLeft = Vector3()
     private val savedEditorUp = Vector3()
@@ -172,6 +184,10 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         val manager = InteractManager()
         interactManager = manager
         manager.setupInput(canvas, physicalLayer, logicalLayer)
+
+        // Play-mode input routes through its own logical layer on the shared physical layer; the
+        // editor drives it (and only it) while playing. See GameInputController.
+        gameInputController = GameInputController(canvas, physicalLayer)
 
         // v2 transform gizmos, each with its full handle set. The scale gizmo drives all three
         // axes (the old SimpleScaleWidget was uniform-Y only).
@@ -1015,6 +1031,15 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         playCamera = cameraNode
         interactManager?.setSpatialTarget(null)
         editorState.setPlaying(true, cameraNode.name)
+
+        // Start the game (if one is set) on the live play scene, viewed through the render camera
+        // (which syncPlayCamera drives to match the play camera each frame). Whatever onStart does to
+        // the scene is inside the snapshot boundary, so Stop discards it.
+        activeGameMode?.let { game ->
+            val context = SceneGameContext(root, render)
+            gameContext = context
+            game.onStart(context)
+        }
     }
 
     /**
@@ -1030,6 +1055,11 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
             // A double-toggle can enqueue two exits; the first flips playing off, so the second
             // finds nothing to do rather than trying to stop an already-stopped session.
             if (!editorState.playing) return@add
+
+            // Stop the game while the play scene is still live (references still valid), before the
+            // snapshot restore throws its scene away.
+            activeGameMode?.onStop()
+            gameContext = null
 
             val render = canvasRenderer?.camera
             if (render != null && hasSavedEditorCamera) {
@@ -1190,12 +1220,13 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         val playing = editorState.playing
 
         // Input routing switch. While playing, the viewport is the game view: editor input
-        // (fly camera, picking, transform gizmo, hotkeys) is off and input is routed to the active
-        // game instead. Until a game attaches an input layer this dispatches nowhere - the same as
-        // the old "suppress input while playing" behavior, but now it is a routing seam rather than
-        // a dead end.
+        // (fly camera, picking, transform gizmo, hotkeys) is off. Input is drained through the game
+        // input layer every play frame (both to feed the game and to keep events from piling up) and
+        // the active game, if any, is ticked with it - before updateGeometricState below, so this
+        // frame's model changes are baked and syncPlayCamera sees them.
         if (playing) {
-            playSession.routeInput(timer.timePerFrame)
+            val input = gameInputController?.poll(timer.timePerFrame) ?: GameInput.EMPTY
+            activeGameMode?.update(timer.timePerFrame, input)
         } else {
             // Check if transform mode changed and update active widget
             if (lastTransformMode != editorState.transformMode) {

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -22,6 +22,8 @@ import com.ardor3d.editor.util.SelectionUtil
 import com.ardor3d.editor.interact.GizmoReadoutFormat
 import com.ardor3d.editor.interact.GizmoUndoFilter
 import com.ardor3d.editor.menu.ShapeType
+import com.ardor3d.editor.play.PlaySession
+import com.ardor3d.editor.util.CameraObjectUtil
 import com.ardor3d.extension.interact.InteractManager
 import com.ardor3d.extension.interact.filter.AngleSnapFilter
 import com.ardor3d.extension.interact.filter.GridSnapFilter
@@ -64,6 +66,7 @@ import com.ardor3d.scenegraph.Mesh
 import com.ardor3d.scenegraph.Node
 import com.ardor3d.scenegraph.SceneIndexer
 import com.ardor3d.scenegraph.Spatial
+import com.ardor3d.scenegraph.extension.CameraNode
 import com.ardor3d.scenegraph.hint.CullHint
 import com.ardor3d.scenegraph.hint.PickingHint
 import com.ardor3d.scenegraph.shape.*
@@ -98,6 +101,21 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
     // One overlay gizmo per light in the document, refreshed on structure changes.
     private val lightGizmos = mutableMapOf<Light, Node>()
     private var lastStructureVersion = -1L
+
+    // One overlay frustum gizmo per camera object, rebuilt when its frustum shape changes.
+    private val cameraGizmos = mutableMapOf<CameraNode, Node>()
+    private val cameraGizmoShapes = mutableMapOf<CameraNode, DoubleArray>()
+
+    // Play mode: the edit/play boundary (snapshot on enter, restore on exit), the camera object
+    // currently driving the viewport, plus the editor fly camera's saved pose so Stop restores
+    // exactly where the user was looking.
+    private val playSession = PlaySession()
+    private var playCamera: CameraNode? = null
+    private val savedEditorLocation = Vector3()
+    private val savedEditorLeft = Vector3()
+    private val savedEditorUp = Vector3()
+    private val savedEditorDirection = Vector3()
+    private var hasSavedEditorCamera = false
 
     // Document lifecycle actions deferred to update() so they run with the GL context current.
     private val pendingActions = java.util.concurrent.ConcurrentLinkedQueue<() -> Unit>()
@@ -345,6 +363,39 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
     }
 
     /**
+     * Adds a new camera object (a [CameraNode] managing its own [Camera]) to the scene (undoable)
+     * and selects it. The camera starts framed on the scene origin, matching the editor's default
+     * viewpoint; its transform - editable by gizmo or inspector - drives the managed camera, and
+     * play mode renders the viewport through it.
+     */
+    fun addCamera() {
+        val count = shapeCounters.merge("Camera", 1, Int::plus)!!
+        val cam = Camera(100, 100)
+        CameraObjectUtil.setPerspective(
+            cam, CameraObjectUtil.DEFAULT_FOV_DEGREES, 1.0,
+            CameraObjectUtil.DEFAULT_NEAR, CameraObjectUtil.DEFAULT_FAR
+        )
+        cam.setLocation(Vector3(8.0, 6.0, 12.0))
+        cam.lookAt(Vector3.ZERO, Vector3.UNIT_Y)
+
+        val node = CameraNode("Camera $count", cam)
+        // Seed the node's local transform from the camera frame; from here the node is the source
+        // of truth and updateWorldTransform keeps the managed camera in sync.
+        node.updateFromCamera()
+
+        editorState.execute(
+            AttachChildCommand(
+                parent = creationParent(),
+                child = node,
+                name = "Add Camera $count",
+                onExecuted = { editorState.select(node) },
+                onUndone = { if (editorState.isSelected(node)) editorState.clearSelection() }
+            )
+        )
+        editorState.sealUndoMerge()
+    }
+
+    /**
      * State captured and applied by the visibility (eye) toggle: the toggled spatial's local
      * cull hint plus the enabled flag of every Light in its subtree. A culled light still
      * illuminates the scene - LightManager gathers lights by isEnabled() and ignores cull hints -
@@ -458,6 +509,60 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
                 gizmo
             }
         }
+    }
+
+    /**
+     * Collects all camera objects in the document.
+     */
+    private fun collectCameras(spatial: Spatial, into: MutableList<CameraNode>) {
+        if (spatial is CameraNode) {
+            into.add(spatial)
+        }
+        if (spatial is Node) {
+            for (child in spatial.children) {
+                collectCameras(child, into)
+            }
+        }
+    }
+
+    /**
+     * Keeps one overlay frustum gizmo per camera object: adds/removes gizmos as cameras come and
+     * go, rebuilds a gizmo's geometry when its frustum shape changes (fov / aspect / near edited
+     * in the inspector), and each frame moves every gizmo onto its camera's world pose and mirrors
+     * its cull state. Also refreshes [EditorState.hasCamera] so the Play button can enable itself.
+     */
+    private fun syncCameraGizmos() {
+        val cameras = mutableListOf<CameraNode>()
+        collectCameras(root, cameras)
+
+        val stale = cameraGizmos.keys - cameras.toSet()
+        for (camera in stale) {
+            cameraGizmos.remove(camera)?.let(overlayRoot::detachChild)
+            cameraGizmoShapes.remove(camera)
+        }
+        for (node in cameras) {
+            val cam = node.camera ?: continue
+            val shape = CameraObjectUtil.frustumShape(cam)
+            val existing = cameraGizmos[node]
+            if (existing == null || !shape.contentEquals(cameraGizmoShapes[node])) {
+                existing?.let(overlayRoot::detachChild)
+                val gizmo = createCameraGizmo(cam)
+                overlayRoot.attachChild(gizmo)
+                MaterialUtil.autoMaterials(gizmo)
+                cameraGizmos[node] = gizmo
+                cameraGizmoShapes[node] = shape
+            }
+        }
+        // Position each gizmo on its camera (translation and rotation, so the frustum points where
+        // the camera looks), hidden along with a hidden camera.
+        for ((node, gizmo) in cameraGizmos) {
+            gizmo.setRotation(node.worldRotation)
+            gizmo.setTranslation(node.worldTranslation)
+            gizmo.sceneHints.cullHint =
+                if (node.sceneHints.cullHint == CullHint.Always) CullHint.Always else CullHint.Inherit
+        }
+
+        editorState.updateHasCamera(cameras.isNotEmpty())
     }
 
     /**
@@ -870,6 +975,102 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         camera.lookAt(Vector3.ZERO, Vector3.UNIT_Y)
     }
 
+    /**
+     * The camera object play mode should render through: the selected one if a camera is selected,
+     * otherwise the first camera found in the document. Null when the scene has no cameras.
+     */
+    private fun playCameraCandidate(): CameraNode? {
+        (editorState.primarySelection as? CameraNode)?.let { return it }
+        val cameras = mutableListOf<CameraNode>()
+        collectCameras(root, cameras)
+        return cameras.firstOrNull()
+    }
+
+    /** Toggles play mode. */
+    fun togglePlayMode() {
+        if (editorState.playing) exitPlayMode() else enterPlayMode()
+    }
+
+    /**
+     * Enters play mode: snapshots the document so Stop can discard whatever play does to it, saves
+     * the editor fly camera's pose, and starts driving the viewport from a camera object. No-op if
+     * already playing or the scene has no camera. The per-frame sync in [update] does the actual
+     * driving; here we only capture state and clear editor affordances.
+     */
+    fun enterPlayMode() {
+        if (editorState.playing) return
+        val cameraNode = playCameraCandidate() ?: return
+        val render = canvasRenderer?.camera ?: return
+
+        // Snapshot the pre-play document. From here play-mode code may mutate the live scene freely;
+        // exitPlayMode restores this snapshot, so nothing play does survives Stop.
+        playSession.start(root)
+
+        savedEditorLocation.set(render.location)
+        savedEditorLeft.set(render.left)
+        savedEditorUp.set(render.up)
+        savedEditorDirection.set(render.direction)
+        hasSavedEditorCamera = true
+
+        playCamera = cameraNode
+        interactManager?.setSpatialTarget(null)
+        editorState.setPlaying(true, cameraNode.name)
+    }
+
+    /**
+     * Leaves play mode: restores the editor fly camera's pose and reinstalls the pre-play scene from
+     * the snapshot, discarding every play-mode mutation. The document swap runs as a deferred action
+     * (like Open/New) so it happens at a clean point in [update] with the same context conditions as
+     * the other document-root operations; that same drain flips `playing` off, so the next render
+     * shows the restored scene with editor overlays back.
+     */
+    fun exitPlayMode() {
+        if (!editorState.playing) return
+        pendingActions.add {
+            // A double-toggle can enqueue two exits; the first flips playing off, so the second
+            // finds nothing to do rather than trying to stop an already-stopped session.
+            if (!editorState.playing) return@add
+
+            val render = canvasRenderer?.camera
+            if (render != null && hasSavedEditorCamera) {
+                render.setFrame(savedEditorLocation, savedEditorLeft, savedEditorUp, savedEditorDirection)
+            }
+            hasSavedEditorCamera = false
+            playCamera = null
+
+            // Rebuild the pre-play document and install it, discarding play-mode changes. This
+            // resets the undo history: entering play is a history boundary.
+            installDocumentRoot(playSession.stop())
+
+            editorState.setPlaying(false, null)
+            resetLastDimensions()
+            lastSelection = null
+        }
+    }
+
+    /**
+     * While playing, drives the viewport render camera from the active camera object: copies its
+     * frame and applies its field of view / near / far with the *viewport's* aspect (so the play
+     * view fills the panel). Called at the end of [update], after the document's world transforms
+     * are current, so the managed camera reflects this frame's node pose.
+     */
+    private fun syncPlayCamera() {
+        val cameraNode = playCamera ?: return
+        val render = canvasRenderer?.camera ?: return
+        val cvs = canvas ?: return
+        val gameCam = cameraNode.camera ?: return
+
+        render.setFrame(gameCam)
+        val w = cvs.contentWidth
+        val h = cvs.contentHeight
+        if (w > 0 && h > 0) {
+            CameraObjectUtil.setPerspective(
+                render, CameraObjectUtil.fovYDegrees(gameCam), w.toDouble() / h.toDouble(),
+                gameCam.frustumNear, gameCam.frustumFar
+            )
+        }
+    }
+
     override fun render(renderer: Renderer): Boolean {
         // Setup on first render (GL context now available)
         if (!initialized) {
@@ -901,12 +1102,16 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
                 lastWidth = w
                 lastHeight = h
                 camera.resize(w, h)
-                camera.setFrustumPerspective(
-                    45.0,
-                    w.toDouble() / h.toDouble(),
-                    0.1,
-                    1000.0
-                )
+                // In play mode the frustum is driven per-frame from the active camera object
+                // (see syncPlayCamera); don't clobber it with the editor's default perspective.
+                if (!editorState.playing) {
+                    camera.setFrustumPerspective(
+                        45.0,
+                        w.toDouble() / h.toDouble(),
+                        0.1,
+                        1000.0
+                    )
+                }
             }
         }
 
@@ -914,6 +1119,15 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         SceneIndexer.getCurrent()?.onRender(renderer)
 
         renderer.draw(root)
+
+        // In play mode the viewport shows only the document, exactly as the game camera sees it:
+        // no grid, light/camera gizmos, selection bounds, transform gizmo, or drag readout. Just
+        // flush the scene and return.
+        if (editorState.playing) {
+            renderer.renderBuckets()
+            return true
+        }
+
         renderer.draw(overlayRoot)
 
         // Draw selection highlight (bounding box) for selected objects. The gizmo target
@@ -973,33 +1187,44 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         // Execute updateQueue item
         GameTaskQueueManager.getManager(ContextManager.getCurrentContext()).getQueue(GameTaskQueue.UPDATE).execute()
 
-        // Check if transform mode changed and update active widget
-        if (lastTransformMode != editorState.transformMode) {
-            lastTransformMode = editorState.transformMode
-            updateActiveWidget()
-        }
+        val playing = editorState.playing
 
-        interactManager?.let {
-            it.logicalLayer.checkTriggers(timer.timePerFrame)
-            it.update(timer)
-        } ?: logicalLayer?.checkTriggers(timer.timePerFrame)
+        // Input routing switch. While playing, the viewport is the game view: editor input
+        // (fly camera, picking, transform gizmo, hotkeys) is off and input is routed to the active
+        // game instead. Until a game attaches an input layer this dispatches nowhere - the same as
+        // the old "suppress input while playing" behavior, but now it is a routing seam rather than
+        // a dead end.
+        if (playing) {
+            playSession.routeInput(timer.timePerFrame)
+        } else {
+            // Check if transform mode changed and update active widget
+            if (lastTransformMode != editorState.transformMode) {
+                lastTransformMode = editorState.transformMode
+                updateActiveWidget()
+            }
 
-        // Sync the gizmo target with the editor selection (which may have been
-        // changed by the hierarchy panel, picking, or programmatically).
-        if (lastSelection !== editorState.primarySelection) {
-            lastSelection = editorState.primarySelection
-            transformCacheValid = false
-            updateInteractTarget()
-        }
+            interactManager?.let {
+                it.logicalLayer.checkTriggers(timer.timePerFrame)
+                it.update(timer)
+            } ?: logicalLayer?.checkTriggers(timer.timePerFrame)
 
-        // Notify the UI when the selected spatial's transform actually changed
-        // (e.g. dragged by a gizmo) so the inspector refreshes.
-        val selected = lastSelection
-        if (selected != null) {
-            if (!transformCacheValid || lastSelectedTransform != selected.transform) {
-                lastSelectedTransform.set(selected.transform)
-                transformCacheValid = true
-                editorState.notifyTransformChanged()
+            // Sync the gizmo target with the editor selection (which may have been
+            // changed by the hierarchy panel, picking, or programmatically).
+            if (lastSelection !== editorState.primarySelection) {
+                lastSelection = editorState.primarySelection
+                transformCacheValid = false
+                updateInteractTarget()
+            }
+
+            // Notify the UI when the selected spatial's transform actually changed
+            // (e.g. dragged by a gizmo) so the inspector refreshes.
+            val selected = lastSelection
+            if (selected != null) {
+                if (!transformCacheValid || lastSelectedTransform != selected.transform) {
+                    lastSelectedTransform.set(selected.transform)
+                    transformCacheValid = true
+                    editorState.notifyTransformChanged()
+                }
             }
         }
 
@@ -1016,10 +1241,18 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
                 if (light.sceneHints.cullHint == CullHint.Always) CullHint.Always else CullHint.Inherit
         }
 
+        // Keep camera gizmos in sync (add/remove/reshape, and position onto each camera).
+        syncCameraGizmos()
+
         // Update geometric state for the document, the editor overlay, and the readout root
         root.updateGeometricState(timer.timePerFrame, true)
         overlayRoot.updateGeometricState(timer.timePerFrame, true)
         orthoRoot.updateGeometricState(timer.timePerFrame, true)
+
+        // With world transforms now current, drive the viewport from the active camera object.
+        if (playing) {
+            syncPlayCamera()
+        }
 
         // Status bar FPS, refreshed twice a second
         fpsAccumulatedTime += timer.timePerFrame

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorScene.kt
@@ -1032,9 +1032,14 @@ class EditorScene(private val editorState: EditorState) : Scene, Updater {
         interactManager?.setSpatialTarget(null)
         editorState.setPlaying(true, cameraNode.name)
 
+        // Align the render camera with the play camera now, not at the end of the next update, so
+        // onStart below already sees the camera it will play through (a game may pick or frame
+        // content from it immediately).
+        syncPlayCamera()
+
         // Start the game (if one is set) on the live play scene, viewed through the render camera
-        // (which syncPlayCamera drives to match the play camera each frame). Whatever onStart does to
-        // the scene is inside the snapshot boundary, so Stop discards it.
+        // (which syncPlayCamera keeps matched to the play camera each frame). Whatever onStart does
+        // to the scene is inside the snapshot boundary, so Stop discards it.
         activeGameMode?.let { game ->
             val context = SceneGameContext(root, render) { status -> editorState.updateGameStatus(status) }
             gameContext = context

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorState.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorState.kt
@@ -53,10 +53,20 @@ class EditorState {
     var hasCamera: Boolean by mutableStateOf(false)
         private set
 
+    // A short status line reported by the active game (e.g. "Red to move", "Black wins!"), shown in
+    // the play status bar. Null when no game is reporting. View state - never touches undo/dirty.
+    var gameStatus: String? by mutableStateOf(null)
+        private set
+
     /** Set by the scene when entering/leaving play mode. */
     fun setPlaying(playing: Boolean, cameraName: String?) {
         this.playing = playing
         this.playCameraName = cameraName
+    }
+
+    /** Set by the scene as the active game reports status (null clears it). */
+    fun updateGameStatus(status: String?) {
+        this.gameStatus = status
     }
 
     /** Set by the scene as camera objects are added/removed. */

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorState.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/EditorState.kt
@@ -38,6 +38,32 @@ class EditorState {
     // Render loop frame rate, updated by the scene for the status bar
     var framesPerSecond: Int by mutableStateOf(0)
 
+    // Play mode: when true the viewport renders through a camera object instead of the editor
+    // fly camera, with editor overlays and controls suspended. This is view state, not a
+    // document edit - it never touches the undo history or the dirty flag.
+    var playing: Boolean by mutableStateOf(false)
+        private set
+
+    // Name of the camera object play mode is rendering through, for the status bar.
+    var playCameraName: String? by mutableStateOf(null)
+        private set
+
+    // Whether the document contains at least one camera object, so the Play button can enable
+    // itself. Refreshed by the scene as the structure changes.
+    var hasCamera: Boolean by mutableStateOf(false)
+        private set
+
+    /** Set by the scene when entering/leaving play mode. */
+    fun setPlaying(playing: Boolean, cameraName: String?) {
+        this.playing = playing
+        this.playCameraName = cameraName
+    }
+
+    /** Set by the scene as camera objects are added/removed. */
+    fun updateHasCamera(hasCamera: Boolean) {
+        this.hasCamera = hasCamera
+    }
+
     // Version counter observed by the inspector - bumped when a transform
     // actually changes so the UI recomposes only when needed.
     var transformVersion: Long by mutableStateOf(0L)

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/NativeEditorApp.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/NativeEditorApp.kt
@@ -250,7 +250,8 @@ fun NativeEditorApp(
             insertSpatial = editorScene::insertSpatial,
             toggleVisibility = editorScene::toggleVisibility,
             createEmpty = editorScene::createEmptyNode,
-            togglePlayMode = editorScene::togglePlayMode
+            togglePlayMode = editorScene::togglePlayMode,
+            playCheckers = editorScene::startCheckers
         )
     }
     val fileOperations = remember(editorScene, window) {

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/NativeEditorApp.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/NativeEditorApp.kt
@@ -154,6 +154,11 @@ fun main() = application {
                         true
                     }
 
+                    Key.P -> {
+                        shortcuts.sceneOperations?.togglePlayMode?.invoke()
+                        true
+                    }
+
                     Key.N -> {
                         shortcuts.fileOperations?.newScene?.invoke()
                         true
@@ -235,6 +240,7 @@ fun NativeEditorApp(
         SceneOperations(
             addShape = editorScene::addShape,
             addLight = editorScene::addLight,
+            addCamera = editorScene::addCamera,
             deleteSpatial = editorScene::deleteSpatial,
             duplicateSpatial = editorScene::duplicateSpatial,
             deleteSelection = editorScene::deleteSelection,
@@ -243,7 +249,8 @@ fun NativeEditorApp(
             reparentSpatial = editorScene::reparentSpatial,
             insertSpatial = editorScene::insertSpatial,
             toggleVisibility = editorScene::toggleVisibility,
-            createEmpty = editorScene::createEmptyNode
+            createEmpty = editorScene::createEmptyNode,
+            togglePlayMode = editorScene::togglePlayMode
         )
     }
     val fileOperations = remember(editorScene, window) {
@@ -311,6 +318,7 @@ fun NativeEditorApp(
                         // Toolbar at top
                         ViewportToolbar(
                             editorState = editorState,
+                            onTogglePlay = { sceneOperations.togglePlayMode() },
                             modifier = Modifier.padding(8.dp)
                         )
 

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/SceneOperations.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/SceneOperations.kt
@@ -24,7 +24,8 @@ enum class LightType {
 /**
  * Scene operations exposed to the UI panels. Implemented by the scene owner (EditorScene) and
  * passed to menus/panels so they stay decoupled from scene internals. Most are undoable document
- * edits; [togglePlayMode] is the exception - it toggles view state, not the document.
+ * edits; [togglePlayMode] and [playCheckers] are the exceptions - they toggle view/play state,
+ * not the document.
  */
 class SceneOperations(
     val addShape: (ShapeType) -> Unit,
@@ -39,5 +40,6 @@ class SceneOperations(
     val insertSpatial: (Spatial, Insertion) -> Unit,
     val toggleVisibility: (Spatial) -> Unit,
     val createEmpty: () -> Unit,
-    val togglePlayMode: () -> Unit
+    val togglePlayMode: () -> Unit,
+    val playCheckers: () -> Unit
 )

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/SceneOperations.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/SceneOperations.kt
@@ -22,12 +22,14 @@ enum class LightType {
 }
 
 /**
- * Undoable scene operations exposed to the UI panels. Implemented by the scene owner
- * (EditorScene) and passed to menus/panels so they stay decoupled from scene internals.
+ * Scene operations exposed to the UI panels. Implemented by the scene owner (EditorScene) and
+ * passed to menus/panels so they stay decoupled from scene internals. Most are undoable document
+ * edits; [togglePlayMode] is the exception - it toggles view state, not the document.
  */
 class SceneOperations(
     val addShape: (ShapeType) -> Unit,
     val addLight: (LightType) -> Unit,
+    val addCamera: () -> Unit,
     val deleteSpatial: (Spatial) -> Unit,
     val duplicateSpatial: (Spatial) -> Unit,
     val deleteSelection: () -> Unit,
@@ -36,5 +38,6 @@ class SceneOperations(
     val reparentSpatial: (Spatial, Node) -> Unit,
     val insertSpatial: (Spatial, Insertion) -> Unit,
     val toggleVisibility: (Spatial) -> Unit,
-    val createEmpty: () -> Unit
+    val createEmpty: () -> Unit,
+    val togglePlayMode: () -> Unit
 )

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/Board.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/Board.kt
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+/**
+ * An immutable checkers position and the rules over it: American/English draughts on an 8x8 board,
+ * 12 pieces a side, men move and capture one diagonal forward, kings any diagonal, captures are
+ * mandatory and a jump chain must be played to its end. Pure - no Ardor3D dependency, fully
+ * unit-testable; [apply] returns a new [Board] rather than mutating.
+ *
+ * A side that has no legal move on its turn has lost (out of pieces, or blocked). A game with no
+ * capture and no man move for [DRAW_PLIES] plies is a draw.
+ */
+class Board private constructor(
+    private val pieces: Map<Square, Piece>,
+    /** Whose turn it is. */
+    val toMove: PieceColor,
+    /** Plies since the last capture or man move - the draw clock. */
+    val pliesSinceProgress: Int
+) {
+    /** The piece on [square], or null if empty. */
+    fun pieceAt(square: Square): Piece? = pieces[square]
+
+    /** Every occupied square, as an immutable view. */
+    val occupied: Map<Square, Piece> get() = pieces
+
+    /** Count of [color]'s pieces still on the board. */
+    fun count(color: PieceColor): Int = pieces.values.count { it.color == color }
+
+    /**
+     * Every legal move for [toMove]. If any capture exists, only captures are returned (mandatory
+     * capture); each jump entry is a maximal chain (you must keep jumping while you can).
+     */
+    fun legalMoves(): List<Move> {
+        val mine = pieces.entries.filter { it.value.color == toMove }
+        val jumps = mine.flatMap { jumpMoves(it.key, it.value) }
+        if (jumps.isNotEmpty()) return jumps
+        return mine.flatMap { simpleMoves(it.key, it.value) }
+    }
+
+    /** Legal moves for the piece on [square] (empty if it is not [toMove]'s, or a capture exists elsewhere). */
+    fun legalMovesFrom(square: Square): List<Move> = legalMoves().filter { it.from == square }
+
+    /**
+     * Applies [move], returning the resulting position with the turn passed to the opponent. Handles
+     * capture removal, crowning a man that reaches the far row, and the draw clock.
+     */
+    fun apply(move: Move): Board {
+        val next = pieces.toMutableMap()
+        val piece = next.remove(move.from) ?: error("no piece to move at ${move.from}")
+        for (captured in move.captured) next.remove(captured)
+        val crowned = !piece.king && isKingRow(piece.color, move.to)
+        next[move.to] = if (crowned) piece.copy(king = true) else piece
+        // A capture or any man move is progress; only quiet king shuffling advances the draw clock.
+        val progress = move.isCapture || !piece.king
+        return Board(next, toMove.opponent, if (progress) 0 else pliesSinceProgress + 1)
+    }
+
+    /** The winner, or null if the game is not decided by a side being unable to move. */
+    fun winner(): PieceColor? = if (legalMoves().isEmpty()) toMove.opponent else null
+
+    /** Whether the position is a draw by the no-progress rule (and not already a win). */
+    fun isDraw(): Boolean = winner() == null && pliesSinceProgress >= DRAW_PLIES
+
+    /** Whether the game is over (a side has won, or it is a draw). */
+    fun isGameOver(): Boolean = winner() != null || isDraw()
+
+    // --- move generation ---------------------------------------------------------------------
+
+    private fun simpleMoves(from: Square, piece: Piece): List<Move> =
+        stepDirections(piece).mapNotNull { (dRow, dCol) ->
+            val to = from.offset(dRow, dCol)
+            // Diagonal neighbours of a playable square are always playable, so on-board + empty suffices.
+            if (to.onBoard && pieceAt(to) == null) Move(from, listOf(to), emptyList()) else null
+        }
+
+    private fun jumpMoves(from: Square, piece: Piece): List<Move> {
+        val out = mutableListOf<Move>()
+        extendJumps(origin = from, piece = piece, at = from, path = emptyList(), captured = emptyList(), out = out)
+        return out
+    }
+
+    /**
+     * Depth-first over jump continuations, emitting only maximal chains (a chain that could jump
+     * again is never emitted short). A man that lands on its king row is crowned and stops there.
+     */
+    private fun extendJumps(
+        origin: Square,
+        piece: Piece,
+        at: Square,
+        path: List<Square>,
+        captured: List<Square>,
+        out: MutableList<Move>
+    ) {
+        for ((dRow, dCol) in stepDirections(piece)) {
+            val over = at.offset(dRow, dCol)
+            val land = at.offset(2 * dRow, 2 * dCol)
+            if (!land.onBoard) continue
+            val jumped = pieceAt(over) ?: continue
+            if (jumped.color != piece.color.opponent) continue
+            if (over in captured) continue // never jump the same piece twice in one chain
+            // Landing must be empty. Nothing has moved on this board yet, so the only occupied square
+            // that is legitimately free to land on is the piece's own (vacated) origin.
+            if (pieceAt(land) != null && land != origin) continue
+
+            val nextPath = path + land
+            val nextCaptured = captured + over
+            val crowns = !piece.king && isKingRow(piece.color, land)
+            if (crowns) {
+                // Reaching the king row ends the move (no continuing as a fresh king this turn).
+                out.add(Move(origin, nextPath, nextCaptured))
+            } else {
+                val sizeBefore = out.size
+                extendJumps(origin, piece, land, nextPath, nextCaptured, out)
+                // If no longer chain grew from here, this square is the end of a maximal chain.
+                if (out.size == sizeBefore) {
+                    out.add(Move(origin, nextPath, nextCaptured))
+                }
+            }
+        }
+    }
+
+    private fun stepDirections(piece: Piece): List<Pair<Int, Int>> {
+        if (piece.king) return KING_DIRECTIONS
+        val forward = if (piece.color == PieceColor.RED) 1 else -1
+        return listOf(forward to 1, forward to -1)
+    }
+
+    private fun isKingRow(color: PieceColor, square: Square): Boolean =
+        (color == PieceColor.RED && square.row == SIZE - 1) || (color == PieceColor.BLACK && square.row == 0)
+
+    companion object {
+        /** Board edge length in squares. */
+        const val SIZE = 8
+
+        /** Plies without a capture or man move after which the game is a draw (40 moves a side). */
+        const val DRAW_PLIES = 80
+
+        private val KING_DIRECTIONS = listOf(1 to 1, 1 to -1, -1 to 1, -1 to -1)
+
+        /** The standard opening position: 12 RED on the low three rows, 12 BLACK on the high three, RED to move. */
+        fun initial(): Board {
+            val pieces = mutableMapOf<Square, Piece>()
+            for (row in 0 until SIZE) {
+                for (col in 0 until SIZE) {
+                    val square = Square(row, col)
+                    if (!square.isPlayable) continue
+                    when (row) {
+                        0, 1, 2 -> pieces[square] = Piece(PieceColor.RED)
+                        5, 6, 7 -> pieces[square] = Piece(PieceColor.BLACK)
+                    }
+                }
+            }
+            return Board(pieces, PieceColor.RED, 0)
+        }
+
+        /** Builds a board from an explicit placement - used by tests to set up specific positions. */
+        fun of(toMove: PieceColor, pieces: Map<Square, Piece>, pliesSinceProgress: Int = 0): Board =
+            Board(pieces.toMap(), toMove, pliesSinceProgress)
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
@@ -16,6 +16,7 @@ import com.ardor3d.editor.play.GameMode
 import com.ardor3d.light.PointLight
 import com.ardor3d.math.Vector3
 import com.ardor3d.scenegraph.Spatial
+import com.ardor3d.scenegraph.extension.CameraNode
 
 /**
  * A playable game of checkers, driven by the editor's play mode. It is the worked example of the
@@ -48,6 +49,12 @@ class CheckersGame : GameMode {
         board = Board.initial()
         selected = null
         animating = false
+
+        // Take over the scene: clear the editing content (keeping camera objects, which play mode
+        // renders through) so the board stands alone. This is inside the snapshot boundary, so Stop
+        // restores whatever was here.
+        context.sceneRoot.children.filter { it !is CameraNode }.toList()
+            .forEach { context.sceneRoot.detachChild(it) }
 
         val view = CheckersView()
         this.view = view

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
@@ -88,8 +88,11 @@ class CheckersGame : GameMode {
 
         // The square under the pointer this frame (null = off the board).
         val hover = squareAt(context, input.mouseX, input.mouseY)
-        if (input.click != null) {
-            processClick(hover)
+        val click = input.click
+        if (click != null) {
+            // Resolve the click where it happened, not where the pointer is now - the pointer can
+            // move between the release and this frame's poll.
+            processClick(squareAt(context, click.x, click.y))
             if (animating) return // a move started; beginMove already cleared the highlights
         }
         refreshHighlights(hover)

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.editor.play.GameContext
+import com.ardor3d.editor.play.GameInput
+import com.ardor3d.editor.play.GameMode
+import com.ardor3d.light.PointLight
+import com.ardor3d.math.Vector3
+import com.ardor3d.scenegraph.Spatial
+
+/**
+ * A playable game of checkers, driven by the editor's play mode. It is the worked example of the
+ * plan's state/view split and the [GameMode] SPI: the pure [Board] is the authoritative state, the
+ * [CheckersView] is its scene view, and this class is the only place they meet - it turns clicks
+ * into model moves and re-syncs the view.
+ *
+ * Interaction: click a piece of the side to move to select it (its legal destinations light up),
+ * then click a highlighted square to move (a jump plays its whole mandatory chain). Clicking
+ * elsewhere reselects or clears. Moves animate with a short slide; input is ignored mid-slide and
+ * once the game is over.
+ */
+class CheckersGame : GameMode {
+    private var context: GameContext? = null
+    private lateinit var view: CheckersView
+    private var board: Board = Board.initial()
+    private var selected: Square? = null
+
+    // Move animation: slide the moving piece from its old square to its new one before the board
+    // (and view) snap to the applied position.
+    private var animating = false
+    private var animElapsed = 0.0
+    private var animNode: com.ardor3d.scenegraph.Node? = null
+    private val animFrom = Vector3()
+    private val animTo = Vector3()
+    private var pendingBoard: Board? = null
+
+    override fun onStart(context: GameContext) {
+        this.context = context
+        board = Board.initial()
+        selected = null
+        animating = false
+
+        val view = CheckersView()
+        this.view = view
+        view.rebuild(board)
+
+        // Own light so the board reads no matter how the host scene is lit.
+        val light = PointLight().apply {
+            name = "Checkers Light"
+            setTranslation(2.0, 9.0, 3.0)
+            intensity = 1.1f
+            isEnabled = true
+        }
+        view.root.attachChild(light)
+
+        context.materialize(view.root)
+        context.sceneRoot.attachChild(view.root)
+        context.setStatus(statusText())
+    }
+
+    override fun update(timePerFrame: Double, input: GameInput) {
+        val context = this.context ?: return
+        if (animating) {
+            advanceAnimation(timePerFrame)
+            return
+        }
+        if (board.isGameOver()) return
+
+        val click = input.click ?: return
+        val square = squareAt(context, click.x, click.y)
+        if (square == null) {
+            deselect()
+            return
+        }
+        onSquareClicked(square)
+    }
+
+    override fun onStop() {
+        context?.setStatus(null)
+        context = null
+        // view.root is thrown away when the pre-play scene is restored - nothing else to release.
+    }
+
+    // --- interaction -------------------------------------------------------------------------
+
+    private fun onSquareClicked(square: Square) {
+        val from = selected
+        if (from == null) {
+            trySelect(square)
+            return
+        }
+        val move = board.legalMovesFrom(from).firstOrNull { it.to == square }
+        when {
+            move != null -> beginMove(move)
+            board.pieceAt(square)?.color == board.toMove -> {
+                deselect()
+                trySelect(square)
+            }
+            else -> deselect()
+        }
+    }
+
+    private fun trySelect(square: Square) {
+        val piece = board.pieceAt(square)
+        if (piece == null || piece.color != board.toMove) return
+        val destinations = board.legalMovesFrom(square).map { it.to }
+        if (destinations.isEmpty()) return // a piece with no legal move (e.g. a capture is forced elsewhere)
+        selected = square
+        view.showHighlights(destinations)
+        context?.materialize(view.root) // materialize the new highlight meshes
+    }
+
+    private fun deselect() {
+        selected = null
+        view.clearHighlights()
+    }
+
+    private fun beginMove(move: Move) {
+        deselect()
+        pendingBoard = board.apply(move)
+        val node = view.pieceNodeAt(move.from)
+        if (node == null) {
+            finalizeMove() // nothing to animate; just snap
+            return
+        }
+        animNode = node
+        animFrom.set(view.worldPositionOf(move.from))
+        animTo.set(view.worldPositionOf(move.to))
+        animElapsed = 0.0
+        animating = true
+    }
+
+    private fun advanceAnimation(timePerFrame: Double) {
+        animElapsed += timePerFrame
+        val t = (animElapsed / ANIM_DURATION).coerceIn(0.0, 1.0)
+        animNode?.setTranslation(
+            animFrom.x + (animTo.x - animFrom.x) * t,
+            animFrom.y + (animTo.y - animFrom.y) * t,
+            animFrom.z + (animTo.z - animFrom.z) * t
+        )
+        if (t >= 1.0) finalizeMove()
+    }
+
+    private fun finalizeMove() {
+        board = pendingBoard ?: board
+        pendingBoard = null
+        animating = false
+        animNode = null
+        view.rebuild(board)
+        context?.let {
+            it.materialize(view.root)
+            it.setStatus(statusText())
+        }
+    }
+
+    // --- test seams (same package/module only) -----------------------------------------------
+
+    /** The current model position - for interaction tests. */
+    internal val boardForTest: Board get() = board
+
+    /** The scene view - for interaction tests. */
+    internal val viewForTest: CheckersView get() = view
+
+    /** Whether a move slide is in progress - for interaction tests. */
+    internal val isAnimatingForTest: Boolean get() = animating
+
+    /** Drives a click on [square] (bypassing pick) - for interaction tests. */
+    internal fun clickSquareForTest(square: Square) = onSquareClicked(square)
+
+    // --- helpers -----------------------------------------------------------------------------
+
+    private fun squareAt(context: GameContext, x: Int, y: Int): Square? {
+        val results = context.pick(x, y)
+        if (results.number == 0) return null
+        val target = results.getPickData(0).target as? Spatial ?: return null
+        return view.squareForTile(target)
+    }
+
+    private fun statusText(): String {
+        if (board.isGameOver()) {
+            val winner = board.winner() ?: return "Draw"
+            return "${label(winner)} wins!"
+        }
+        return "${label(board.toMove)} to move"
+    }
+
+    private fun label(color: PieceColor): String = if (color == PieceColor.RED) "Red" else "Black"
+
+    companion object {
+        private const val ANIM_DURATION = 0.22
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
@@ -24,16 +24,20 @@ import com.ardor3d.scenegraph.extension.CameraNode
  * [CheckersView] is its scene view, and this class is the only place they meet - it turns clicks
  * into model moves and re-syncs the view.
  *
- * Interaction: click a piece of the side to move to select it (its legal destinations light up),
- * then click a highlighted square to move (a jump plays its whole mandatory chain). Clicking
- * elsewhere reselects or clears. Moves animate with a short slide; input is ignored mid-slide and
- * once the game is over.
+ * Interaction: hovering a movable piece previews its legal moves; clicking one selects it (it
+ * stays lit with its destinations), and the destination under the pointer highlights distinctly.
+ * Clicking a destination moves (a jump plays its whole mandatory chain); clicking another of your
+ * pieces reselects; clicking elsewhere clears. Moves animate with a short slide; input is ignored
+ * mid-slide and once the game is over.
  */
 class CheckersGame : GameMode {
     private var context: GameContext? = null
     private lateinit var view: CheckersView
     private var board: Board = Board.initial()
     private var selected: Square? = null
+
+    // The highlight set currently shown, so it is only rebuilt/re-materialized when it changes.
+    private var lastHighlights: Map<Square, HighlightKind> = emptyMap()
 
     // Move animation: slide the moving piece from its old square to its new one before the board
     // (and view) snap to the applied position.
@@ -82,13 +86,13 @@ class CheckersGame : GameMode {
         }
         if (board.isGameOver()) return
 
-        val click = input.click ?: return
-        val square = squareAt(context, click.x, click.y)
-        if (square == null) {
-            deselect()
-            return
+        // The square under the pointer this frame (null = off the board).
+        val hover = squareAt(context, input.mouseX, input.mouseY)
+        if (input.click != null) {
+            processClick(hover)
+            if (animating) return // a move started; beginMove already cleared the highlights
         }
-        onSquareClicked(square)
+        refreshHighlights(hover)
     }
 
     override fun onStop() {
@@ -99,7 +103,12 @@ class CheckersGame : GameMode {
 
     // --- interaction -------------------------------------------------------------------------
 
-    private fun onSquareClicked(square: Square) {
+    /** Handles a click on [square] (null = off the board): select, move, reselect, or deselect. */
+    private fun processClick(square: Square?) {
+        if (square == null) {
+            deselect()
+            return
+        }
         val from = selected
         if (from == null) {
             trySelect(square)
@@ -108,31 +117,61 @@ class CheckersGame : GameMode {
         val move = board.legalMovesFrom(from).firstOrNull { it.to == square }
         when {
             move != null -> beginMove(move)
-            board.pieceAt(square)?.color == board.toMove -> {
-                deselect()
-                trySelect(square)
-            }
+            isMovable(square) -> selected = square // clicked another of my movable pieces: reselect
             else -> deselect()
         }
     }
 
+    /** Selects [square] if it holds a piece of the side to move that has at least one legal move. */
     private fun trySelect(square: Square) {
-        val piece = board.pieceAt(square)
-        if (piece == null || piece.color != board.toMove) return
-        val destinations = board.legalMovesFrom(square).map { it.to }
-        if (destinations.isEmpty()) return // a piece with no legal move (e.g. a capture is forced elsewhere)
-        selected = square
-        view.showHighlights(destinations)
-        context?.materialize(view.root) // materialize the new highlight meshes
+        if (isMovable(square)) selected = square
+    }
+
+    private fun isMovable(square: Square): Boolean {
+        val piece = board.pieceAt(square) ?: return false
+        return piece.color == board.toMove && board.legalMovesFrom(square).isNotEmpty()
     }
 
     private fun deselect() {
         selected = null
-        view.clearHighlights()
+    }
+
+    // --- highlighting ------------------------------------------------------------------------
+
+    /** Recomputes the hover/selection highlight set and applies it if it changed. */
+    private fun refreshHighlights(hover: Square?) {
+        applyHighlights(computeHighlights(hover))
+    }
+
+    private fun computeHighlights(hover: Square?): Map<Square, HighlightKind> {
+        val map = linkedMapOf<Square, HighlightKind>()
+        val from = selected
+        if (from != null) {
+            // A piece is committed: mark it and its destinations; light the one under the pointer.
+            map[from] = HighlightKind.SELECTED
+            for (dest in board.legalMovesFrom(from).map { it.to }) {
+                map[dest] = if (dest == hover) HighlightKind.MOVE_HOVER else HighlightKind.MOVE
+            }
+        } else if (hover != null && isMovable(hover)) {
+            // Nothing committed: preview the hovered piece's moves.
+            map[hover] = HighlightKind.HOVER_PIECE
+            for (dest in board.legalMovesFrom(hover).map { it.to }) {
+                map[dest] = HighlightKind.PREVIEW
+            }
+        }
+        return map
+    }
+
+    private fun applyHighlights(desired: Map<Square, HighlightKind>) {
+        if (desired == lastHighlights) return
+        lastHighlights = desired
+        view.setHighlights(desired)
+        context?.materialize(view.highlightRoot)
     }
 
     private fun beginMove(move: Move) {
         deselect()
+        applyHighlights(emptyMap()) // clear highlights for the duration of the slide
         pendingBoard = board.apply(move)
         val node = view.pieceNodeAt(move.from)
         if (node == null) {
@@ -163,6 +202,7 @@ class CheckersGame : GameMode {
         animating = false
         animNode = null
         view.rebuild(board)
+        applyHighlights(emptyMap())
         context?.let {
             it.materialize(view.root)
             it.setStatus(statusText())
@@ -180,8 +220,22 @@ class CheckersGame : GameMode {
     /** Whether a move slide is in progress - for interaction tests. */
     internal val isAnimatingForTest: Boolean get() = animating
 
-    /** Drives a click on [square] (bypassing pick) - for interaction tests. */
-    internal fun clickSquareForTest(square: Square) = onSquareClicked(square)
+    /** Number of highlight markers currently shown - for interaction tests. */
+    internal val highlightCountForTest: Int get() = lastHighlights.size
+
+    /** The highlight kind shown on [square], or null - for interaction tests. */
+    internal fun highlightForTest(square: Square): HighlightKind? = lastHighlights[square]
+
+    /** Simulates a click at [square] (null = off the board), then refreshes highlights - for tests. */
+    internal fun clickSquareForTest(square: Square?) {
+        processClick(square)
+        if (!animating) refreshHighlights(square)
+    }
+
+    /** Simulates the pointer moving to [square] (null = off the board) - for tests. */
+    internal fun hoverSquareForTest(square: Square?) {
+        if (!animating) refreshHighlights(square)
+    }
 
     // --- helpers -----------------------------------------------------------------------------
 

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersModel.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersModel.kt
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+/**
+ * The pure value types of the checkers model. No Ardor3D dependency - this is the plain-data game
+ * state the plan's state/view split calls for; the scene graph is only its view.
+ */
+
+/** The two sides. RED starts on the low rows and advances up-board; BLACK starts high and advances down. */
+enum class PieceColor {
+    RED,
+    BLACK;
+
+    val opponent: PieceColor get() = if (this == RED) BLACK else RED
+}
+
+/** A checker: its owner and whether it has been crowned a king (moves and captures in all four diagonals). */
+data class Piece(val color: PieceColor, val king: Boolean = false)
+
+/**
+ * A board square by (row, col), row 0 at RED's home edge. Only "playable" (dark) squares - where
+ * row + col is even - ever hold a piece; all diagonal neighbours of a playable square are playable.
+ */
+data class Square(val row: Int, val col: Int) {
+    val onBoard: Boolean get() = row in 0 until Board.SIZE && col in 0 until Board.SIZE
+    val isPlayable: Boolean get() = onBoard && (row + col) % 2 == 0
+
+    /** The square [dRow], [dCol] away (used for stepping/jumping along diagonals). */
+    fun offset(dRow: Int, dCol: Int): Square = Square(row + dRow, col + dCol)
+}
+
+/**
+ * A complete legal move by one piece: a simple one-square slide, or a jump chain. [path] is the
+ * landing square(s) in order (the final one is [to]); [captured] are the squares of the pieces
+ * removed by a jump chain, empty for a slide.
+ */
+data class Move(val from: Square, val path: List<Square>, val captured: List<Square>) {
+    init {
+        require(path.isNotEmpty()) { "a move must have at least one landing square" }
+    }
+
+    /** The square the piece ends on. */
+    val to: Square get() = path.last()
+
+    /** Whether this move captures at least one piece. */
+    val isCapture: Boolean get() = captured.isNotEmpty()
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersView.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersView.kt
@@ -10,6 +10,7 @@
 
 package com.ardor3d.editor.checkers
 
+import com.ardor3d.bounding.BoundingBox
 import com.ardor3d.math.ColorRGBA
 import com.ardor3d.math.Quaternion
 import com.ardor3d.math.Vector3
@@ -102,6 +103,10 @@ class CheckersView {
                 val square = Square(row, col)
                 val tile = Box("tile_${row}_$col", Vector3.ZERO, 0.5, TILE_HALF_HEIGHT, 0.5)
                 tile.setTranslation(col - OFFSET, TILE_TOP - TILE_HALF_HEIGHT, row - OFFSET)
+                // A finite model bound is required for picking: the default bound is an infinite
+                // BoundingSphere, whose ray broad-phase fails, so findPick would skip the tile.
+                tile.modelBound = BoundingBox()
+                tile.updateModelBound()
                 if (square.isPlayable) {
                     tile.setDefaultColor(DARK_TILE)
                     squareByTile[tile] = square // only playable tiles are click targets

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersView.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersView.kt
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.math.ColorRGBA
+import com.ardor3d.math.Quaternion
+import com.ardor3d.math.Vector3
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.Spatial
+import com.ardor3d.scenegraph.hint.PickingHint
+import com.ardor3d.scenegraph.shape.Box
+import com.ardor3d.scenegraph.shape.Cylinder
+import java.util.IdentityHashMap
+
+/**
+ * The scene-graph *view* of a checkers [Board] - the counterpart to the pure model in the plan's
+ * state/view split. It builds a procedural board and pieces under [root] and re-syncs the pieces
+ * from a board on demand; it never contains game rules, only presentation and the click-target
+ * mapping the game needs.
+ *
+ * Building and syncing is plain scene-graph work (no GL, no materials), so it is headless-testable;
+ * the caller assigns materials (e.g. `MaterialUtil.autoMaterials(root)`) once it is in the editor.
+ *
+ * Picking model: only the playable board tiles are pickable and mapped to squares; pieces and
+ * highlights are non-pickable, so a click always resolves to the tile (hence square) beneath the
+ * pointer, and the model decides what is there.
+ */
+class CheckersView {
+    /** Attach this under the play scene root; discarded when play stops. */
+    val root = Node("Checkers")
+
+    private val tilesRoot = Node("Tiles")
+    private val piecesRoot = Node("Pieces")
+    private val highlightsRoot = Node("Highlights")
+
+    // Pickable playable tiles -> their square, and square -> the piece node currently shown on it.
+    private val squareByTile = IdentityHashMap<Spatial, Square>()
+    private val pieceNodeBySquare = mutableMapOf<Square, Node>()
+
+    init {
+        root.attachChild(tilesRoot)
+        root.attachChild(piecesRoot)
+        root.attachChild(highlightsRoot)
+        buildTiles()
+    }
+
+    /** World-space centre of the top face of [square] (pieces sit here). */
+    fun worldPositionOf(square: Square): Vector3 =
+        Vector3(square.col - OFFSET, PIECE_Y, square.row - OFFSET)
+
+    /** The square of a picked tile spatial, or null if it was not a pickable tile. */
+    fun squareForTile(spatial: Spatial): Square? = squareByTile[spatial]
+
+    /** The piece node currently shown on [square], or null. */
+    fun pieceNodeAt(square: Square): Node? = pieceNodeBySquare[square]
+
+    /** Number of piece spatials currently shown (test/inspection aid). */
+    val pieceCount: Int get() = pieceNodeBySquare.size
+
+    /** Rebuilds the pieces to match [board] exactly (add/move/remove/crown), snapping positions. */
+    fun rebuild(board: Board) {
+        piecesRoot.detachAllChildren()
+        pieceNodeBySquare.clear()
+        for ((square, piece) in board.occupied) {
+            val node = buildPiece(piece, square)
+            node.setTranslation(worldPositionOf(square))
+            piecesRoot.attachChild(node)
+            pieceNodeBySquare[square] = node
+        }
+    }
+
+    /** Shows a legal-destination marker on each of [squares]; replaces any previous markers. */
+    fun showHighlights(squares: Collection<Square>) {
+        highlightsRoot.detachAllChildren()
+        for (square in squares) {
+            val marker = Box("highlight", Vector3.ZERO, 0.42, 0.03, 0.42)
+            marker.setDefaultColor(HIGHLIGHT_COLOR)
+            marker.setTranslation(square.col - OFFSET, TILE_TOP + 0.02, square.row - OFFSET)
+            marker.sceneHints.setPickingHint(PickingHint.Pickable, false)
+            highlightsRoot.attachChild(marker)
+        }
+    }
+
+    /** Clears any destination markers. */
+    fun clearHighlights() {
+        highlightsRoot.detachAllChildren()
+    }
+
+    // --- construction ------------------------------------------------------------------------
+
+    private fun buildTiles() {
+        for (row in 0 until Board.SIZE) {
+            for (col in 0 until Board.SIZE) {
+                val square = Square(row, col)
+                val tile = Box("tile_${row}_$col", Vector3.ZERO, 0.5, TILE_HALF_HEIGHT, 0.5)
+                tile.setTranslation(col - OFFSET, TILE_TOP - TILE_HALF_HEIGHT, row - OFFSET)
+                if (square.isPlayable) {
+                    tile.setDefaultColor(DARK_TILE)
+                    squareByTile[tile] = square // only playable tiles are click targets
+                } else {
+                    tile.setDefaultColor(LIGHT_TILE)
+                    tile.sceneHints.setPickingHint(PickingHint.Pickable, false)
+                }
+                tilesRoot.attachChild(tile)
+            }
+        }
+    }
+
+    private fun buildPiece(piece: Piece, square: Square): Node {
+        val node = Node("piece_${square.row}_${square.col}")
+        val color = if (piece.color == PieceColor.RED) RED_PIECE else BLACK_PIECE
+
+        val disk = Cylinder("disk", 2, 24, PIECE_RADIUS, PIECE_HEIGHT, true)
+        disk.setRotation(Quaternion().fromAngleAxis(Math.PI / 2, Vector3.UNIT_X)) // stand the disk on the board
+        disk.setDefaultColor(color)
+        node.attachChild(disk)
+
+        if (piece.king) {
+            val crown = Cylinder("crown", 2, 24, PIECE_RADIUS * 0.6, PIECE_HEIGHT, true)
+            crown.setRotation(Quaternion().fromAngleAxis(Math.PI / 2, Vector3.UNIT_X))
+            crown.setTranslation(0.0, PIECE_HEIGHT, 0.0)
+            crown.setDefaultColor(CROWN_COLOR)
+            node.attachChild(crown)
+        }
+
+        // Pieces are presentation only - never picked (clicks resolve through the tile beneath).
+        node.sceneHints.setPickingHint(PickingHint.Pickable, false)
+
+        // Game metadata on the node, per the plan (Savable, additive): colour, king, square index.
+        node.setProperty(PROP_COLOR, piece.color.name)
+        node.setProperty(PROP_KING, piece.king)
+        node.setProperty(PROP_SQUARE, square.row * Board.SIZE + square.col)
+        return node
+    }
+
+    companion object {
+        // Geometry: 1-unit squares, board centred on the origin, board top at y = 0.
+        private const val OFFSET = (Board.SIZE - 1) / 2.0 // 3.5
+        private const val TILE_TOP = 0.0
+        private const val TILE_HALF_HEIGHT = 0.1
+        private const val PIECE_RADIUS = 0.36
+        private const val PIECE_HEIGHT = 0.18
+        private const val PIECE_Y = TILE_TOP + PIECE_HEIGHT / 2 + 0.02
+
+        // Metadata property keys on piece nodes.
+        const val PROP_COLOR = "checkers.color"
+        const val PROP_KING = "checkers.king"
+        const val PROP_SQUARE = "checkers.square"
+
+        private val DARK_TILE = ColorRGBA(0.30f, 0.20f, 0.14f, 1f)
+        private val LIGHT_TILE = ColorRGBA(0.82f, 0.76f, 0.62f, 1f)
+        private val RED_PIECE = ColorRGBA(0.72f, 0.14f, 0.11f, 1f)
+        private val BLACK_PIECE = ColorRGBA(0.10f, 0.10f, 0.12f, 1f)
+        private val CROWN_COLOR = ColorRGBA(0.90f, 0.78f, 0.25f, 1f)
+        private val HIGHLIGHT_COLOR = ColorRGBA(0.30f, 0.85f, 0.35f, 1f)
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersView.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersView.kt
@@ -78,21 +78,27 @@ class CheckersView {
         }
     }
 
-    /** Shows a legal-destination marker on each of [squares]; replaces any previous markers. */
-    fun showHighlights(squares: Collection<Square>) {
+    /** The node holding the highlight markers, so the caller can materialize just these. */
+    val highlightRoot: Node get() = highlightsRoot
+
+    /** Replaces the highlight markers with one per entry, coloured by its [HighlightKind]. */
+    fun setHighlights(highlights: Map<Square, HighlightKind>) {
         highlightsRoot.detachAllChildren()
-        for (square in squares) {
-            val marker = Box("highlight", Vector3.ZERO, 0.42, 0.03, 0.42)
-            marker.setDefaultColor(HIGHLIGHT_COLOR)
+        for ((square, kind) in highlights) {
+            val marker = Box("highlight", Vector3.ZERO, 0.46, 0.03, 0.46)
+            marker.setDefaultColor(colorFor(kind))
             marker.setTranslation(square.col - OFFSET, TILE_TOP + 0.02, square.row - OFFSET)
             marker.sceneHints.setPickingHint(PickingHint.Pickable, false)
             highlightsRoot.attachChild(marker)
         }
     }
 
-    /** Clears any destination markers. */
-    fun clearHighlights() {
-        highlightsRoot.detachAllChildren()
+    private fun colorFor(kind: HighlightKind): ColorRGBA = when (kind) {
+        HighlightKind.SELECTED -> SELECTED_COLOR
+        HighlightKind.HOVER_PIECE -> HOVER_PIECE_COLOR
+        HighlightKind.MOVE -> MOVE_COLOR
+        HighlightKind.MOVE_HOVER -> MOVE_HOVER_COLOR
+        HighlightKind.PREVIEW -> PREVIEW_COLOR
     }
 
     // --- construction ------------------------------------------------------------------------
@@ -165,6 +171,30 @@ class CheckersView {
         private val RED_PIECE = ColorRGBA(0.72f, 0.14f, 0.11f, 1f)
         private val BLACK_PIECE = ColorRGBA(0.10f, 0.10f, 0.12f, 1f)
         private val CROWN_COLOR = ColorRGBA(0.90f, 0.78f, 0.25f, 1f)
-        private val HIGHLIGHT_COLOR = ColorRGBA(0.30f, 0.85f, 0.35f, 1f)
+
+        // Highlight colours (see HighlightKind).
+        private val SELECTED_COLOR = ColorRGBA(1.0f, 0.85f, 0.20f, 1f)   // the committed piece
+        private val HOVER_PIECE_COLOR = ColorRGBA(0.95f, 0.92f, 0.55f, 1f) // a piece being hovered (preview)
+        private val MOVE_COLOR = ColorRGBA(0.20f, 0.80f, 0.32f, 1f)      // a legal destination
+        private val MOVE_HOVER_COLOR = ColorRGBA(0.35f, 0.95f, 0.95f, 1f) // the destination under the pointer
+        private val PREVIEW_COLOR = ColorRGBA(0.22f, 0.55f, 0.50f, 1f)   // previewed destinations (no selection)
     }
+}
+
+/** How a highlighted square is shown - drives its colour. */
+enum class HighlightKind {
+    /** The piece the player has clicked to move. */
+    SELECTED,
+
+    /** A movable piece under the pointer, previewing its moves (no selection yet). */
+    HOVER_PIECE,
+
+    /** A legal destination of the selected piece. */
+    MOVE,
+
+    /** A legal destination currently under the pointer. */
+    MOVE_HOVER,
+
+    /** A destination previewed from hovering a piece (no selection). */
+    PREVIEW
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/inspector/InspectorPanel.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/inspector/InspectorPanel.kt
@@ -784,7 +784,9 @@ private fun CameraSection(cameraNode: CameraNode, editorState: EditorState) {
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Slider(
-                value = fov.coerceIn(20f, 120f),
+                value = fov.coerceIn(
+                    CameraObjectUtil.MIN_FOV_DEGREES.toFloat(), CameraObjectUtil.MAX_FOV_DEGREES.toFloat()
+                ),
                 onValueChange = { new ->
                     fov = new
                     editorState.execute(
@@ -802,7 +804,7 @@ private fun CameraSection(cameraNode: CameraNode, editorState: EditorState) {
                     )
                 },
                 onValueChangeFinished = { editorState.sealUndoMerge() },
-                valueRange = 20f..120f,
+                valueRange = CameraObjectUtil.MIN_FOV_DEGREES.toFloat()..CameraObjectUtil.MAX_FOV_DEGREES.toFloat(),
                 modifier = Modifier.weight(1f)
             )
             Text(

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/inspector/InspectorPanel.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/inspector/InspectorPanel.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import com.ardor3d.editor.EditorState
 import com.ardor3d.editor.command.CompositeCommand
 import com.ardor3d.editor.command.SetterCommand
+import com.ardor3d.editor.util.CameraObjectUtil
 import com.ardor3d.editor.util.EulerUtil
 import com.ardor3d.light.Light
 import com.ardor3d.math.ColorRGBA
@@ -41,6 +42,7 @@ import com.ardor3d.renderer.state.WireframeState
 import com.ardor3d.scenegraph.Mesh
 import com.ardor3d.scenegraph.Node
 import com.ardor3d.scenegraph.Spatial
+import com.ardor3d.scenegraph.extension.CameraNode
 import com.ardor3d.surface.ColorSurface
 import java.util.Locale
 
@@ -104,10 +106,11 @@ fun InspectorPanel(
                     // Transform section - observe transformVersion to trigger refresh
                     TransformSection(selection, editorState)
 
-                    // Type-specific sections
+                    // Type-specific sections. CameraNode is a Node, so it must be matched first.
                     when (selection) {
                         is Light -> LightSection(selection, editorState)
                         is Mesh -> MeshSection(selection, editorState)
+                        is CameraNode -> CameraSection(selection, editorState)
                         is Node -> NodeSection(selection)
                     }
                 }
@@ -744,6 +747,131 @@ private fun LightSection(light: Light, editorState: EditorState) {
                 }
             },
             onEditFinished = { editorState.sealUndoMerge() }
+        )
+    }
+}
+
+@Composable
+private fun CameraSection(cameraNode: CameraNode, editorState: EditorState) {
+    val cam = cameraNode.camera
+    if (cam == null) {
+        InspectorSection(title = "Camera") {
+            Text(
+                text = "No camera",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        return
+    }
+    val camKey = System.identityHashCode(cam)
+
+    InspectorSection(title = "Camera") {
+        // Field of view (vertical, in degrees). Derived from the frustum planes, edited by
+        // rebuilding a symmetric perspective that keeps the current aspect, near and far.
+        var fov by remember(cameraNode, editorState.propertyVersion) {
+            mutableStateOf(CameraObjectUtil.fovYDegrees(cam).toFloat())
+        }
+        Text(
+            text = "Field of View",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Slider(
+                value = fov.coerceIn(20f, 120f),
+                onValueChange = { new ->
+                    fov = new
+                    editorState.execute(
+                        SetterCommand(
+                            name = "Edit Field of View",
+                            oldValue = CameraObjectUtil.fovYDegrees(cam),
+                            newValue = new.toDouble(),
+                            mergeKey = "cameraFov:$camKey",
+                            setter = { f ->
+                                CameraObjectUtil.setPerspective(
+                                    cam, f, CameraObjectUtil.aspect(cam), cam.frustumNear, cam.frustumFar
+                                )
+                            }
+                        )
+                    )
+                },
+                onValueChangeFinished = { editorState.sealUndoMerge() },
+                valueRange = 20f..120f,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = String.format(Locale.ROOT, "%.0f°", fov),
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.width(40.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Near / far clip planes. Editing one keeps the field of view and the other plane.
+        // ComponentField shows the live value while unfocused, so it re-reads after undo/redo
+        // (CameraSection recomposes on propertyVersion via the FOV remember above).
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            ComponentField(
+                value = cam.frustumNear,
+                label = "Near",
+                modifier = Modifier.weight(1f),
+                onValueChange = { near ->
+                    editorState.execute(
+                        SetterCommand(
+                            name = "Edit Near Plane",
+                            oldValue = cam.frustumNear,
+                            newValue = near,
+                            mergeKey = "cameraNear:$camKey",
+                            setter = { n ->
+                                CameraObjectUtil.setPerspective(
+                                    cam, CameraObjectUtil.fovYDegrees(cam), CameraObjectUtil.aspect(cam),
+                                    n, cam.frustumFar
+                                )
+                            }
+                        )
+                    )
+                },
+                onEditFinished = { editorState.sealUndoMerge() }
+            )
+            ComponentField(
+                value = cam.frustumFar,
+                label = "Far",
+                modifier = Modifier.weight(1f),
+                onValueChange = { far ->
+                    editorState.execute(
+                        SetterCommand(
+                            name = "Edit Far Plane",
+                            oldValue = cam.frustumFar,
+                            newValue = far,
+                            mergeKey = "cameraFar:$camKey",
+                            setter = { f ->
+                                CameraObjectUtil.setPerspective(
+                                    cam, CameraObjectUtil.fovYDegrees(cam), CameraObjectUtil.aspect(cam),
+                                    cam.frustumNear, f
+                                )
+                            }
+                        )
+                    )
+                },
+                onEditFinished = { editorState.sealUndoMerge() }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Use the Play button to view the scene through this camera.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/menu/EditorMenuBar.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/menu/EditorMenuBar.kt
@@ -10,6 +10,7 @@
 
 package com.ardor3d.editor.menu
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
@@ -61,7 +62,10 @@ fun EditorMenuBar(
         modifier = modifier
     ) {
         Row(modifier = Modifier.padding(horizontal = 4.dp)) {
+            // Each menu button + its dropdown is wrapped in a Box so the dropdown anchors to the
+            // button's position, not the Row's start (otherwise every menu opens at the far left).
             // File menu
+            Box {
             TextButton(onClick = { fileMenuExpanded = true }) {
                 Text("File")
             }
@@ -114,8 +118,10 @@ fun EditorMenuBar(
                     }
                 )
             }
+            }
 
             // Edit menu
+            Box {
             TextButton(onClick = { editMenuExpanded = true }) {
                 Text("Edit")
             }
@@ -164,8 +170,10 @@ fun EditorMenuBar(
                     }
                 )
             }
+            }
 
             // GameObject menu
+            Box {
             TextButton(onClick = { gameObjectMenuExpanded = true }) {
                 Text("GameObject")
             }
@@ -279,8 +287,10 @@ fun EditorMenuBar(
                     }
                 )
             }
+            }
 
             // Game menu - launch a sample game in play mode.
+            Box {
             TextButton(onClick = { gameMenuExpanded = true }) {
                 Text("Game")
             }
@@ -295,6 +305,7 @@ fun EditorMenuBar(
                         gameMenuExpanded = false
                     }
                 )
+            }
             }
         }
     }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/menu/EditorMenuBar.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/menu/EditorMenuBar.kt
@@ -54,6 +54,7 @@ fun EditorMenuBar(
     var gameObjectMenuExpanded by remember { mutableStateOf(false) }
     var shapesSubmenuExpanded by remember { mutableStateOf(false) }
     var lightsSubmenuExpanded by remember { mutableStateOf(false) }
+    var gameMenuExpanded by remember { mutableStateOf(false) }
 
     Surface(
         tonalElevation = 2.dp,
@@ -275,6 +276,23 @@ fun EditorMenuBar(
                         gameObjectMenuExpanded = false
                         shapesSubmenuExpanded = false
                         lightsSubmenuExpanded = false
+                    }
+                )
+            }
+
+            // Game menu - launch a sample game in play mode.
+            TextButton(onClick = { gameMenuExpanded = true }) {
+                Text("Game")
+            }
+            DropdownMenu(
+                expanded = gameMenuExpanded,
+                onDismissRequest = { gameMenuExpanded = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text("Play Checkers") },
+                    onClick = {
+                        operations.playCheckers()
+                        gameMenuExpanded = false
                     }
                 )
             }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/menu/EditorMenuBar.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/menu/EditorMenuBar.kt
@@ -266,10 +266,16 @@ fun EditorMenuBar(
                     )
                 }
 
+                HorizontalDivider()
+
                 DropdownMenuItem(
                     text = { Text("Camera") },
-                    enabled = false,
-                    onClick = { gameObjectMenuExpanded = false }
+                    onClick = {
+                        operations.addCamera()
+                        gameObjectMenuExpanded = false
+                        shapesSubmenuExpanded = false
+                        lightsSubmenuExpanded = false
+                    }
                 )
             }
         }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/menu/EditorMenuBar.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/menu/EditorMenuBar.kt
@@ -11,6 +11,7 @@
 package com.ardor3d.editor.menu
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
@@ -62,16 +63,10 @@ fun EditorMenuBar(
         modifier = modifier
     ) {
         Row(modifier = Modifier.padding(horizontal = 4.dp)) {
-            // Each menu button + its dropdown is wrapped in a Box so the dropdown anchors to the
-            // button's position, not the Row's start (otherwise every menu opens at the far left).
-            // File menu
-            Box {
-            TextButton(onClick = { fileMenuExpanded = true }) {
-                Text("File")
-            }
-            DropdownMenu(
+            MenuBarItem(
+                label = "File",
                 expanded = fileMenuExpanded,
-                onDismissRequest = { fileMenuExpanded = false }
+                onExpandedChange = { fileMenuExpanded = it }
             ) {
                 DropdownMenuItem(
                     text = { Text("New Scene") },
@@ -118,16 +113,11 @@ fun EditorMenuBar(
                     }
                 )
             }
-            }
 
-            // Edit menu
-            Box {
-            TextButton(onClick = { editMenuExpanded = true }) {
-                Text("Edit")
-            }
-            DropdownMenu(
+            MenuBarItem(
+                label = "Edit",
                 expanded = editMenuExpanded,
-                onDismissRequest = { editMenuExpanded = false }
+                onExpandedChange = { editMenuExpanded = it }
             ) {
                 // Observe historyVersion so enabled state and labels refresh
                 @Suppress("UNUSED_VARIABLE")
@@ -170,19 +160,17 @@ fun EditorMenuBar(
                     }
                 )
             }
-            }
 
-            // GameObject menu
-            Box {
-            TextButton(onClick = { gameObjectMenuExpanded = true }) {
-                Text("GameObject")
-            }
-            DropdownMenu(
+            MenuBarItem(
+                label = "GameObject",
                 expanded = gameObjectMenuExpanded,
-                onDismissRequest = {
-                    gameObjectMenuExpanded = false
-                    shapesSubmenuExpanded = false
-                    lightsSubmenuExpanded = false
+                onExpandedChange = { open ->
+                    gameObjectMenuExpanded = open
+                    if (!open) {
+                        // Dismissing the menu collapses its inline submenus too.
+                        shapesSubmenuExpanded = false
+                        lightsSubmenuExpanded = false
+                    }
                 }
             ) {
                 DropdownMenuItem(
@@ -287,16 +275,12 @@ fun EditorMenuBar(
                     }
                 )
             }
-            }
 
             // Game menu - launch a sample game in play mode.
-            Box {
-            TextButton(onClick = { gameMenuExpanded = true }) {
-                Text("Game")
-            }
-            DropdownMenu(
+            MenuBarItem(
+                label = "Game",
                 expanded = gameMenuExpanded,
-                onDismissRequest = { gameMenuExpanded = false }
+                onExpandedChange = { gameMenuExpanded = it }
             ) {
                 DropdownMenuItem(
                     text = { Text("Play Checkers") },
@@ -306,7 +290,30 @@ fun EditorMenuBar(
                     }
                 )
             }
-            }
         }
+    }
+}
+
+/**
+ * One top-level menu bar entry: a text button that opens a dropdown anchored to itself. The Box is
+ * what anchors the dropdown to the button's position rather than the Row's start (otherwise every
+ * menu opens at the far left).
+ */
+@Composable
+private fun MenuBarItem(
+    label: String,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Box {
+        TextButton(onClick = { onExpandedChange(true) }) {
+            Text(label)
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { onExpandedChange(false) },
+            content = content
+        )
     }
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameContext.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameContext.kt
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.play
+
+import com.ardor3d.intersection.PickingUtil
+import com.ardor3d.intersection.PrimitivePickResults
+import com.ardor3d.math.Vector2
+import com.ardor3d.renderer.Camera
+import com.ardor3d.scenegraph.Node
+
+/**
+ * The durable runtime services a [GameMode] gets for the lifetime of a play session: the live play
+ * scene it reads and mutates, the camera the viewport renders through, and picking. Frame-varying
+ * input is *not* here - that is handed to [GameMode.update] as a [GameInput] each frame.
+ *
+ * Reminder on the state/view split this plan is built around: the scene graph reached through
+ * [sceneRoot] is the game's *view*. A [GameMode] should own its own plain-data model and sync the
+ * scene from it - not treat the scene graph as the source of truth.
+ */
+interface GameContext {
+    /** The live play-scene root the game reads and mutates. Restored to its pre-play state on stop. */
+    val sceneRoot: Node
+
+    /** The camera the viewport renders through while playing (the frame [pick] rays are cast from). */
+    val camera: Camera
+
+    /**
+     * Picks the play scene under a canvas pixel ([GameInput] coordinates: bottom-left origin),
+     * against actual primitives, closest-first. Empty results mean nothing was hit.
+     */
+    fun pick(x: Int, y: Int): PrimitivePickResults
+}
+
+/**
+ * The standard [GameContext]: picking casts a ray from [camera] through the pixel and tests the
+ * primitives under [sceneRoot], mirroring the editor's own click-picking.
+ */
+class SceneGameContext(
+    override val sceneRoot: Node,
+    override val camera: Camera
+) : GameContext {
+    override fun pick(x: Int, y: Int): PrimitivePickResults {
+        val results = PrimitivePickResults()
+        results.setCheckDistance(true)
+        val ray = camera.getPickRay(Vector2(x.toDouble(), y.toDouble()), false, null)
+        PickingUtil.findPick(sceneRoot, ray, results)
+        return results
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameContext.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameContext.kt
@@ -15,6 +15,8 @@ import com.ardor3d.intersection.PrimitivePickResults
 import com.ardor3d.math.Vector2
 import com.ardor3d.renderer.Camera
 import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.Spatial
+import com.ardor3d.util.MaterialUtil
 
 /**
  * The durable runtime services a [GameMode] gets for the lifetime of a play session: the live play
@@ -37,15 +39,30 @@ interface GameContext {
      * against actual primitives, closest-first. Empty results mean nothing was hit.
      */
     fun pick(x: Int, y: Int): PrimitivePickResults
+
+    /**
+     * Reports a short status line for the host to surface (e.g. "RED to move", "BLACK wins") - the
+     * plan's "surface result in UI". Null clears it. In the editor it shows in the play status bar.
+     */
+    fun setStatus(text: String?)
+
+    /**
+     * Assigns render materials to geometry the game built at runtime. The host owns material policy
+     * (resource locators, the material system), so a game that creates spatials during play asks the
+     * context to materialize them rather than reaching for the material system itself.
+     */
+    fun materialize(spatial: Spatial)
 }
 
 /**
  * The standard [GameContext]: picking casts a ray from [camera] through the pixel and tests the
- * primitives under [sceneRoot], mirroring the editor's own click-picking.
+ * primitives under [sceneRoot], mirroring the editor's own click-picking. [statusSink] receives
+ * [setStatus] text (the editor routes it to the play status bar).
  */
 class SceneGameContext(
     override val sceneRoot: Node,
-    override val camera: Camera
+    override val camera: Camera,
+    private val statusSink: (String?) -> Unit = {}
 ) : GameContext {
     override fun pick(x: Int, y: Int): PrimitivePickResults {
         val results = PrimitivePickResults()
@@ -54,4 +71,8 @@ class SceneGameContext(
         PickingUtil.findPick(sceneRoot, ray, results)
         return results
     }
+
+    override fun setStatus(text: String?) = statusSink(text)
+
+    override fun materialize(spatial: Spatial) = MaterialUtil.autoMaterials(spatial)
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameInput.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameInput.kt
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.play
+
+import com.ardor3d.input.InputState
+import com.ardor3d.input.keyboard.Key
+import com.ardor3d.input.mouse.ButtonState
+import com.ardor3d.input.mouse.MouseButton
+
+/**
+ * A read-only, per-frame view of player input handed to [GameMode.update]. Positions are in canvas
+ * pixels with Ardor3D's bottom-left origin (the same coordinates [GameContext.pick] expects).
+ *
+ * The distinction that matters for turn-based games: pointer position and key/button state are
+ * *polled* (whatever they are this frame), while [clicks] are *edge events* - a click is a
+ * completed press+release that did not drag, reported once on the frame it completes and never
+ * again. So "did the player click a square this frame?" is [clicks]/[click]; "is the pointer over
+ * this square right now?" is [mouseX]/[mouseY].
+ */
+interface GameInput {
+    /** Pointer X in canvas pixels (bottom-left origin). */
+    val mouseX: Int
+
+    /** Pointer Y in canvas pixels (bottom-left origin). */
+    val mouseY: Int
+
+    /** Clicks (press+release, not drags) completed this frame, in the order they occurred. */
+    val clicks: List<ClickEvent>
+
+    /** The last click completed this frame, or null - convenience over [clicks]. */
+    val click: ClickEvent? get() = clicks.lastOrNull()
+
+    /** Whether [key] is currently held down. */
+    fun isKeyDown(key: Key): Boolean
+
+    /** Whether [button] is currently held down. */
+    fun isButtonDown(button: MouseButton): Boolean
+
+    companion object {
+        /** An input with nothing pressed and no clicks - used to tick a game with no input source. */
+        val EMPTY: GameInput = object : GameInput {
+            override val mouseX = 0
+            override val mouseY = 0
+            override val clicks = emptyList<ClickEvent>()
+            override fun isKeyDown(key: Key) = false
+            override fun isButtonDown(button: MouseButton) = false
+        }
+    }
+}
+
+/** A completed mouse click at a canvas pixel (bottom-left origin). */
+data class ClickEvent(val x: Int, val y: Int, val button: MouseButton)
+
+/**
+ * The mutable accumulator behind a live [GameInput]. [GameInputController] owns one, calls
+ * [beginFrame] to clear the previous frame's edge events, then drives Ardor3D input into it via
+ * [capture] and [recordClick]; the same object is handed to the game as a [GameInput].
+ */
+internal class MutableGameInput : GameInput {
+    private var mouseState: com.ardor3d.input.mouse.MouseState? = null
+    private var keyboardState: com.ardor3d.input.keyboard.KeyboardState? = null
+    private val _clicks = mutableListOf<ClickEvent>()
+
+    override val mouseX: Int get() = mouseState?.x ?: 0
+    override val mouseY: Int get() = mouseState?.y ?: 0
+    override val clicks: List<ClickEvent> get() = _clicks
+    override fun isKeyDown(key: Key): Boolean = keyboardState?.isDown(key) ?: false
+    override fun isButtonDown(button: MouseButton): Boolean =
+        mouseState?.getButtonState(button) == ButtonState.DOWN
+
+    /** Clears per-frame edge events (clicks). Polled state (pointer, keys) persists as last-known. */
+    fun beginFrame() {
+        _clicks.clear()
+    }
+
+    /** Adopts [state] as the current polled pointer/keyboard state. */
+    fun capture(state: InputState) {
+        mouseState = state.mouseState
+        keyboardState = state.keyboardState
+    }
+
+    /** Records a completed click for this frame. */
+    fun recordClick(x: Int, y: Int, button: MouseButton) {
+        _clicks.add(ClickEvent(x, y, button))
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameInputController.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameInputController.kt
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.play
+
+import com.ardor3d.framework.Canvas
+import com.ardor3d.input.PhysicalLayer
+import com.ardor3d.input.logical.InputTrigger
+import com.ardor3d.input.logical.LogicalLayer
+import java.util.function.Predicate
+
+/**
+ * The play-mode input routing switch. It owns its own [LogicalLayer] on the editor's shared
+ * [PhysicalLayer]; while playing, the editor drives this layer instead of its selection/gizmo input,
+ * so input reaches the game rather than editor tools.
+ *
+ * Only [poll] drains input, and the editor calls it only while playing - so it never competes with
+ * the editor's own layers (which don't run during play), and draining every play frame keeps input
+ * events from piling up unseen. A single catch-all trigger runs on every drained input state, which
+ * is what makes click detection reliable: a press+release that both land within one frame are
+ * distinct states in the drained batch, so no click is missed by only sampling frame endpoints.
+ */
+class GameInputController(canvas: Canvas, physicalLayer: PhysicalLayer) {
+    private val logicalLayer = LogicalLayer()
+    private val input = MutableGameInput()
+
+    init {
+        logicalLayer.registerInput(canvas, physicalLayer)
+        logicalLayer.registerTrigger(InputTrigger(Predicate { true }) { _, states, _ ->
+            val current = states.current
+            input.capture(current)
+            val mouse = current.mouseState
+            for (button in mouse.buttonsClicked) {
+                input.recordClick(mouse.x, mouse.y, button)
+            }
+        })
+    }
+
+    /**
+     * Advances input by one play frame: clears the previous frame's clicks, drains the physical
+     * layer (firing the capture trigger for each new state), and returns the frame's [GameInput].
+     * The returned view is reused each frame - read it within the same update, don't retain it.
+     */
+    fun poll(timePerFrame: Double): GameInput {
+        input.beginFrame()
+        logicalLayer.checkTriggers(timePerFrame)
+        return input
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameInputController.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameInputController.kt
@@ -14,6 +14,8 @@ import com.ardor3d.framework.Canvas
 import com.ardor3d.input.PhysicalLayer
 import com.ardor3d.input.logical.InputTrigger
 import com.ardor3d.input.logical.LogicalLayer
+import com.ardor3d.input.logical.MouseButtonClickedCondition
+import com.ardor3d.input.mouse.MouseButton
 import java.util.function.Predicate
 
 /**
@@ -23,9 +25,13 @@ import java.util.function.Predicate
  *
  * Only [poll] drains input, and the editor calls it only while playing - so it never competes with
  * the editor's own layers (which don't run during play), and draining every play frame keeps input
- * events from piling up unseen. A single catch-all trigger runs on every drained input state, which
- * is what makes click detection reliable: a press+release that both land within one frame are
- * distinct states in the drained batch, so no click is missed by only sampling frame endpoints.
+ * events from piling up unseen.
+ *
+ * Pointer position and keys are captured by a catch-all trigger (idempotent - safe to re-run against
+ * the stale last state when no new input arrives). Clicks, however, must be *edge* events: a
+ * [MouseButtonClickedCondition] fires once on the press-release transition, so a click is reported
+ * exactly once - not re-reported every frame from a state whose click count is still set (which made
+ * selection "stick" to the mouse and behave erratically).
  */
 class GameInputController(canvas: Canvas, physicalLayer: PhysicalLayer) {
     private val logicalLayer = LogicalLayer()
@@ -34,13 +40,14 @@ class GameInputController(canvas: Canvas, physicalLayer: PhysicalLayer) {
     init {
         logicalLayer.registerInput(canvas, physicalLayer)
         logicalLayer.registerTrigger(InputTrigger(Predicate { true }) { _, states, _ ->
-            val current = states.current
-            input.capture(current)
-            val mouse = current.mouseState
-            for (button in mouse.buttonsClicked) {
-                input.recordClick(mouse.x, mouse.y, button)
-            }
+            input.capture(states.current)
         })
+        for (button in listOf(MouseButton.LEFT, MouseButton.RIGHT)) {
+            logicalLayer.registerTrigger(InputTrigger(MouseButtonClickedCondition(button)) { _, states, _ ->
+                val mouse = states.current.mouseState
+                input.recordClick(mouse.x, mouse.y, button)
+            })
+        }
     }
 
     /**

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameMode.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/GameMode.kt
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.play
+
+/**
+ * A game's behavior, driven by the editor's play mode. This is the editor/sample-side sandbox for
+ * the behavior-model questions a future Ardor3D 2.0 must answer (an ordered service layer, explicit
+ * update phases, a jME-`AppState`-style split): patterns proven here are *candidate designs*, not
+ * promoted into core by this work.
+ *
+ * Lifecycle, all on the render/update thread:
+ * - [onStart] once when play begins, with the play-session [GameContext]. Set up the model and its
+ *   scene view here.
+ * - [update] every frame while playing, with the elapsed time and this frame's [GameInput]. Advance
+ *   the model, then sync the scene view from it.
+ * - [onStop] once when play ends, *before* the pre-play scene is restored (so references are still
+ *   valid). Release anything held.
+ *
+ * Everything a mode does to the scene during play is discarded on stop (see the edit/play boundary),
+ * so a mode never has to undo its own mutations.
+ */
+interface GameMode {
+    /** Called once when play begins. */
+    fun onStart(context: GameContext)
+
+    /** Called every frame while playing. */
+    fun update(timePerFrame: Double, input: GameInput)
+
+    /** Called once when play ends, before the pre-play scene is restored. */
+    fun onStop()
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/PlaySession.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/PlaySession.kt
@@ -10,7 +10,6 @@
 
 package com.ardor3d.editor.play
 
-import com.ardor3d.input.logical.LogicalLayer
 import com.ardor3d.scenegraph.Node
 import com.ardor3d.util.export.binary.BinaryExporter
 import com.ardor3d.util.export.binary.BinaryImporter
@@ -29,12 +28,8 @@ import java.io.ByteArrayOutputStream
  * The snapshot/restore pair is deliberately GL-free and side-effect-free (it only reads and builds
  * scene graphs), so it can be unit-tested headlessly and reused wherever a scene needs a disposable
  * working copy. Installing the restored root back into the running editor - swapping the document,
- * reindexing, re-deriving materials - is the caller's job.
- *
- * A session also owns the play-mode input routing switch ([gameInput] / [routeInput]): while a
- * session is active the editor drives the game's input instead of its own selection/gizmo input.
- * Until a game attaches a layer this is a no-op, which is exactly today's "input suppressed while
- * playing" behavior.
+ * reindexing, re-deriving materials - is the caller's job, as is routing play-mode input to the
+ * game (see [GameInputController]) and driving its [GameMode].
  */
 class PlaySession {
     // The pre-play snapshot, held for the lifetime of the session. Non-null iff a session is active.
@@ -61,33 +56,14 @@ class PlaySession {
         val bytes = snapshotBytes ?: error("play session not active")
         val restored = deserialize(bytes)
         snapshotBytes = null
-        gameInput = null
         return restored
     }
 
     /**
      * The exact bytes captured at [start], or null when no session is active. Exposed so a test can
-     * confirm the snapshot round-trips byte-identically.
+     * confirm the snapshot faithfully captures the pre-play document.
      */
     val snapshot: ByteArray? get() = snapshotBytes
-
-    /**
-     * Input routing target for play mode. A game registers its triggers on this layer; while a
-     * session is active the editor calls [routeInput] each frame to dispatch input here instead of
-     * to editor selection/gizmos. Null (the default) means input is simply not routed - play mode
-     * with no game behaves as before. Cleared on [stop].
-     */
-    var gameInput: LogicalLayer? = null
-
-    /**
-     * Dispatches one frame of input to the active game. A no-op unless a session is active and a
-     * [gameInput] layer is attached.
-     */
-    fun routeInput(timePerFrame: Double) {
-        if (isActive) {
-            gameInput?.checkTriggers(timePerFrame)
-        }
-    }
 
     companion object {
         /** Serializes [node] to Ardor3D's binary format - the same format `.a3d` files use. */

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/PlaySession.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/play/PlaySession.kt
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.play
+
+import com.ardor3d.input.logical.LogicalLayer
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.util.export.binary.BinaryExporter
+import com.ardor3d.util.export.binary.BinaryImporter
+import java.io.ByteArrayOutputStream
+
+/**
+ * The editor's edit/play boundary: Unity-style snapshot-on-enter, discard-on-exit.
+ *
+ * On [start] the current document is serialized to a `byte[]` with the same [BinaryExporter] the
+ * editor writes `.a3d` files with; play-mode code (a game, in a later phase) then mutates the live
+ * document freely. On [stop] the snapshot is deserialized back into a fresh document that replaces
+ * the mutated one, so every play-mode change is discarded and the pre-play scene is restored
+ * exactly. Because the game mutates the scene directly - never through editor commands - play never
+ * enters the edit-mode undo history.
+ *
+ * The snapshot/restore pair is deliberately GL-free and side-effect-free (it only reads and builds
+ * scene graphs), so it can be unit-tested headlessly and reused wherever a scene needs a disposable
+ * working copy. Installing the restored root back into the running editor - swapping the document,
+ * reindexing, re-deriving materials - is the caller's job.
+ *
+ * A session also owns the play-mode input routing switch ([gameInput] / [routeInput]): while a
+ * session is active the editor drives the game's input instead of its own selection/gizmo input.
+ * Until a game attaches a layer this is a no-op, which is exactly today's "input suppressed while
+ * playing" behavior.
+ */
+class PlaySession {
+    // The pre-play snapshot, held for the lifetime of the session. Non-null iff a session is active.
+    private var snapshotBytes: ByteArray? = null
+
+    /** True between [start] and [stop]. */
+    val isActive: Boolean get() = snapshotBytes != null
+
+    /**
+     * Enters play: captures a byte-for-byte snapshot of [document] so [stop] can restore it. The
+     * document itself is left untouched and stays live for play-mode code to mutate.
+     */
+    fun start(document: Node) {
+        check(!isActive) { "play session already active" }
+        snapshotBytes = serialize(document)
+    }
+
+    /**
+     * Leaves play: rebuilds the pre-play document from the snapshot (discarding all play-mode
+     * mutations) and ends the session. The returned [Node] is a fresh graph the caller installs as
+     * the new document root.
+     */
+    fun stop(): Node {
+        val bytes = snapshotBytes ?: error("play session not active")
+        val restored = deserialize(bytes)
+        snapshotBytes = null
+        gameInput = null
+        return restored
+    }
+
+    /**
+     * The exact bytes captured at [start], or null when no session is active. Exposed so a test can
+     * confirm the snapshot round-trips byte-identically.
+     */
+    val snapshot: ByteArray? get() = snapshotBytes
+
+    /**
+     * Input routing target for play mode. A game registers its triggers on this layer; while a
+     * session is active the editor calls [routeInput] each frame to dispatch input here instead of
+     * to editor selection/gizmos. Null (the default) means input is simply not routed - play mode
+     * with no game behaves as before. Cleared on [stop].
+     */
+    var gameInput: LogicalLayer? = null
+
+    /**
+     * Dispatches one frame of input to the active game. A no-op unless a session is active and a
+     * [gameInput] layer is attached.
+     */
+    fun routeInput(timePerFrame: Double) {
+        if (isActive) {
+            gameInput?.checkTriggers(timePerFrame)
+        }
+    }
+
+    companion object {
+        /** Serializes [node] to Ardor3D's binary format - the same format `.a3d` files use. */
+        fun serialize(node: Node): ByteArray {
+            val out = ByteArrayOutputStream()
+            BinaryExporter().save(node, out)
+            return out.toByteArray()
+        }
+
+        /** Rebuilds a scene-graph [Node] from bytes produced by [serialize]. */
+        fun deserialize(bytes: ByteArray): Node =
+            BinaryImporter().load(bytes) as? Node
+                ?: throw IllegalStateException("snapshot did not contain a scene-root Node")
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/util/CameraObjectUtil.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/util/CameraObjectUtil.kt
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.util
+
+import com.ardor3d.renderer.Camera
+
+/**
+ * Pure math for the editor's camera objects. A camera object is a
+ * [com.ardor3d.scenegraph.extension.CameraNode] whose managed [Camera] carries the frustum the
+ * inspector edits and play mode renders through.
+ *
+ * Field of view is always *derived* from the frustum planes rather than read from
+ * [Camera.getFovY]: that value is only populated by [Camera.setFrustumPerspective] and is not
+ * written by [Camera.write], so it is NaN after a binary round trip.
+ */
+object CameraObjectUtil {
+    const val DEFAULT_FOV_DEGREES = 60.0
+    const val DEFAULT_NEAR = 0.1
+    const val DEFAULT_FAR = 1000.0
+
+    /** Sensible bounds for the vertical field of view the inspector exposes. */
+    const val MIN_FOV_DEGREES = 5.0
+    const val MAX_FOV_DEGREES = 170.0
+
+    /**
+     * Vertical field of view in degrees, recovered from the frustum geometry:
+     * `setFrustumPerspective` sets `top = tan(fovY/2) * near`, so `fovY = 2*atan(top/near)`.
+     * Falls back to [DEFAULT_FOV_DEGREES] for a degenerate (non-positive near) frustum.
+     */
+    fun fovYDegrees(camera: Camera): Double {
+        val near = camera.frustumNear
+        if (near <= 0.0) return DEFAULT_FOV_DEGREES
+        return Math.toDegrees(2.0 * Math.atan(camera.frustumTop / near))
+    }
+
+    /**
+     * Aspect ratio (width / height) recovered from the frustum planes
+     * (`right = top * aspect`). Falls back to 1.0 for a degenerate frustum.
+     */
+    fun aspect(camera: Camera): Double {
+        val top = camera.frustumTop
+        if (top == 0.0) return 1.0
+        return camera.frustumRight / top
+    }
+
+    /**
+     * Applies a symmetric perspective frustum, clamping every input so the camera is never left
+     * degenerate: fov to [[MIN_FOV_DEGREES], [MAX_FOV_DEGREES]], a non-finite or non-positive
+     * aspect to 1.0, near above zero, and far strictly beyond near.
+     */
+    fun setPerspective(camera: Camera, fovDegrees: Double, aspect: Double, near: Double, far: Double) {
+        val fov = fovDegrees.coerceIn(MIN_FOV_DEGREES, MAX_FOV_DEGREES)
+        val safeAspect = if (aspect.isFinite() && aspect > 0.0) aspect else 1.0
+        val safeNear = if (near > 0.0) near else DEFAULT_NEAR
+        val safeFar = if (far > safeNear) far else safeNear + 1.0
+        camera.setFrustumPerspective(fov, safeAspect, safeNear, safeFar)
+    }
+
+    /**
+     * A signature of the frustum's *shape* (near, top, right) used to detect when a camera's
+     * overlay gizmo needs its geometry rebuilt. Location and orientation are not included -
+     * those are tracked live by moving the gizmo, not by rebuilding it.
+     */
+    fun frustumShape(camera: Camera): DoubleArray =
+        doubleArrayOf(camera.frustumNear, camera.frustumTop, camera.frustumRight)
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/viewport/ViewportPanel.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/viewport/ViewportPanel.kt
@@ -165,10 +165,13 @@ fun ViewportStatusBar(
                 .padding(horizontal = 8.dp, vertical = 4.dp),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            // Selection info - or, while playing, which camera the viewport is rendering through.
+            // Selection info - or, while playing, the active game's status (if any) else which
+            // camera the viewport is rendering through.
             if (editorState.playing) {
+                val gameStatus = editorState.gameStatus
                 Text(
-                    text = "▶ PLAYING — ${editorState.playCameraName ?: "camera"}",
+                    text = if (gameStatus != null) "▶ $gameStatus"
+                        else "▶ PLAYING — ${editorState.playCameraName ?: "camera"}",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.error
                 )

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/viewport/ViewportPanel.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/viewport/ViewportPanel.kt
@@ -141,10 +141,11 @@ private fun TransformToolButton(
             imageVector = icon,
             contentDescription = contentDescription,
             modifier = Modifier.size(20.dp),
-            tint = if (selected)
-                MaterialTheme.colorScheme.onPrimaryContainer
-            else
-                MaterialTheme.colorScheme.onSurface
+            tint = when {
+                !enabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                selected -> MaterialTheme.colorScheme.onPrimaryContainer
+                else -> MaterialTheme.colorScheme.onSurface
+            }
         )
     }
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/viewport/ViewportPanel.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/viewport/ViewportPanel.kt
@@ -10,10 +10,13 @@
 
 package com.ardor3d.editor.viewport
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.OpenWith
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Rotate90DegreesCcw
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.ZoomOutMap
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -26,8 +29,10 @@ import com.ardor3d.editor.TransformMode
 @Composable
 fun ViewportToolbar(
     editorState: EditorState,
+    onTogglePlay: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val playing = editorState.playing
     Surface(
         modifier = modifier,
         shape = MaterialTheme.shapes.small,
@@ -36,32 +41,80 @@ fun ViewportToolbar(
     ) {
         Row(
             modifier = Modifier.padding(4.dp),
-            horizontalArrangement = Arrangement.spacedBy(2.dp)
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
         ) {
-            // Translate tool
+            // Transform tools are disabled while playing - there is no gizmo in the game view.
             TransformToolButton(
                 icon = Icons.Default.OpenWith,
                 contentDescription = "Translate (1)",
                 selected = editorState.transformMode == TransformMode.TRANSLATE,
+                enabled = !playing,
                 onClick = { editorState.transformMode = TransformMode.TRANSLATE }
             )
 
-            // Rotate tool
             TransformToolButton(
                 icon = Icons.Default.Rotate90DegreesCcw,
                 contentDescription = "Rotate (2)",
                 selected = editorState.transformMode == TransformMode.ROTATE,
+                enabled = !playing,
                 onClick = { editorState.transformMode = TransformMode.ROTATE }
             )
 
-            // Scale tool
             TransformToolButton(
                 icon = Icons.Default.ZoomOutMap,
                 contentDescription = "Scale (3)",
                 selected = editorState.transformMode == TransformMode.SCALE,
+                enabled = !playing,
                 onClick = { editorState.transformMode = TransformMode.SCALE }
             )
+
+            VerticalToolbarDivider()
+
+            // Play / stop: renders the viewport through the active camera object. Enabled when the
+            // scene has a camera (or while already playing, so Stop is always reachable).
+            PlayToggleButton(
+                playing = playing,
+                enabled = editorState.hasCamera || playing,
+                onClick = onTogglePlay
+            )
         }
+    }
+}
+
+@Composable
+private fun VerticalToolbarDivider() {
+    Box(
+        modifier = Modifier
+            .padding(horizontal = 2.dp)
+            .height(24.dp)
+            .width(1.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant)
+    )
+}
+
+@Composable
+private fun PlayToggleButton(
+    playing: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    val tint = when {
+        playing -> MaterialTheme.colorScheme.error
+        enabled -> Color(0xFF4CAF50) // green "go"
+        else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+    }
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.size(32.dp)
+    ) {
+        Icon(
+            imageVector = if (playing) Icons.Default.Stop else Icons.Default.PlayArrow,
+            contentDescription = if (playing) "Stop (exit play mode)" else "Play (view through camera)",
+            modifier = Modifier.size(22.dp),
+            tint = tint
+        )
     }
 }
 
@@ -70,10 +123,12 @@ private fun TransformToolButton(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     contentDescription: String,
     selected: Boolean,
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     IconButton(
         onClick = onClick,
+        enabled = enabled,
         modifier = Modifier.size(32.dp),
         colors = IconButtonDefaults.iconButtonColors(
             containerColor = if (selected)
@@ -110,17 +165,25 @@ fun ViewportStatusBar(
                 .padding(horizontal = 8.dp, vertical = 4.dp),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            // Selection info
-            val selectionText = when (editorState.selection.size) {
-                0 -> "No selection"
-                1 -> editorState.selection.first().name ?: "(unnamed)"
-                else -> "${editorState.selection.size} objects selected"
+            // Selection info - or, while playing, which camera the viewport is rendering through.
+            if (editorState.playing) {
+                Text(
+                    text = "▶ PLAYING — ${editorState.playCameraName ?: "camera"}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            } else {
+                val selectionText = when (editorState.selection.size) {
+                    0 -> "No selection"
+                    1 -> editorState.selection.first().name ?: "(unnamed)"
+                    else -> "${editorState.selection.size} objects selected"
+                }
+                Text(
+                    text = selectionText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
-            Text(
-                text = selectionText,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
 
             // Transform mode and frame rate
             Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/EditorGlTestSupport.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/EditorGlTestSupport.kt
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor
+
+import com.ardor3d.framework.DisplaySettings
+import com.ardor3d.framework.lwjgl3.GLFWCanvas
+import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
+import com.ardor3d.image.util.awt.AWTImageLoader
+import com.ardor3d.renderer.material.MaterialManager
+import com.ardor3d.util.ReadOnlyTimer
+import com.ardor3d.util.resource.ResourceLocatorTool
+import com.ardor3d.util.resource.SimpleResourceLocator
+import org.junit.Assert
+import org.junit.Assume
+
+/**
+ * Shared fixtures for the editor's GL smoke tests: the fixed-step timer, resource-locator setup,
+ * the skip-without-GL policy (ARDOR3D_REQUIRE_GL_SMOKE=1 turns skips into failures, as CI does
+ * under Xvfb + software GL), and headless canvas creation.
+ */
+internal object EditorGlTestSupport {
+
+    /** A fixed-step timer for driving [EditorScene.update] deterministically (20 fps, tpf 0.05). */
+    val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
+        override fun getTimeInSeconds() = 0.0
+        override fun getTime() = 0L
+        override fun getResolution() = 1_000_000_000L
+        override fun getFrameRate() = 20.0
+        override fun getTimePerFrame() = 0.05
+        override fun getPreviousFrameTime() = 0L
+    }
+
+    /** Registers the PNG/JPG image loader and the material/shader locators every GL test needs. */
+    fun setupResourceLocators() {
+        AWTImageLoader.registerLoader()
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
+    }
+
+    /** Skips the calling test for [reason] - or fails it when ARDOR3D_REQUIRE_GL_SMOKE=1. */
+    fun skipOrFail(reason: String) {
+        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
+            Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
+        }
+        Assume.assumeTrue(reason, false)
+    }
+
+    /**
+     * Creates and initializes a headless GLFW canvas, or ends the calling test via [skipOrFail]
+     * when no GL context can be created here. The caller owns closing the returned canvas.
+     */
+    fun initCanvasOrSkip(
+        canvasRenderer: Lwjgl3CanvasRenderer, width: Int = 320, height: Int = 240
+    ): GLFWCanvas {
+        var canvas: GLFWCanvas? = null
+        try {
+            canvas = GLFWCanvas(DisplaySettings(width, height, 24, 0), canvasRenderer)
+            canvas.init()
+            return canvas
+        } catch (t: Throwable) {
+            canvas?.close()
+            skipOrFail("Could not create a GL context here: $t")
+            throw AssertionError("unreachable - skipOrFail always throws")
+        }
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/PlayModeRenderTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/PlayModeRenderTest.kt
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor
+
+import com.ardor3d.editor.util.CameraObjectUtil
+import com.ardor3d.framework.DisplaySettings
+import com.ardor3d.framework.lwjgl3.GLFWCanvas
+import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
+import com.ardor3d.image.util.awt.AWTImageLoader
+import com.ardor3d.input.PhysicalLayer
+import com.ardor3d.input.logical.LogicalLayer
+import com.ardor3d.renderer.material.MaterialManager
+import com.ardor3d.scenegraph.extension.CameraNode
+import com.ardor3d.util.ReadOnlyTimer
+import com.ardor3d.util.resource.ResourceLocatorTool
+import com.ardor3d.util.resource.SimpleResourceLocator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+
+/**
+ * End-to-end check that entering play mode actually drives the viewport's render camera from a
+ * camera object, and leaving it restores the editor fly camera. It runs the real [EditorScene]
+ * through a headless GLFW canvas - the only place [EditorScene.enterPlayMode] /
+ * [EditorScene.syncPlayCamera] can be exercised, since they read the live render camera and
+ * viewport size.
+ *
+ * Like the readout smoke test it SKIPS when no GL context is available, so it never breaks builds
+ * over infrastructure; set ARDOR3D_REQUIRE_GL_SMOKE=1 (as CI does, under Xvfb + llvmpipe) to turn
+ * the skip into a failure.
+ */
+class PlayModeRenderTest {
+
+    private companion object {
+        const val W = 320
+        const val H = 240
+        val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
+            override fun getTimeInSeconds() = 0.0
+            override fun getTime() = 0L
+            override fun getResolution() = 1_000_000_000L
+            override fun getFrameRate() = 20.0
+            override fun getTimePerFrame() = 0.05
+            override fun getPreviousFrameTime() = 0L
+        }
+    }
+
+    @Test
+    fun playModeDrivesRenderCameraFromCameraObjectAndRestoresOnStop() {
+        setupResourceLocators()
+
+        val state = EditorState()
+        val scene = EditorScene(state)
+        val canvasRenderer = Lwjgl3CanvasRenderer(scene)
+
+        var canvas: GLFWCanvas? = null
+        try {
+            canvas = GLFWCanvas(DisplaySettings(W, H, 24, 0), canvasRenderer)
+            canvas.init()
+        } catch (t: Throwable) {
+            canvas?.close()
+            skipOrFail("Could not create a GL context here: $t")
+            return
+        }
+
+        try {
+            scene.canvasRenderer = canvasRenderer
+            scene.canvas = canvas
+            scene.setupInteractManager(canvas, PhysicalLayer.Builder().build(), LogicalLayer())
+
+            // Warm-up frame sets up the editor fly camera (location 8,6,12 looking at the origin).
+            canvas.draw(null)
+            val render = canvasRenderer.camera
+            val editorLocation = com.ardor3d.math.Vector3(render.location)
+
+            // Add a camera object, give it a distinctive frustum and a distinctive pose so the
+            // assertions can't accidentally match the editor camera.
+            scene.addCamera()
+            val cameraNode = state.primarySelection as CameraNode
+            val gameCam = cameraNode.camera
+            assertNotNull("camera object should carry a managed camera", gameCam)
+            CameraObjectUtil.setPerspective(gameCam!!, 30.0, 1.0, 0.2, 500.0)
+            cameraNode.setTranslation(0.0, 2.0, 20.0)
+
+            // The pre-play scene, for the discard-on-stop check below.
+            val preplayChildCount = state.sceneRoot.numberOfChildren
+
+            // Enter play mode and run one frame: syncPlayCamera should copy the camera object's
+            // pose and field of view onto the render camera, fitted to the viewport aspect.
+            scene.enterPlayMode()
+            assertTrue("editor should report playing", state.playing)
+            scene.update(TIMER)
+
+            assertEquals("render camera adopts the camera object's field of view",
+                30.0, CameraObjectUtil.fovYDegrees(render), 1e-3)
+            assertEquals("render camera uses the viewport aspect",
+                W.toDouble() / H.toDouble(), CameraObjectUtil.aspect(render), 1e-3)
+            assertEquals("render camera moves to the camera object's position (x)",
+                0.0, render.location.x, 1e-6)
+            assertEquals("render camera moves to the camera object's position (y)",
+                2.0, render.location.y, 1e-6)
+            assertEquals("render camera moves to the camera object's position (z)",
+                20.0, render.location.z, 1e-6)
+
+            // Simulate a play-mode mutation of the live scene (a game would do this). It must not
+            // survive Stop.
+            state.sceneRoot.attachChild(com.ardor3d.scenegraph.Node("PlayMutation"))
+            assertEquals("play-mode mutation is applied to the live scene",
+                preplayChildCount + 1, state.sceneRoot.numberOfChildren)
+
+            // Stop: the document swap is deferred, so drain it with one update. The editor fly
+            // camera's pose is restored exactly, and the play-mode mutation is gone.
+            scene.exitPlayMode()
+            scene.update(TIMER)
+            assertFalse("editor should report not playing", state.playing)
+            assertEquals("play-mode mutation is discarded on stop",
+                preplayChildCount, state.sceneRoot.numberOfChildren)
+            assertEquals(editorLocation.x, render.location.x, 1e-6)
+            assertEquals(editorLocation.y, render.location.y, 1e-6)
+            assertEquals(editorLocation.z, render.location.z, 1e-6)
+        } finally {
+            canvas.close()
+        }
+    }
+
+    private fun setupResourceLocators() {
+        AWTImageLoader.registerLoader()
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
+    }
+
+    private fun skipOrFail(reason: String) {
+        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
+            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
+        }
+        Assume.assumeTrue(reason, false)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/PlayModeRenderTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/PlayModeRenderTest.kt
@@ -10,23 +10,18 @@
 
 package com.ardor3d.editor
 
+import com.ardor3d.editor.EditorGlTestSupport.TIMER
+import com.ardor3d.editor.EditorGlTestSupport.initCanvasOrSkip
+import com.ardor3d.editor.EditorGlTestSupport.setupResourceLocators
 import com.ardor3d.editor.util.CameraObjectUtil
-import com.ardor3d.framework.DisplaySettings
-import com.ardor3d.framework.lwjgl3.GLFWCanvas
 import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
-import com.ardor3d.image.util.awt.AWTImageLoader
 import com.ardor3d.input.PhysicalLayer
 import com.ardor3d.input.logical.LogicalLayer
-import com.ardor3d.renderer.material.MaterialManager
 import com.ardor3d.scenegraph.extension.CameraNode
-import com.ardor3d.util.ReadOnlyTimer
-import com.ardor3d.util.resource.ResourceLocatorTool
-import com.ardor3d.util.resource.SimpleResourceLocator
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Assume
 import org.junit.Test
 
 /**
@@ -45,14 +40,6 @@ class PlayModeRenderTest {
     private companion object {
         const val W = 320
         const val H = 240
-        val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
-            override fun getTimeInSeconds() = 0.0
-            override fun getTime() = 0L
-            override fun getResolution() = 1_000_000_000L
-            override fun getFrameRate() = 20.0
-            override fun getTimePerFrame() = 0.05
-            override fun getPreviousFrameTime() = 0L
-        }
     }
 
     @Test
@@ -63,15 +50,7 @@ class PlayModeRenderTest {
         val scene = EditorScene(state)
         val canvasRenderer = Lwjgl3CanvasRenderer(scene)
 
-        var canvas: GLFWCanvas? = null
-        try {
-            canvas = GLFWCanvas(DisplaySettings(W, H, 24, 0), canvasRenderer)
-            canvas.init()
-        } catch (t: Throwable) {
-            canvas?.close()
-            skipOrFail("Could not create a GL context here: $t")
-            return
-        }
+        val canvas = initCanvasOrSkip(canvasRenderer, W, H)
 
         try {
             scene.canvasRenderer = canvasRenderer
@@ -131,20 +110,5 @@ class PlayModeRenderTest {
         } finally {
             canvas.close()
         }
-    }
-
-    private fun setupResourceLocators() {
-        AWTImageLoader.registerLoader()
-        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
-            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
-        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
-            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
-    }
-
-    private fun skipOrFail(reason: String) {
-        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
-            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
-        }
-        Assume.assumeTrue(reason, false)
     }
 }

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/BoardTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/BoardTest.kt
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.editor.checkers.PieceColor.BLACK
+import com.ardor3d.editor.checkers.PieceColor.RED
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The checkers rules engine, tested in isolation (no scene, no GL): opening setup, mandatory
+ * capture, maximal jump chains, crowning (including that it ends a jump), king movement, and
+ * win/draw detection.
+ */
+class BoardTest {
+
+    private fun sq(row: Int, col: Int) = Square(row, col)
+
+    @Test
+    fun openingPositionHasTwelveEachAndRedToMove() {
+        val board = Board.initial()
+        assertEquals(12, board.count(RED))
+        assertEquals(12, board.count(BLACK))
+        assertEquals(RED, board.toMove)
+        assertEquals(Piece(RED), board.pieceAt(sq(0, 0)))
+        assertEquals(Piece(BLACK), board.pieceAt(sq(7, 7)))
+        assertNull("middle rows are empty", board.pieceAt(sq(3, 1)))
+        // Only the four front men (row 2) have room; standard opening = 7 moves.
+        assertEquals(7, board.legalMoves().size)
+        assertTrue("no captures at the opening", board.legalMoves().none { it.isCapture })
+    }
+
+    @Test
+    fun captureIsMandatory() {
+        // A jump exists for the (2,2) man; a quiet man at (0,0) also could slide, but must not.
+        val board = Board.of(RED, mapOf(
+            sq(2, 2) to Piece(RED),
+            sq(0, 0) to Piece(RED),
+            sq(3, 3) to Piece(BLACK)
+        ))
+        val moves = board.legalMoves()
+        assertEquals("only the capture is legal", 1, moves.size)
+        val jump = moves.single()
+        assertTrue(jump.isCapture)
+        assertEquals(sq(2, 2), jump.from)
+        assertEquals(sq(4, 4), jump.to)
+        assertEquals(listOf(sq(3, 3)), jump.captured)
+    }
+
+    @Test
+    fun mustPlayTheWholeJumpChain() {
+        // (2,2) can jump (3,3)->(4,4) then (5,3)->(6,2): a single maximal 2-capture chain.
+        val board = Board.of(RED, mapOf(
+            sq(2, 2) to Piece(RED),
+            sq(3, 3) to Piece(BLACK),
+            sq(5, 3) to Piece(BLACK)
+        ))
+        val moves = board.legalMoves()
+        assertEquals(1, moves.size)
+        val chain = moves.single()
+        assertEquals(listOf(sq(4, 4), sq(6, 2)), chain.path)
+        assertEquals(setOf(sq(3, 3), sq(5, 3)), chain.captured.toSet())
+        assertEquals(sq(6, 2), chain.to)
+    }
+
+    @Test
+    fun crowningEndsAJumpChain() {
+        // (5,1) jumps (6,2)->(7,3): lands on the king row and is crowned, so it may NOT continue on
+        // to capture (6,4) even though a king there could.
+        val board = Board.of(RED, mapOf(
+            sq(5, 1) to Piece(RED),
+            sq(6, 2) to Piece(BLACK),
+            sq(6, 4) to Piece(BLACK)
+        ))
+        val moves = board.legalMoves()
+        assertEquals(1, moves.size)
+        val jump = moves.single()
+        assertEquals(sq(7, 3), jump.to)
+        assertEquals("chain stops at crowning", listOf(sq(6, 2)), jump.captured)
+    }
+
+    @Test
+    fun manIsCrownedOnReachingTheFarRow() {
+        val board = Board.of(RED, mapOf(sq(6, 2) to Piece(RED), sq(0, 0) to Piece(BLACK)))
+        val step = board.legalMovesFrom(sq(6, 2)).first { it.to == sq(7, 3) }
+        val after = board.apply(step)
+        assertEquals("man becomes a king on the far row", Piece(RED, king = true), after.pieceAt(sq(7, 3)))
+        assertEquals("turn passes to the opponent", BLACK, after.toMove)
+    }
+
+    @Test
+    fun kingMovesAndCapturesBackward() {
+        val king = Piece(RED, king = true)
+        val board = Board.of(RED, mapOf(sq(4, 4) to king, sq(0, 0) to Piece(BLACK)))
+        // All four diagonals are open on-board squares.
+        assertEquals(4, board.legalMovesFrom(sq(4, 4)).size)
+
+        // A king can jump a piece diagonally behind it.
+        val capBoard = Board.of(RED, mapOf(sq(4, 4) to king, sq(3, 3) to Piece(BLACK)))
+        val backJump = capBoard.legalMoves().single()
+        assertEquals(sq(2, 2), backJump.to)
+        assertEquals(listOf(sq(3, 3)), backJump.captured)
+    }
+
+    @Test
+    fun applyRemovesCapturedAndSwitchesTurn() {
+        val board = Board.of(RED, mapOf(sq(2, 2) to Piece(RED), sq(3, 3) to Piece(BLACK)))
+        val after = board.apply(board.legalMoves().single())
+        assertNull("captured piece removed", after.pieceAt(sq(3, 3)))
+        assertNull("origin vacated", after.pieceAt(sq(2, 2)))
+        assertEquals(Piece(RED), after.pieceAt(sq(4, 4)))
+        assertEquals(0, after.count(BLACK))
+        assertEquals(BLACK, after.toMove)
+    }
+
+    @Test
+    fun sideWithNoPiecesHasLost() {
+        val board = Board.of(BLACK, mapOf(sq(0, 0) to Piece(RED)))
+        assertTrue(board.legalMoves().isEmpty())
+        assertEquals(RED, board.winner())
+        assertTrue(board.isGameOver())
+        assertFalse(board.isDraw())
+    }
+
+    @Test
+    fun blockedSideHasLost() {
+        // BLACK man in the corner, RED wall so it can neither slide nor jump (the jump landing is off-board).
+        val board = Board.of(BLACK, mapOf(
+            sq(7, 7) to Piece(BLACK),
+            sq(6, 6) to Piece(RED),
+            sq(5, 5) to Piece(RED)
+        ))
+        assertTrue("no slide and the jump would land off-board", board.legalMoves().isEmpty())
+        assertEquals(RED, board.winner())
+    }
+
+    @Test
+    fun noProgressReachesADraw() {
+        val kings = mapOf(sq(0, 0) to Piece(RED, king = true), sq(7, 7) to Piece(BLACK, king = true))
+        assertFalse(Board.of(RED, kings, Board.DRAW_PLIES - 1).isDraw())
+        val drawn = Board.of(RED, kings, Board.DRAW_PLIES)
+        assertTrue(drawn.legalMoves().isNotEmpty())
+        assertTrue(drawn.isDraw())
+        assertNull(drawn.winner())
+        assertTrue(drawn.isGameOver())
+    }
+
+    @Test
+    fun drawClockResetsOnProgressAndTicksOnQuietKingMoves() {
+        val kings = mapOf(sq(4, 4) to Piece(RED, king = true), sq(0, 0) to Piece(BLACK, king = true))
+        val quiet = Board.of(RED, kings, 5)
+        val afterQuiet = quiet.apply(quiet.legalMovesFrom(sq(4, 4)).first { it.to == sq(5, 5) })
+        assertEquals("quiet king move advances the draw clock", 6, afterQuiet.pliesSinceProgress)
+
+        val manMove = Board.of(RED, mapOf(sq(2, 2) to Piece(RED), sq(0, 0) to Piece(BLACK)), 30)
+        val afterMan = manMove.apply(manMove.legalMovesFrom(sq(2, 2)).first())
+        assertEquals("a man move resets the draw clock", 0, afterMan.pliesSinceProgress)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersInteractionTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersInteractionTest.kt
@@ -24,9 +24,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * The click-to-move glue of [CheckersGame], tested headlessly through a fake [GameContext] (clicks
- * are driven by square, bypassing pick; materialization is a no-op). Verifies the full select ->
- * highlight -> move -> animate -> finalize -> sync -> turn-switch path over the real model and view.
+ * The hover/click interaction of [CheckersGame], tested headlessly through a fake [GameContext]
+ * (hover and clicks are driven by square, bypassing pick; materialization is a no-op). Covers the
+ * UX: hovering a movable piece previews its moves; clicking selects it; hovering a destination lights
+ * it distinctly; clicking a destination moves and switches turns; clicking elsewhere clears.
  */
 class CheckersInteractionTest {
 
@@ -41,54 +42,68 @@ class CheckersInteractionTest {
 
     private fun sq(row: Int, col: Int) = Square(row, col)
 
-    private fun highlightCount(game: CheckersGame): Int =
-        (game.viewForTest.root.children.first { it.name == "Highlights" } as Node).numberOfChildren
-
     @Test
-    fun selectingHighlightsThenMovingAdvancesModelViewAndTurn() {
-        val ctx = FakeGameContext()
-        val game = CheckersGame()
-        game.onStart(ctx)
+    fun hoveringAMovablePiecePreviewsItsMovesAndClearsWhenLeaving() {
+        val game = CheckersGame().also { it.onStart(FakeGameContext()) }
+        assertEquals(0, game.highlightCountForTest)
 
-        assertEquals("board attached to the scene", 1, ctx.sceneRoot.numberOfChildren)
-        assertEquals(24, game.viewForTest.pieceCount)
-        assertEquals("Red to move", ctx.lastStatus)
+        // (2,0) is a red front man with one opening move, to (3,1).
+        game.hoverSquareForTest(sq(2, 0))
+        assertEquals(HighlightKind.HOVER_PIECE, game.highlightForTest(sq(2, 0)))
+        assertEquals(HighlightKind.PREVIEW, game.highlightForTest(sq(3, 1)))
+        assertEquals(2, game.highlightCountForTest)
 
-        // Select the front man on (2,0): its one legal opening move to (3,1) lights up.
-        game.clickSquareForTest(sq(2, 0))
-        assertEquals("one legal destination highlighted", 1, highlightCount(game))
+        game.hoverSquareForTest(null)
+        assertEquals("leaving the piece clears the preview", 0, game.highlightCountForTest)
 
-        // Click the destination: the move begins animating (input ignored until it finishes).
-        game.clickSquareForTest(sq(3, 1))
-        assertTrue("move is animating", game.isAnimatingForTest)
-        assertEquals("highlights cleared once the move starts", 0, highlightCount(game))
-
-        // Drive the slide to completion (0.22s at 0.1s/frame -> 3 frames).
-        repeat(4) { game.update(0.1, GameInput.EMPTY) }
-        assertFalse("animation finished", game.isAnimatingForTest)
-
-        val board = game.boardForTest
-        assertNull("piece left its origin", board.pieceAt(sq(2, 0)))
-        assertEquals("piece reached its destination", Piece(PieceColor.RED), board.pieceAt(sq(3, 1)))
-        assertEquals("turn passed to Black", PieceColor.BLACK, board.toMove)
-
-        assertNull("view: origin now empty", game.viewForTest.pieceNodeAt(sq(2, 0)))
-        assertNotNull("view: piece shown on destination", game.viewForTest.pieceNodeAt(sq(3, 1)))
-        assertEquals("status updated to Black", "Black to move", ctx.lastStatus)
+        // Hovering an empty square previews nothing.
+        game.hoverSquareForTest(sq(4, 4))
+        assertEquals(0, game.highlightCountForTest)
     }
 
     @Test
-    fun clickingEmptyElsewhereDeselects() {
+    fun selectHoverDestinationThenMove() {
         val ctx = FakeGameContext()
-        val game = CheckersGame()
-        game.onStart(ctx)
+        val game = CheckersGame().also { it.onStart(ctx) }
 
+        // Click the piece: it stays selected with its destination lit.
         game.clickSquareForTest(sq(2, 0))
-        assertEquals(1, highlightCount(game))
+        assertEquals(HighlightKind.SELECTED, game.highlightForTest(sq(2, 0)))
+        assertEquals(HighlightKind.MOVE, game.highlightForTest(sq(3, 1)))
 
-        // An empty square that is not a legal destination clears the selection.
+        // Hover the destination: it lights distinctly.
+        game.hoverSquareForTest(sq(3, 1))
+        assertEquals(HighlightKind.MOVE_HOVER, game.highlightForTest(sq(3, 1)))
+
+        // Click the destination: the move animates, then model, view, and turn advance.
+        game.clickSquareForTest(sq(3, 1))
+        assertTrue(game.isAnimatingForTest)
+        repeat(4) { game.update(0.1, GameInput.EMPTY) }
+        assertFalse(game.isAnimatingForTest)
+
+        assertNull(game.boardForTest.pieceAt(sq(2, 0)))
+        assertEquals(Piece(PieceColor.RED), game.boardForTest.pieceAt(sq(3, 1)))
+        assertEquals(PieceColor.BLACK, game.boardForTest.toMove)
+        assertNotNull(game.viewForTest.pieceNodeAt(sq(3, 1)))
+        assertEquals("highlights cleared after the move", 0, game.highlightCountForTest)
+        assertEquals("Black to move", ctx.lastStatus)
+    }
+
+    @Test
+    fun clickingElsewhereDeselects() {
+        val game = CheckersGame().also { it.onStart(FakeGameContext()) }
+
+        game.clickSquareForTest(sq(2, 2))
+        assertTrue("a piece is selected", game.highlightCountForTest > 0)
+
+        // An empty, non-destination square clears the selection.
         game.clickSquareForTest(sq(3, 5))
-        assertEquals("selection cleared", 0, highlightCount(game))
-        assertFalse("no move started", game.isAnimatingForTest)
+        assertEquals(0, game.highlightCountForTest)
+
+        // Clicking off the board (null) also clears.
+        game.clickSquareForTest(sq(2, 2))
+        assertTrue(game.highlightCountForTest > 0)
+        game.clickSquareForTest(null)
+        assertEquals(0, game.highlightCountForTest)
     }
 }

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersInteractionTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersInteractionTest.kt
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.editor.play.GameContext
+import com.ardor3d.editor.play.GameInput
+import com.ardor3d.intersection.PrimitivePickResults
+import com.ardor3d.renderer.Camera
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.Spatial
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The click-to-move glue of [CheckersGame], tested headlessly through a fake [GameContext] (clicks
+ * are driven by square, bypassing pick; materialization is a no-op). Verifies the full select ->
+ * highlight -> move -> animate -> finalize -> sync -> turn-switch path over the real model and view.
+ */
+class CheckersInteractionTest {
+
+    private class FakeGameContext : GameContext {
+        override val sceneRoot: Node = Node("scene")
+        override val camera: Camera = Camera(1, 1)
+        var lastStatus: String? = null
+        override fun pick(x: Int, y: Int): PrimitivePickResults = PrimitivePickResults()
+        override fun setStatus(text: String?) { lastStatus = text }
+        override fun materialize(spatial: Spatial) { /* no material system in this test */ }
+    }
+
+    private fun sq(row: Int, col: Int) = Square(row, col)
+
+    private fun highlightCount(game: CheckersGame): Int =
+        (game.viewForTest.root.children.first { it.name == "Highlights" } as Node).numberOfChildren
+
+    @Test
+    fun selectingHighlightsThenMovingAdvancesModelViewAndTurn() {
+        val ctx = FakeGameContext()
+        val game = CheckersGame()
+        game.onStart(ctx)
+
+        assertEquals("board attached to the scene", 1, ctx.sceneRoot.numberOfChildren)
+        assertEquals(24, game.viewForTest.pieceCount)
+        assertEquals("Red to move", ctx.lastStatus)
+
+        // Select the front man on (2,0): its one legal opening move to (3,1) lights up.
+        game.clickSquareForTest(sq(2, 0))
+        assertEquals("one legal destination highlighted", 1, highlightCount(game))
+
+        // Click the destination: the move begins animating (input ignored until it finishes).
+        game.clickSquareForTest(sq(3, 1))
+        assertTrue("move is animating", game.isAnimatingForTest)
+        assertEquals("highlights cleared once the move starts", 0, highlightCount(game))
+
+        // Drive the slide to completion (0.22s at 0.1s/frame -> 3 frames).
+        repeat(4) { game.update(0.1, GameInput.EMPTY) }
+        assertFalse("animation finished", game.isAnimatingForTest)
+
+        val board = game.boardForTest
+        assertNull("piece left its origin", board.pieceAt(sq(2, 0)))
+        assertEquals("piece reached its destination", Piece(PieceColor.RED), board.pieceAt(sq(3, 1)))
+        assertEquals("turn passed to Black", PieceColor.BLACK, board.toMove)
+
+        assertNull("view: origin now empty", game.viewForTest.pieceNodeAt(sq(2, 0)))
+        assertNotNull("view: piece shown on destination", game.viewForTest.pieceNodeAt(sq(3, 1)))
+        assertEquals("status updated to Black", "Black to move", ctx.lastStatus)
+    }
+
+    @Test
+    fun clickingEmptyElsewhereDeselects() {
+        val ctx = FakeGameContext()
+        val game = CheckersGame()
+        game.onStart(ctx)
+
+        game.clickSquareForTest(sq(2, 0))
+        assertEquals(1, highlightCount(game))
+
+        // An empty square that is not a legal destination clears the selection.
+        game.clickSquareForTest(sq(3, 5))
+        assertEquals("selection cleared", 0, highlightCount(game))
+        assertFalse("no move started", game.isAnimatingForTest)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersLaunchTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersLaunchTest.kt
@@ -10,25 +10,20 @@
 
 package com.ardor3d.editor.checkers
 
+import com.ardor3d.editor.EditorGlTestSupport.TIMER
+import com.ardor3d.editor.EditorGlTestSupport.initCanvasOrSkip
+import com.ardor3d.editor.EditorGlTestSupport.setupResourceLocators
 import com.ardor3d.editor.EditorScene
 import com.ardor3d.editor.EditorState
-import com.ardor3d.framework.DisplaySettings
-import com.ardor3d.framework.lwjgl3.GLFWCanvas
 import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
-import com.ardor3d.image.util.awt.AWTImageLoader
 import com.ardor3d.input.PhysicalLayer
 import com.ardor3d.input.logical.LogicalLayer
-import com.ardor3d.renderer.material.MaterialManager
 import com.ardor3d.scenegraph.Node
-import com.ardor3d.util.ReadOnlyTimer
-import com.ardor3d.util.resource.ResourceLocatorTool
-import com.ardor3d.util.resource.SimpleResourceLocator
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assume
 import org.junit.Test
 
 /**
@@ -38,17 +33,6 @@ import org.junit.Test
  * canvas; SKIPS without a GL context (ARDOR3D_REQUIRE_GL_SMOKE=1 turns the skip into a failure).
  */
 class CheckersLaunchTest {
-
-    private companion object {
-        val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
-            override fun getTimeInSeconds() = 0.0
-            override fun getTime() = 0L
-            override fun getResolution() = 1_000_000_000L
-            override fun getFrameRate() = 20.0
-            override fun getTimePerFrame() = 0.05
-            override fun getPreviousFrameTime() = 0L
-        }
-    }
 
     private fun checkersNode(root: Node): Node? = root.children.firstOrNull { it.name == "Checkers" } as? Node
 
@@ -60,15 +44,7 @@ class CheckersLaunchTest {
         val scene = EditorScene(state)
         val canvasRenderer = Lwjgl3CanvasRenderer(scene)
 
-        var canvas: GLFWCanvas? = null
-        try {
-            canvas = GLFWCanvas(DisplaySettings(320, 240, 24, 0), canvasRenderer)
-            canvas.init()
-        } catch (t: Throwable) {
-            canvas?.close()
-            skipOrFail("Could not create a GL context here: $t")
-            return
-        }
+        val canvas = initCanvasOrSkip(canvasRenderer)
 
         try {
             scene.canvasRenderer = canvasRenderer
@@ -96,20 +72,5 @@ class CheckersLaunchTest {
         } finally {
             canvas.close()
         }
-    }
-
-    private fun setupResourceLocators() {
-        AWTImageLoader.registerLoader()
-        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
-            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
-        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
-            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
-    }
-
-    private fun skipOrFail(reason: String) {
-        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
-            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
-        }
-        Assume.assumeTrue(reason, false)
     }
 }

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersLaunchTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersLaunchTest.kt
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.editor.EditorScene
+import com.ardor3d.editor.EditorState
+import com.ardor3d.framework.DisplaySettings
+import com.ardor3d.framework.lwjgl3.GLFWCanvas
+import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
+import com.ardor3d.image.util.awt.AWTImageLoader
+import com.ardor3d.input.PhysicalLayer
+import com.ardor3d.input.logical.LogicalLayer
+import com.ardor3d.renderer.material.MaterialManager
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.util.ReadOnlyTimer
+import com.ardor3d.util.resource.ResourceLocatorTool
+import com.ardor3d.util.resource.SimpleResourceLocator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+
+/**
+ * End-to-end launch of checkers in the editor: Game > Play Checkers adds a camera if needed, enters
+ * play, and starts the game (board attached, status reported); Stop discards the board (it was added
+ * after the snapshot) and clears the game. Runs the real [EditorScene] through a headless GLFW
+ * canvas; SKIPS without a GL context (ARDOR3D_REQUIRE_GL_SMOKE=1 turns the skip into a failure).
+ */
+class CheckersLaunchTest {
+
+    private companion object {
+        val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
+            override fun getTimeInSeconds() = 0.0
+            override fun getTime() = 0L
+            override fun getResolution() = 1_000_000_000L
+            override fun getFrameRate() = 20.0
+            override fun getTimePerFrame() = 0.05
+            override fun getPreviousFrameTime() = 0L
+        }
+    }
+
+    private fun checkersNode(root: Node): Node? = root.children.firstOrNull { it.name == "Checkers" } as? Node
+
+    @Test
+    fun playCheckersStartsAndStopDiscardsIt() {
+        setupResourceLocators()
+
+        val state = EditorState()
+        val scene = EditorScene(state)
+        val canvasRenderer = Lwjgl3CanvasRenderer(scene)
+
+        var canvas: GLFWCanvas? = null
+        try {
+            canvas = GLFWCanvas(DisplaySettings(320, 240, 24, 0), canvasRenderer)
+            canvas.init()
+        } catch (t: Throwable) {
+            canvas?.close()
+            skipOrFail("Could not create a GL context here: $t")
+            return
+        }
+
+        try {
+            scene.canvasRenderer = canvasRenderer
+            scene.canvas = canvas
+            scene.setupInteractManager(canvas, PhysicalLayer.Builder().build(), LogicalLayer())
+            canvas.draw(null) // warm-up: editor camera + input controller
+
+            // Launch. No camera in the default scene, so startCheckers should add one, then play.
+            scene.startCheckers()
+            assertTrue("entered play", state.playing)
+
+            val checkers = checkersNode(state.sceneRoot)
+            assertNotNull("the checkers board was added to the play scene", checkers)
+            val pieces = checkers!!.children.first { it.name == "Pieces" } as Node
+            assertEquals("opening lays out 24 pieces", 24, pieces.numberOfChildren)
+            assertEquals("status is surfaced", "Red to move", state.gameStatus)
+
+            // Stop: the board (added after the snapshot) is discarded and the game is cleared.
+            scene.exitPlayMode()
+            scene.update(TIMER)
+            assertFalse("no longer playing", state.playing)
+            assertNull("checkers board discarded on stop", checkersNode(state.sceneRoot))
+            assertNull("status cleared", state.gameStatus)
+            assertNull("active game cleared (each launch is one game)", scene.activeGameMode)
+        } finally {
+            canvas.close()
+        }
+    }
+
+    private fun setupResourceLocators() {
+        AWTImageLoader.registerLoader()
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
+    }
+
+    private fun skipOrFail(reason: String) {
+        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
+            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
+        }
+        Assume.assumeTrue(reason, false)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersPickTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersPickTest.kt
@@ -10,27 +10,22 @@
 
 package com.ardor3d.editor.checkers
 
+import com.ardor3d.editor.EditorGlTestSupport.TIMER
+import com.ardor3d.editor.EditorGlTestSupport.initCanvasOrSkip
+import com.ardor3d.editor.EditorGlTestSupport.setupResourceLocators
 import com.ardor3d.editor.EditorScene
 import com.ardor3d.editor.EditorState
-import com.ardor3d.framework.DisplaySettings
-import com.ardor3d.framework.lwjgl3.GLFWCanvas
 import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
-import com.ardor3d.image.util.awt.AWTImageLoader
 import com.ardor3d.input.PhysicalLayer
 import com.ardor3d.input.logical.LogicalLayer
 import com.ardor3d.intersection.PickingUtil
 import com.ardor3d.intersection.PrimitivePickResults
 import com.ardor3d.math.Vector2
 import com.ardor3d.math.Vector3
-import com.ardor3d.renderer.material.MaterialManager
 import com.ardor3d.scenegraph.Node
 import com.ardor3d.scenegraph.Spatial
-import com.ardor3d.util.ReadOnlyTimer
-import com.ardor3d.util.resource.ResourceLocatorTool
-import com.ardor3d.util.resource.SimpleResourceLocator
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assume
 import org.junit.Test
 
 /**
@@ -43,15 +38,6 @@ import org.junit.Test
  */
 class CheckersPickTest {
 
-    private val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
-        override fun getTimeInSeconds() = 0.0
-        override fun getTime() = 0L
-        override fun getResolution() = 1_000_000_000L
-        override fun getFrameRate() = 20.0
-        override fun getTimePerFrame() = 0.05
-        override fun getPreviousFrameTime() = 0L
-    }
-
     @Test
     fun clicksResolveToTilesAndTheSceneIsCleared() {
         setupResourceLocators()
@@ -59,15 +45,7 @@ class CheckersPickTest {
         val state = EditorState()
         val scene = EditorScene(state)
         val canvasRenderer = Lwjgl3CanvasRenderer(scene)
-        var canvas: GLFWCanvas? = null
-        try {
-            canvas = GLFWCanvas(DisplaySettings(640, 480, 24, 0), canvasRenderer)
-            canvas.init()
-        } catch (t: Throwable) {
-            canvas?.close()
-            skipOrFail("Could not create a GL context here: $t")
-            return
-        }
+        val canvas = initCanvasOrSkip(canvasRenderer, width = 640, height = 480)
 
         try {
             scene.canvasRenderer = canvasRenderer
@@ -104,20 +82,5 @@ class CheckersPickTest {
         } finally {
             canvas.close()
         }
-    }
-
-    private fun setupResourceLocators() {
-        AWTImageLoader.registerLoader()
-        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
-            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
-        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
-            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
-    }
-
-    private fun skipOrFail(reason: String) {
-        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
-            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
-        }
-        Assume.assumeTrue(reason, false)
     }
 }

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersPickTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersPickTest.kt
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.editor.EditorScene
+import com.ardor3d.editor.EditorState
+import com.ardor3d.framework.DisplaySettings
+import com.ardor3d.framework.lwjgl3.GLFWCanvas
+import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
+import com.ardor3d.image.util.awt.AWTImageLoader
+import com.ardor3d.input.PhysicalLayer
+import com.ardor3d.input.logical.LogicalLayer
+import com.ardor3d.intersection.PickingUtil
+import com.ardor3d.intersection.PrimitivePickResults
+import com.ardor3d.math.Vector2
+import com.ardor3d.math.Vector3
+import com.ardor3d.renderer.material.MaterialManager
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.Spatial
+import com.ardor3d.util.ReadOnlyTimer
+import com.ardor3d.util.resource.ResourceLocatorTool
+import com.ardor3d.util.resource.SimpleResourceLocator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assume
+import org.junit.Test
+
+/**
+ * Guards the two bugs that made the board unclickable: board tiles need a finite model bound (the
+ * default is an infinite BoundingSphere, whose ray broad-phase fails, so picking would miss every
+ * tile), and starting checkers must clear the editing scene so leftover geometry (e.g. the default
+ * cube at the origin) doesn't intercept clicks at the board centre. Projects a square's world centre
+ * to the screen through the live render camera and casts a pick ray back - the exact path a click
+ * takes. Runs the real scene through a headless GLFW canvas; SKIPS without a GL context.
+ */
+class CheckersPickTest {
+
+    private val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
+        override fun getTimeInSeconds() = 0.0
+        override fun getTime() = 0L
+        override fun getResolution() = 1_000_000_000L
+        override fun getFrameRate() = 20.0
+        override fun getTimePerFrame() = 0.05
+        override fun getPreviousFrameTime() = 0L
+    }
+
+    @Test
+    fun clicksResolveToTilesAndTheSceneIsCleared() {
+        setupResourceLocators()
+
+        val state = EditorState()
+        val scene = EditorScene(state)
+        val canvasRenderer = Lwjgl3CanvasRenderer(scene)
+        var canvas: GLFWCanvas? = null
+        try {
+            canvas = GLFWCanvas(DisplaySettings(640, 480, 24, 0), canvasRenderer)
+            canvas.init()
+        } catch (t: Throwable) {
+            canvas?.close()
+            skipOrFail("Could not create a GL context here: $t")
+            return
+        }
+
+        try {
+            scene.canvasRenderer = canvasRenderer
+            scene.canvas = canvas
+            scene.setupInteractManager(canvas, PhysicalLayer.Builder().build(), LogicalLayer())
+            canvas.draw(null)
+
+            // Launch from the default scene (which has a cube at the origin). Do NOT clear manually -
+            // starting checkers should clear it for us.
+            scene.startCheckers()
+            repeat(4) { scene.update(TIMER); canvas.draw(null) }
+
+            // #1: the editing content is gone; only the (kept) camera and the checkers board remain.
+            assertNull("default cube cleared", state.sceneRoot.children.firstOrNull { it.name == "TestCube" })
+            val checkers = state.sceneRoot.children.first { it.name == "Checkers" } as Node
+
+            // #2: a ray cast at each square's projected screen position hits that square's tile -
+            // corners, a piece square, and the centre (which the default cube used to block).
+            val camera = canvasRenderer.camera
+            fun tileHitAt(row: Int, col: Int): String? {
+                val world = Vector3(col - 3.5, 0.0, row - 3.5)
+                val screen = camera.getScreenCoordinates(world)
+                val ray = camera.getPickRay(Vector2(screen.x, screen.y), false, null)
+                val results = PrimitivePickResults().apply { setCheckDistance(true) }
+                PickingUtil.findPick(state.sceneRoot, ray, results)
+                if (results.number == 0) return null
+                return (results.getPickData(0).target as? Spatial)?.name
+            }
+            for ((row, col) in listOf(0 to 0, 7 to 7, 2 to 0, 3 to 3)) {
+                assertEquals("click on ($row,$col) resolves to its tile",
+                    "tile_${row}_$col", tileHitAt(row, col))
+            }
+            assertEquals("board present", "Checkers", checkers.name)
+        } finally {
+            canvas.close()
+        }
+    }
+
+    private fun setupResourceLocators() {
+        AWTImageLoader.registerLoader()
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
+    }
+
+    private fun skipOrFail(reason: String) {
+        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
+            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
+        }
+        Assume.assumeTrue(reason, false)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersViewTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersViewTest.kt
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.Spatial
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The scene view of the board, tested headlessly - it is pure scene-graph construction (no GL, no
+ * materials): the opening lays out 24 pieces on the right squares, re-syncing tracks a capture,
+ * crowning shows on the node metadata, and pickable tiles map back to their squares.
+ */
+class CheckersViewTest {
+
+    private fun sq(row: Int, col: Int) = Square(row, col)
+
+    private fun tileNamed(view: CheckersView, name: String): Spatial {
+        val tiles = view.root.children.first { it.name == "Tiles" } as Node
+        return tiles.children.first { it.name == name }
+    }
+
+    @Test
+    fun openingLaysOutTwentyFourPieces() {
+        val view = CheckersView()
+        view.rebuild(Board.initial())
+
+        assertEquals(24, view.pieceCount)
+        assertNotNull("a red man sits on (0,0)", view.pieceNodeAt(sq(0, 0)))
+        assertNotNull("a black man sits on (7,7)", view.pieceNodeAt(sq(7, 7)))
+        assertNull("the middle rows are empty", view.pieceNodeAt(sq(3, 1)))
+
+        // The piece node sits at the square's world position.
+        val node = view.pieceNodeAt(sq(0, 0))!!
+        val expected = view.worldPositionOf(sq(0, 0))
+        assertEquals(expected.x, node.translation.x, 1e-9)
+        assertEquals(expected.z, node.translation.z, 1e-9)
+    }
+
+    @Test
+    fun rebuildTracksACapture() {
+        val view = CheckersView()
+        val board = Board.of(PieceColor.RED, mapOf(sq(2, 2) to Piece(PieceColor.RED), sq(3, 3) to Piece(PieceColor.BLACK)))
+        view.rebuild(board)
+        assertEquals(2, view.pieceCount)
+
+        val after = board.apply(board.legalMoves().single())
+        view.rebuild(after)
+        assertEquals(1, view.pieceCount)
+        assertNull("captured piece removed from the view", view.pieceNodeAt(sq(3, 3)))
+        assertNull("mover no longer on its origin", view.pieceNodeAt(sq(2, 2)))
+        assertNotNull("mover shown on its destination", view.pieceNodeAt(sq(4, 4)))
+    }
+
+    @Test
+    fun pieceMetadataReflectsColorAndKing() {
+        val view = CheckersView()
+        view.rebuild(Board.of(PieceColor.RED, mapOf(
+            sq(0, 0) to Piece(PieceColor.RED),
+            sq(7, 7) to Piece(PieceColor.BLACK, king = true)
+        )))
+
+        val man = view.pieceNodeAt(sq(0, 0))!!
+        assertEquals("RED", man.getProperty(CheckersView.PROP_COLOR, ""))
+        assertFalse(man.getProperty(CheckersView.PROP_KING, false))
+
+        val king = view.pieceNodeAt(sq(7, 7))!!
+        assertEquals("BLACK", king.getProperty(CheckersView.PROP_COLOR, ""))
+        assertTrue("king metadata set", king.getProperty(CheckersView.PROP_KING, false))
+    }
+
+    @Test
+    fun playableTilesMapBackToTheirSquares() {
+        val view = CheckersView()
+        // (0,0) is playable (0+0 even); (0,1) is a light square and not a click target.
+        assertEquals(sq(0, 0), view.squareForTile(tileNamed(view, "tile_0_0")))
+        assertEquals(sq(5, 3), view.squareForTile(tileNamed(view, "tile_5_3")))
+        assertNull("light squares are not click targets", view.squareForTile(tileNamed(view, "tile_0_1")))
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/io/SceneRoundTripTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/io/SceneRoundTripTest.kt
@@ -11,12 +11,15 @@
 package com.ardor3d.editor.io
 
 import com.ardor3d.bounding.BoundingBox
+import com.ardor3d.editor.util.CameraObjectUtil
 import com.ardor3d.light.PointLight
 import com.ardor3d.math.ColorRGBA
 import com.ardor3d.math.Vector3
+import com.ardor3d.renderer.Camera
 import com.ardor3d.renderer.state.RenderState
 import com.ardor3d.renderer.state.WireframeState
 import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.extension.CameraNode
 import com.ardor3d.scenegraph.shape.Box
 import com.ardor3d.surface.ColorSurface
 import com.ardor3d.util.export.binary.BinaryExporter
@@ -59,12 +62,20 @@ class SceneRoundTripTest {
         light.setTranslation(5.0, 8.0, 5.0)
         root.attachChild(light)
 
+        val cameraObject = Camera(100, 100)
+        CameraObjectUtil.setPerspective(cameraObject, 35.0, 1.6, 0.5, 250.0)
+        cameraObject.setLocation(2.0, 3.0, 9.0)
+        cameraObject.lookAt(0.0, 0.0, 0.0, Vector3.UNIT_Y)
+        val cameraNode = CameraNode("Main Camera", cameraObject)
+        cameraNode.updateFromCamera()
+        root.attachChild(cameraNode)
+
         val bytes = ByteArrayOutputStream()
         BinaryExporter().save(root, bytes)
         val loaded = BinaryImporter().load(ByteArrayInputStream(bytes.toByteArray())) as Node
 
         assertEquals("Scene Root", loaded.name)
-        assertEquals(3, loaded.numberOfChildren)
+        assertEquals(4, loaded.numberOfChildren)
 
         val loadedBox = loaded.getChild("Crate") as Box
         assertEquals(1.0, loadedBox.translation.x, 0.0)
@@ -88,5 +99,15 @@ class SceneRoundTripTest {
 
         val loadedGroup = loaded.getChild("Group") as Node
         assertEquals(-4.0, loadedGroup.translation.x, 0.0)
+
+        // Camera object: the CameraNode and its managed camera's frustum survive. Field of view is
+        // recovered from the frustum planes, since Camera.write() does not persist the fovY value.
+        val loadedCamera = loaded.getChild("Main Camera") as CameraNode
+        val loadedCam = loadedCamera.camera
+        assertNotNull("managed camera should survive", loadedCam)
+        assertEquals(0.5, loadedCam!!.frustumNear, 1e-6)
+        assertEquals(250.0, loadedCam.frustumFar, 1e-6)
+        assertEquals(35.0, CameraObjectUtil.fovYDegrees(loadedCam), 1e-6)
+        assertEquals(1.6, CameraObjectUtil.aspect(loadedCam), 1e-6)
     }
 }

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/play/GameInputTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/play/GameInputTest.kt
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.play
+
+import com.ardor3d.input.keyboard.Key
+import com.ardor3d.input.mouse.MouseButton
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure test of the [GameInput] contract: the per-frame click accumulation / reset that
+ * [GameInputController] relies on, and the do-nothing [GameInput.EMPTY]. No GL or input hardware -
+ * the capture-from-Ardor3D-input path is covered end-to-end by the render test.
+ */
+class GameInputTest {
+
+    @Test
+    fun defaultsBeforeAnyInput() {
+        val input = MutableGameInput()
+        assertEquals(0, input.mouseX)
+        assertEquals(0, input.mouseY)
+        assertTrue(input.clicks.isEmpty())
+        assertNull(input.click)
+        assertFalse(input.isKeyDown(Key.A))
+        assertFalse(input.isButtonDown(MouseButton.LEFT))
+    }
+
+    @Test
+    fun clicksAccumulateWithinAFrameThenClearOnNext() {
+        val input = MutableGameInput()
+
+        input.beginFrame()
+        input.recordClick(10, 20, MouseButton.LEFT)
+        input.recordClick(30, 40, MouseButton.RIGHT)
+        assertEquals(2, input.clicks.size)
+        assertEquals(ClickEvent(10, 20, MouseButton.LEFT), input.clicks[0])
+        assertEquals("click is the last one this frame", ClickEvent(30, 40, MouseButton.RIGHT), input.click)
+
+        input.beginFrame()
+        assertTrue("beginFrame clears the previous frame's clicks", input.clicks.isEmpty())
+        assertNull(input.click)
+    }
+
+    @Test
+    fun emptyInputHasNothingPressed() {
+        val input = GameInput.EMPTY
+        assertEquals(0, input.mouseX)
+        assertEquals(0, input.mouseY)
+        assertTrue(input.clicks.isEmpty())
+        assertNull(input.click)
+        assertFalse(input.isKeyDown(Key.ESCAPE))
+        assertFalse(input.isButtonDown(MouseButton.LEFT))
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/play/GameModeRenderTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/play/GameModeRenderTest.kt
@@ -10,25 +10,20 @@
 
 package com.ardor3d.editor.play
 
+import com.ardor3d.editor.EditorGlTestSupport.TIMER
+import com.ardor3d.editor.EditorGlTestSupport.initCanvasOrSkip
+import com.ardor3d.editor.EditorGlTestSupport.setupResourceLocators
 import com.ardor3d.editor.EditorScene
 import com.ardor3d.editor.EditorState
-import com.ardor3d.framework.DisplaySettings
-import com.ardor3d.framework.lwjgl3.GLFWCanvas
 import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
-import com.ardor3d.image.util.awt.AWTImageLoader
 import com.ardor3d.input.PhysicalLayer
 import com.ardor3d.input.logical.LogicalLayer
-import com.ardor3d.renderer.material.MaterialManager
 import com.ardor3d.scenegraph.Node
-import com.ardor3d.util.ReadOnlyTimer
-import com.ardor3d.util.resource.ResourceLocatorTool
-import com.ardor3d.util.resource.SimpleResourceLocator
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Assume
 import org.junit.Test
 
 /**
@@ -40,19 +35,6 @@ import org.junit.Test
  * ARDOR3D_REQUIRE_GL_SMOKE=1 to turn the skip into a failure), like the other editor GL tests.
  */
 class GameModeRenderTest {
-
-    private companion object {
-        const val W = 320
-        const val H = 240
-        val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
-            override fun getTimeInSeconds() = 0.0
-            override fun getTime() = 0L
-            override fun getResolution() = 1_000_000_000L
-            override fun getFrameRate() = 20.0
-            override fun getTimePerFrame() = 0.05
-            override fun getPreviousFrameTime() = 0L
-        }
-    }
 
     /** A GameMode that records its lifecycle and mutates the play scene in onStart. */
     private class RecordingGameMode : GameMode {
@@ -87,15 +69,7 @@ class GameModeRenderTest {
         val scene = EditorScene(state)
         val canvasRenderer = Lwjgl3CanvasRenderer(scene)
 
-        var canvas: GLFWCanvas? = null
-        try {
-            canvas = GLFWCanvas(DisplaySettings(W, H, 24, 0), canvasRenderer)
-            canvas.init()
-        } catch (t: Throwable) {
-            canvas?.close()
-            skipOrFail("Could not create a GL context here: $t")
-            return
-        }
+        val canvas = initCanvasOrSkip(canvasRenderer)
 
         try {
             scene.canvasRenderer = canvasRenderer
@@ -140,20 +114,5 @@ class GameModeRenderTest {
         } finally {
             canvas.close()
         }
-    }
-
-    private fun setupResourceLocators() {
-        AWTImageLoader.registerLoader()
-        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
-            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
-        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
-            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
-    }
-
-    private fun skipOrFail(reason: String) {
-        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
-            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
-        }
-        Assume.assumeTrue(reason, false)
     }
 }

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/play/GameModeRenderTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/play/GameModeRenderTest.kt
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.play
+
+import com.ardor3d.editor.EditorScene
+import com.ardor3d.editor.EditorState
+import com.ardor3d.framework.DisplaySettings
+import com.ardor3d.framework.lwjgl3.GLFWCanvas
+import com.ardor3d.framework.lwjgl3.Lwjgl3CanvasRenderer
+import com.ardor3d.image.util.awt.AWTImageLoader
+import com.ardor3d.input.PhysicalLayer
+import com.ardor3d.input.logical.LogicalLayer
+import com.ardor3d.renderer.material.MaterialManager
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.util.ReadOnlyTimer
+import com.ardor3d.util.resource.ResourceLocatorTool
+import com.ardor3d.util.resource.SimpleResourceLocator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+
+/**
+ * End-to-end check that a [GameMode] set on the editor is driven by the play boundary: onStart when
+ * Play begins (with a [GameContext] over the live play scene and the render camera), update every
+ * play frame, onStop when Stop ends - and that whatever the game did to the scene is discarded on
+ * Stop by the snapshot restore. Runs the real [EditorScene] through a headless GLFW canvas, the only
+ * place the play loop can be exercised; SKIPS when no GL context is available (set
+ * ARDOR3D_REQUIRE_GL_SMOKE=1 to turn the skip into a failure), like the other editor GL tests.
+ */
+class GameModeRenderTest {
+
+    private companion object {
+        const val W = 320
+        const val H = 240
+        val TIMER: ReadOnlyTimer = object : ReadOnlyTimer {
+            override fun getTimeInSeconds() = 0.0
+            override fun getTime() = 0L
+            override fun getResolution() = 1_000_000_000L
+            override fun getFrameRate() = 20.0
+            override fun getTimePerFrame() = 0.05
+            override fun getPreviousFrameTime() = 0L
+        }
+    }
+
+    /** A GameMode that records its lifecycle and mutates the play scene in onStart. */
+    private class RecordingGameMode : GameMode {
+        var starts = 0
+        var updates = 0
+        var stops = 0
+        var lastTpf = 0.0
+        var startContext: GameContext? = null
+
+        override fun onStart(context: GameContext) {
+            starts++
+            startContext = context
+            context.sceneRoot.attachChild(Node("GameMarker"))
+        }
+
+        override fun update(timePerFrame: Double, input: GameInput) {
+            updates++
+            lastTpf = timePerFrame
+            assertNotNull("update always gets an input", input)
+        }
+
+        override fun onStop() {
+            stops++
+        }
+    }
+
+    @Test
+    fun playDrivesTheGameModeLifecycleAndDiscardsItsSceneChanges() {
+        setupResourceLocators()
+
+        val state = EditorState()
+        val scene = EditorScene(state)
+        val canvasRenderer = Lwjgl3CanvasRenderer(scene)
+
+        var canvas: GLFWCanvas? = null
+        try {
+            canvas = GLFWCanvas(DisplaySettings(W, H, 24, 0), canvasRenderer)
+            canvas.init()
+        } catch (t: Throwable) {
+            canvas?.close()
+            skipOrFail("Could not create a GL context here: $t")
+            return
+        }
+
+        try {
+            scene.canvasRenderer = canvasRenderer
+            scene.canvas = canvas
+            scene.setupInteractManager(canvas, PhysicalLayer.Builder().build(), LogicalLayer())
+
+            // Warm-up frame sets up the editor camera and the game input controller.
+            canvas.draw(null)
+
+            scene.addCamera()
+            val game = RecordingGameMode()
+            scene.activeGameMode = game
+            val preplayChildCount = state.sceneRoot.numberOfChildren
+            val preplayRoot = state.sceneRoot
+
+            // Enter play: onStart fires once, with a context over the live scene + a camera, and its
+            // scene mutation is applied.
+            scene.enterPlayMode()
+            assertEquals("onStart called once", 1, game.starts)
+            assertNotNull("context provided to onStart", game.startContext)
+            assertSame("context exposes the live play scene", preplayRoot, game.startContext!!.sceneRoot)
+            assertNotNull("context exposes a camera", game.startContext!!.camera)
+            assertEquals("onStart's scene mutation is applied to the live scene",
+                preplayChildCount + 1, state.sceneRoot.numberOfChildren)
+
+            // Two play frames: update fires once each, with the timer's tpf; no stop yet.
+            scene.update(TIMER)
+            scene.update(TIMER)
+            assertEquals("update called once per play frame", 2, game.updates)
+            assertEquals("update gets the frame delta", 0.05, game.lastTpf, 1e-9)
+            assertEquals("no stop while playing", 0, game.stops)
+
+            // Stop: deferred, so drain with one update. onStop fires once and the game's scene
+            // change is gone (snapshot restored the pre-play scene).
+            scene.exitPlayMode()
+            scene.update(TIMER)
+            assertFalse("no longer playing", state.playing)
+            assertEquals("onStop called once", 1, game.stops)
+            assertEquals("update not called on the stop frame", 2, game.updates)
+            assertEquals("the game's scene mutation is discarded on stop",
+                preplayChildCount, state.sceneRoot.numberOfChildren)
+        } finally {
+            canvas.close()
+        }
+    }
+
+    private fun setupResourceLocators() {
+        AWTImageLoader.registerLoader()
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_MATERIAL, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/material")))
+        ResourceLocatorTool.addResourceLocator(ResourceLocatorTool.TYPE_SHADER, SimpleResourceLocator(
+            ResourceLocatorTool.getClassPathResource(MaterialManager::class.java, "com/ardor3d/renderer/shader")))
+    }
+
+    private fun skipOrFail(reason: String) {
+        if ("1" == System.getenv("ARDOR3D_REQUIRE_GL_SMOKE")) {
+            org.junit.Assert.fail("$reason - and ARDOR3D_REQUIRE_GL_SMOKE=1 requires this test to run")
+        }
+        Assume.assumeTrue(reason, false)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/play/PlaySessionTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/play/PlaySessionTest.kt
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.play
+
+import com.ardor3d.math.Quaternion
+import com.ardor3d.math.Vector3
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.shape.Box
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Headless test of the edit/play boundary primitive: entering play snapshots the document, and
+ * leaving it rebuilds the pre-play scene from that snapshot no matter what play mode did to the live
+ * scene in between. This is the "does [com.ardor3d.util.export.binary.BinaryExporter] round-trip
+ * everything?" check the game-mode plan calls out as Phase 1's risk; it needs no GL context, so it
+ * always runs.
+ *
+ * Note on fidelity: the invariant is *semantic*, not byte-for-byte. Re-serializing a deserialized
+ * graph produces output of identical length but with the id/location table renumbered - equal-
+ * content objects that shared an instance in the authored graph come back as distinct instances, so
+ * the exporter is not a byte-level fixed point. That is benign (no data is lost or added) and lives
+ * in core, which this work must not touch; what matters here is that the restored scene faithfully
+ * reproduces the pre-play structure, transforms, and properties while discarding play's mutations.
+ */
+class PlaySessionTest {
+
+    /** A small but non-trivial document: nested nodes, meshes, non-identity transforms, a property. */
+    private fun buildDocument(): Node {
+        val root = Node("Scene Root")
+
+        val group = Node("Group")
+        group.setTranslation(1.0, 2.0, 3.0)
+        group.setRotation(Quaternion().fromAngleAxis(Math.PI / 3, Vector3.UNIT_Y))
+
+        val box = Box("Box", Vector3.ZERO, 0.5, 0.5, 0.5)
+        box.setTranslation(0.0, 0.5, 0.0)
+        box.setScale(2.0, 1.0, 1.0)
+        box.setProperty("gameSquare", "e4")   // spatial property must survive the round trip (Phase 3)
+        group.attachChild(box)
+
+        root.attachChild(group)
+        root.attachChild(Box("LooseBox", Vector3.ZERO, 1.0, 1.0, 1.0))
+        return root
+    }
+
+    @Test
+    fun startSnapshotsAndStopRestoresPreplayScene() {
+        val document = buildDocument()
+        val before = PlaySession.serialize(document)
+
+        val session = PlaySession()
+        assertFalse("a fresh session is inactive", session.isActive)
+
+        session.start(document)
+        assertTrue("session is active after start", session.isActive)
+        assertNotNull("start captures a snapshot", session.snapshot)
+        assertArrayEquals("the held snapshot is the pre-play document's serialized form",
+            before, session.snapshot)
+
+        // Play mode mutates the live document freely - add, remove, move things.
+        document.attachChild(Node("PlayerSpawn"))
+        document.detachChildAt(0)
+        document.setTranslation(99.0, 99.0, 99.0)
+
+        val restored = session.stop()
+        assertFalse("session is inactive after stop", session.isActive)
+
+        // The restored graph reproduces the pre-play scene exactly, structure and data, with every
+        // play-mode mutation discarded.
+        assertEquals("Scene Root", restored.name)
+        assertEquals("root children restored (mutations discarded)", 2, restored.numberOfChildren)
+        assertVector("root translation is the authored identity", Vector3(0.0, 0.0, 0.0), restored.translation)
+
+        val group = restored.getChild(0) as Node
+        assertEquals("Group", group.name)
+        assertVector("group translation preserved", Vector3(1.0, 2.0, 3.0), group.translation)
+        assertEquals("group child preserved", 1, group.numberOfChildren)
+
+        val box = group.getChild(0)
+        assertEquals("Box", box.name)
+        assertVector("box translation preserved", Vector3(0.0, 0.5, 0.0), box.translation)
+        assertVector("box scale preserved", Vector3(2.0, 1.0, 1.0), box.scale)
+        assertEquals("box spatial property preserved", "e4", box.getProperty("gameSquare", ""))
+
+        assertEquals("LooseBox", restored.getChild(1).name)
+    }
+
+    @Test
+    fun restoredDocumentIsIndependentOfTheMutatedOne() {
+        val document = buildDocument()
+        val session = PlaySession()
+        session.start(document)
+
+        val restored = session.stop()
+
+        // The restored graph is a fresh copy: further edits to the (discarded) play document can't
+        // touch it, and it carries the original structure.
+        document.attachChild(Node("StrayEdit"))
+        assertEquals("restored document has the original child count",
+            2, restored.numberOfChildren)
+        assertEquals("restored group is preserved", "Group", restored.getChild(0).name)
+    }
+
+    @Test
+    fun stopWithoutStartFails() {
+        val session = PlaySession()
+        try {
+            session.stop()
+            org.junit.Assert.fail("stop() on an inactive session should throw")
+        } catch (expected: IllegalStateException) {
+            // expected
+        }
+    }
+
+    private fun assertVector(message: String, expected: Vector3, actual: com.ardor3d.math.type.ReadOnlyVector3) {
+        assertEquals("$message (x)", expected.x, actual.x, 1e-9)
+        assertEquals("$message (y)", expected.y, actual.y, 1e-9)
+        assertEquals("$message (z)", expected.z, actual.z, 1e-9)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/util/CameraObjectUtilTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/util/CameraObjectUtilTest.kt
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.util
+
+import com.ardor3d.renderer.Camera
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Field-of-view and frustum math for camera objects. A plain [Camera] is a pure JVM object here -
+ * no GL context is required to set or read its frustum planes.
+ */
+class CameraObjectUtilTest {
+
+    @Test
+    fun fovAndAspectRecoveredFromFrustumPlanes() {
+        val cam = Camera(100, 100)
+        CameraObjectUtil.setPerspective(cam, 60.0, 1.5, 0.1, 500.0)
+
+        assertEquals(60.0, CameraObjectUtil.fovYDegrees(cam), 1e-9)
+        assertEquals(1.5, CameraObjectUtil.aspect(cam), 1e-9)
+        assertEquals(0.1, cam.frustumNear, 1e-9)
+        assertEquals(500.0, cam.frustumFar, 1e-9)
+    }
+
+    @Test
+    fun editingNearPreservesFieldOfView() {
+        val cam = Camera(100, 100)
+        CameraObjectUtil.setPerspective(cam, 45.0, 1.0, 0.1, 100.0)
+
+        // Mirror the inspector's Near edit: hold fov and aspect, change only near.
+        CameraObjectUtil.setPerspective(
+            cam, CameraObjectUtil.fovYDegrees(cam), CameraObjectUtil.aspect(cam), 2.0, cam.frustumFar
+        )
+
+        assertEquals(45.0, CameraObjectUtil.fovYDegrees(cam), 1e-9)
+        assertEquals(2.0, cam.frustumNear, 1e-9)
+        assertEquals(100.0, cam.frustumFar, 1e-9)
+    }
+
+    @Test
+    fun fieldOfViewIsClampedToSaneBounds() {
+        val cam = Camera(100, 100)
+        CameraObjectUtil.setPerspective(cam, 1000.0, 1.0, 0.1, 100.0)
+        assertEquals(CameraObjectUtil.MAX_FOV_DEGREES, CameraObjectUtil.fovYDegrees(cam), 1e-6)
+
+        CameraObjectUtil.setPerspective(cam, 0.0, 1.0, 0.1, 100.0)
+        assertEquals(CameraObjectUtil.MIN_FOV_DEGREES, CameraObjectUtil.fovYDegrees(cam), 1e-6)
+    }
+
+    @Test
+    fun degenerateInputsAreSanitized() {
+        val cam = Camera(100, 100)
+
+        // A non-positive/non-finite aspect must not produce a degenerate frustum.
+        CameraObjectUtil.setPerspective(cam, 60.0, 0.0, 0.1, 100.0)
+        assertTrue("frustum width must be positive", cam.frustumRight > 0.0)
+
+        CameraObjectUtil.setPerspective(cam, 60.0, Double.NaN, 0.1, 100.0)
+        assertTrue("frustum width must be positive", cam.frustumRight > 0.0)
+
+        // Far must end up strictly beyond near even when asked for the reverse.
+        CameraObjectUtil.setPerspective(cam, 60.0, 1.0, 5.0, 1.0)
+        assertTrue("far must exceed near", cam.frustumFar > cam.frustumNear)
+    }
+
+    @Test
+    fun frustumShapeIgnoresPose() {
+        val cam = Camera(100, 100)
+        CameraObjectUtil.setPerspective(cam, 60.0, 1.0, 0.1, 100.0)
+        val before = CameraObjectUtil.frustumShape(cam)
+
+        // Moving the camera must not change its frustum shape signature.
+        cam.setLocation(10.0, 20.0, 30.0)
+        cam.lookAt(0.0, 0.0, 0.0, com.ardor3d.math.Vector3.UNIT_Y)
+        val after = CameraObjectUtil.frustumShape(cam)
+
+        assertTrue("pose changes must not alter the frustum shape", before.contentEquals(after))
+    }
+}


### PR DESCRIPTION
## Summary
- **Edit/play boundary** — entering Play snapshots the scene document (binary serializer) and Stop restores it exactly: play-mode mutations are discarded, and entering Play is an undo-history boundary. Play renders through a camera object (`GameObject > Camera`), auto-framing one if none exists.
- **Game-behavior SPI** (`com.ardor3d.editor.play`) — `GameMode` / `GameContext` / `GameInput`, driven by the Play toggle; while playing, viewport input routes to the running game instead of editor selection/gizmos.
- **Playable checkers sample** (`com.ardor3d.editor.checkers`) — a pure, unit-tested rules engine (forced captures, jump chains, kinging, end detection) as the model, a scene view synced from it, hover-preview and selection highlighting, animated moves, and a status line for turn/result. The worked example of the state-vs-view contract the SPI is built around.
- **README** — play-SPI design contract and test-running notes.

## Test plan
- `LIBGL_ALWAYS_SOFTWARE=1 ./gradlew :ardor3d-editor:test` — full editor suite green (rules engine, play-boundary restore, checkers interaction, undo and scene round-trips).
- Manual: Game > Play Checkers — full game flow including mandatory jump chains and kinging; Stop restores the pre-play scene, undo history boundary, and editor camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added editor camera objects with editable perspective, near/far planes, and per-camera frustum gizmos.
  - Introduced Play mode with camera-based rendering, Play/Stop UI, and Ctrl/Meta+P window-wide toggle.
  - Added a playable checkers sample (selection/hover previews, animations, and game status) plus Game menu actions.
- **Documentation**
  - Expanded editor documentation for camera objects and Play mode behavior, and updated WSL/test execution guidance and limitations.
- **Tests**
  - Added end-to-end and headless tests covering Play mode lifecycle, camera math/serialization, checkers rules and interactions, and improved GL smoke test support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->