### PR TITLE
Scale gates and a curve bench for the composed scene layer

### DIFF
--- a/ardor3d-editor/build.gradle.kts
+++ b/ardor3d-editor/build.gradle.kts
@@ -56,3 +56,9 @@ compose.desktop {
 kotlin {
     jvmToolchain(17)
 }
+
+tasks.test {
+    // The composition scale gates hold 50k-spatial scenes; the default 512m test heap is tight
+    // enough there that GC would skew the allocation accounting the gates assert on.
+    maxHeapSize = "2g"
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleBench.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleBench.kt
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import androidx.compose.runtime.Composable
+import com.ardor3d.scenegraph.Node
+import org.junit.Assume
+import org.junit.Test
+import java.lang.management.ManagementFactory
+
+/**
+ * Curve bench for the composed scene layer. Not a gate: the deterministic pass/fail assertions
+ * live in [CompositionScaleGateTest]; this prints the numbers the curves are read from - initial
+ * composition and teardown time, retained memory per spatial against an imperative twin of the
+ * same tree, leaf-write latency and allocation, many-writes-one-frame cost, and keyed-churn cost.
+ * Churn against a single global list ("flat", "chunked") recomposes the scope that reads that
+ * list and reconciles the whole keyed run - its curve locates the cliff where dynamic collections
+ * must leave global-list composition. The "cells" shape is the stable-partition alternative that
+ * is supposed to stay off that cliff; its churn rewrites one cell's membership state.
+ *
+ * The composed memory column includes the per-leaf MutableState objects the shapes read - the
+ * state model is part of what the approach costs, so it is deliberately not subtracted.
+ *
+ * Run explicitly (env vars, not -D: Gradle does not forward system properties to test JVMs);
+ * A3D_BENCH_SHAPES optionally limits the run to a comma-separated subset of shape names:
+ *
+ *   A3D_COMPOSE_BENCH=1 ./gradlew :ardor3d-editor:test --tests 'com.ardor3d.compose.CompositionScaleBench'
+ */
+class CompositionScaleBench {
+
+    private val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
+    private val self = Thread.currentThread().id
+
+    private class ChurnOps(val remove: () -> Unit, val insert: () -> Unit, val move: () -> Unit)
+
+    private class BenchTarget(
+        val leafCount: Int,
+        val content: @Composable () -> Unit,
+        val poke: (Int, Double) -> Unit,
+        val churn: ChurnOps?
+    )
+
+    private class ShapeCase(
+        val name: String,
+        val imperative: () -> Node,
+        val makeScene: () -> BenchTarget
+    )
+
+    /** Global-list churn: remove/re-insert the middle element, move the first to the end. */
+    private fun listChurn(model: ScaleModel): ChurnOps {
+        var pulled = -1
+        return ChurnOps(
+            remove = {
+                val ids = model.ids.value
+                pulled = ids[ids.size / 2]
+                model.ids.value = ids - pulled
+            },
+            insert = { model.ids.value = model.ids.value.toMutableList().apply { add(size / 2, pulled) } },
+            move = {
+                val ids = model.ids.value
+                model.ids.value = ids.drop(1) + ids.first()
+            }
+        )
+    }
+
+    /** Stable-partition churn: the same operations expressed as single-cell membership edits. */
+    private fun cellChurn(model: CellModel): ChurnOps {
+        val c = model.cells.size / 2
+        var pulled = -1
+        return ChurnOps(
+            remove = {
+                val cell = model.cells[c].value
+                pulled = cell[cell.size / 2]
+                model.cells[c].value = cell - pulled
+            },
+            insert = { model.cells[c].value = model.cells[c].value.toMutableList().apply { add(size / 2, pulled) } },
+            move = { // transfer one leaf to the neighboring cell: the cross-parent case
+                val from = model.cells[c].value
+                val id = from.first()
+                model.cells[c].value = from.drop(1)
+                model.cells[c + 1].value = model.cells[c + 1].value + id
+            }
+        )
+    }
+
+    @Test
+    fun printScaleCurves() {
+        Assume.assumeTrue(
+            "set A3D_COMPOSE_BENCH=1 to run the bench",
+            System.getenv("A3D_COMPOSE_BENCH") != null
+        )
+        val only = System.getenv("A3D_BENCH_SHAPES")?.split(',')?.map { it.trim() }?.toSet()
+
+        val rt = Runtime.getRuntime()
+        println()
+        println("## Composition scale bench")
+        println()
+        println(
+            "JVM ${System.getProperty("java.version")}, max heap ${rt.maxMemory() / (1 shl 20)} MiB, " +
+                "${rt.availableProcessors()} cores"
+        )
+        println()
+        println(
+            "| shape | spatials | initial ms | teardown ms | imperative B/sp | composed B/sp | overhead B/sp " +
+                "| leaf write us | leaf write B | 100 writes us | remove us | insert us | move us |"
+        )
+        println("|---|---|---|---|---|---|---|---|---|---|---|---|---|")
+
+        for (target in listOf(1_000, 10_000, 50_000)) {
+            val depth = 4
+            val branching = Math.round(Math.pow(target.toDouble(), 1.0 / depth)).toInt()
+            val treeLeaves = generateSequence(1) { it * branching }.elementAt(depth)
+            val entities = target / 3
+            val chunkSize = Math.round(Math.sqrt(target.toDouble())).toInt()
+
+            val cases = listOf(
+                ShapeCase("flat", { buildFlatImperative(target) }) {
+                    val m = ScaleModel(target)
+                    BenchTarget(target, { FlatScene(m) }, m::poke, listChurn(m))
+                },
+                ShapeCase("chunked", { buildChunkedImperative(target, chunkSize) }) {
+                    val m = ScaleModel(target)
+                    BenchTarget(target, { ChunkedScene(m, chunkSize) }, m::poke, listChurn(m))
+                },
+                ShapeCase("cells", { buildChunkedImperative(target, chunkSize) }) {
+                    val m = CellModel(target, chunkSize)
+                    BenchTarget(target, { CellScene(m) }, m::poke, cellChurn(m))
+                },
+                ShapeCase("tree", { buildTreeImperative(branching, depth) }) {
+                    val m = ScaleModel(treeLeaves)
+                    BenchTarget(treeLeaves, { TreeScene(m, branching, depth) }, m::poke, null)
+                },
+                ShapeCase("entity", { buildEntityImperative(entities) }) {
+                    val m = ScaleModel(entities)
+                    BenchTarget(entities, { EntityScene(m) }, m::poke, listChurn(m))
+                }
+            )
+            cases.filter { only == null || it.name in only }.forEach { println(measureCase(it)) }
+        }
+    }
+
+    private fun measureCase(case: ShapeCase): String {
+        // Retained memory: the imperative twin first, then the composed scene, deltas over settled heap.
+        gcSettle()
+        val baseline = usedHeap()
+        var imperative: Node? = case.imperative()
+        val spatialCount = countSpatials(imperative!!)
+        gcSettle()
+        val imperativeBytes = usedHeap() - baseline
+        @Suppress("UNUSED_VALUE")
+        imperative = null
+
+        gcSettle()
+        val composedBaseline = usedHeap()
+        var target = case.makeScene()
+        var scene = SceneComposition(Node("root"))
+        scene.setContent(target.content)
+        gcSettle()
+        val composedBytes = usedHeap() - composedBaseline
+        scene.close()
+
+        // Initial composition and teardown, medians over fresh compositions; the last stays open
+        // for the write and churn measurements, and its close supplies the final teardown sample.
+        val initialNs = LongArray(5)
+        val teardownNs = LongArray(5)
+        for (i in 0 until 5) {
+            target = case.makeScene()
+            scene = SceneComposition(Node("root"))
+            val t0 = System.nanoTime()
+            scene.setContent(target.content)
+            initialNs[i] = System.nanoTime() - t0
+            if (i < 4) {
+                val t1 = System.nanoTime()
+                scene.close()
+                teardownNs[i] = System.nanoTime() - t1
+            }
+        }
+
+        var t = 0L
+        fun frame() = scene.frame(++t)
+        var value = 1.0
+        val leafCount = target.leafCount
+
+        repeat(1_000) { i ->
+            target.poke(i % leafCount, value++)
+            frame()
+        }
+
+        val writeNs = LongArray(9)
+        val writeBytes = LongArray(9)
+        for (i in writeNs.indices) {
+            val id = (leafCount / 2 + i * 13) % leafCount
+            val b0 = threads.getThreadAllocatedBytes(self)
+            val t0 = System.nanoTime()
+            target.poke(id, value++)
+            frame()
+            writeNs[i] = System.nanoTime() - t0
+            writeBytes[i] = threads.getThreadAllocatedBytes(self) - b0
+        }
+
+        val k100Ns = LongArray(5)
+        for (i in k100Ns.indices) {
+            val t0 = System.nanoTime()
+            repeat(100) { k -> target.poke((k * 97 + i) % leafCount, value++) }
+            frame()
+            k100Ns[i] = System.nanoTime() - t0
+        }
+
+        // The global-list shapes' churn runs seconds-per-op at 50k; medians of 3 over fewer warmup
+        // cycles keep the bench's wall time sane where single samples are already second-scale.
+        val churn = target.churn
+        val churnReps = if (leafCount > 10_000) 3 else 5
+        val churnWarmup = if (leafCount > 10_000) 2 else 10
+        val removeNs = LongArray(churnReps)
+        val insertNs = LongArray(churnReps)
+        val moveNs = LongArray(churnReps)
+        if (churn != null) {
+            repeat(churnWarmup) { // warm the structural paths before timing them
+                churn.move()
+                frame()
+            }
+            for (i in removeNs.indices) {
+                var t0 = System.nanoTime()
+                churn.remove()
+                frame()
+                removeNs[i] = System.nanoTime() - t0
+
+                t0 = System.nanoTime()
+                churn.insert()
+                frame()
+                insertNs[i] = System.nanoTime() - t0
+
+                t0 = System.nanoTime()
+                churn.move()
+                frame()
+                moveNs[i] = System.nanoTime() - t0
+            }
+        }
+
+        val tClose = System.nanoTime()
+        scene.close()
+        teardownNs[4] = System.nanoTime() - tClose
+
+        fun ms(ns: LongArray) = "%.1f".format(median(ns) / 1e6)
+        fun us(ns: LongArray) = "%.1f".format(median(ns) / 1e3)
+        val churnCols = if (churn != null) "${us(removeNs)} | ${us(insertNs)} | ${us(moveNs)}" else "- | - | -"
+
+        return "| ${case.name} | $spatialCount | ${ms(initialNs)} | ${ms(teardownNs)} " +
+            "| ${imperativeBytes / spatialCount} | ${composedBytes / spatialCount} " +
+            "| ${(composedBytes - imperativeBytes) / spatialCount} " +
+            "| ${us(writeNs)} | ${median(writeBytes)} | ${us(k100Ns)} | $churnCols |"
+    }
+
+    private fun median(samples: LongArray): Long {
+        val sorted = samples.sortedArray()
+        return sorted[sorted.size / 2]
+    }
+
+    private fun gcSettle() = repeat(3) {
+        System.gc()
+        Thread.sleep(50)
+    }
+
+    private fun usedHeap(): Long = Runtime.getRuntime().let { it.totalMemory() - it.freeMemory() }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleBench.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleBench.kt
@@ -76,6 +76,7 @@ class CompositionScaleBench {
     private fun cellChurn(model: CellModel): ChurnOps {
         val c = model.cells.size / 2
         var pulled = -1
+        var onLoan = -1 // id currently transferred to cell c+1, or -1 when it is home in cell c
         return ChurnOps(
             remove = {
                 val cell = model.cells[c].value
@@ -83,11 +84,17 @@ class CompositionScaleBench {
                 model.cells[c].value = cell - pulled
             },
             insert = { model.cells[c].value = model.cells[c].value.toMutableList().apply { add(size / 2, pulled) } },
-            move = { // transfer one leaf to the neighboring cell: the cross-parent case
-                val from = model.cells[c].value
-                val id = from.first()
-                model.cells[c].value = from.drop(1)
-                model.cells[c + 1].value = model.cells[c + 1].value + id
+            move = { // the cross-parent case: transfer one leaf across the c/c+1 boundary, alternating
+                if (onLoan < 0) { // direction each call so both cells stay bounded and the partition holds
+                    val from = model.cells[c].value
+                    onLoan = from.first()
+                    model.cells[c].value = from.drop(1)
+                    model.cells[c + 1].value = model.cells[c + 1].value + onLoan
+                } else { // return the same leaf to its original cell
+                    model.cells[c + 1].value = model.cells[c + 1].value - onLoan
+                    model.cells[c].value = model.cells[c].value + onLoan
+                    onLoan = -1
+                }
             }
         )
     }
@@ -156,6 +163,9 @@ class CompositionScaleBench {
         val spatialCount = countSpatials(imperative!!)
         gcSettle()
         val imperativeBytes = usedHeap() - baseline
+        // countSpatials is imperative's last read; without a fence the JIT may let gcSettle above
+        // reclaim the tree before this delta, undercounting what it actually retains.
+        java.lang.ref.Reference.reachabilityFence(imperative)
         @Suppress("UNUSED_VALUE")
         imperative = null
 

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleBench.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleBench.kt
@@ -36,8 +36,9 @@ import java.lang.management.ManagementFactory
  */
 class CompositionScaleBench {
 
-    private val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
-    private val self = Thread.currentThread().id
+    // Lazy so instantiating the (normally skipped) bench never touches com.sun.management.
+    private val threads by lazy { ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean }
+    private val self by lazy { Thread.currentThread().id }
 
     private class ChurnOps(val remove: () -> Unit, val insert: () -> Unit, val move: () -> Unit)
 
@@ -95,7 +96,7 @@ class CompositionScaleBench {
     fun printScaleCurves() {
         Assume.assumeTrue(
             "set A3D_COMPOSE_BENCH=1 to run the bench",
-            System.getenv("A3D_COMPOSE_BENCH") != null
+            System.getenv("A3D_COMPOSE_BENCH") == "1"
         )
         val only = System.getenv("A3D_BENCH_SHAPES")?.split(',')?.map { it.trim() }?.toSet()
 

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleGateTest.kt
@@ -56,14 +56,18 @@ class CompositionScaleGateTest {
     /**
      * The allocation gates are only meaningful if thread-allocation accounting is actually on:
      * when it is unsupported or disabled, getThreadAllocatedBytes returns -1 for every call and
-     * a before/after delta is 0 - the gate would pass vacuously. Fail loudly instead.
+     * a before/after delta is 0 - the gate would pass vacuously. Enable it when the JVM merely
+     * left it off; fail loudly only when the platform cannot support it at all.
      */
     private fun allocationAccounting(): com.sun.management.ThreadMXBean {
         val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
         assertTrue(
-            "thread allocation accounting must be supported and enabled for the allocation gates",
-            threads.isThreadAllocatedMemorySupported && threads.isThreadAllocatedMemoryEnabled
+            "thread allocation accounting must be supported for the allocation gates",
+            threads.isThreadAllocatedMemorySupported
         )
+        if (!threads.isThreadAllocatedMemoryEnabled) {
+            threads.isThreadAllocatedMemoryEnabled = true
+        }
         return threads
     }
 

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleGateTest.kt
@@ -53,6 +53,20 @@ class CompositionScaleGateTest {
         override fun close() = scene.close()
     }
 
+    /**
+     * The allocation gates are only meaningful if thread-allocation accounting is actually on:
+     * when it is unsupported or disabled, getThreadAllocatedBytes returns -1 for every call and
+     * a before/after delta is 0 - the gate would pass vacuously. Fail loudly instead.
+     */
+    private fun allocationAccounting(): com.sun.management.ThreadMXBean {
+        val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
+        assertTrue(
+            "thread allocation accounting must be supported and enabled for the allocation gates",
+            threads.isThreadAllocatedMemorySupported && threads.isThreadAllocatedMemoryEnabled
+        )
+        return threads
+    }
+
     private fun assertConfined(name: String, model: ScaleModel, pokeId: Int, compose: Harness.() -> Unit) {
         Harness().use { h ->
             h.compose()
@@ -114,7 +128,7 @@ class CompositionScaleGateTest {
         val model = ScaleModel(leafCount)
         Harness().use { h ->
             h.scene.setContent { FlatScene(model) } // no sync hook: measure the bare path
-            val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
+            val threads = allocationAccounting()
             val self = Thread.currentThread().id
             var value = 1.0
 
@@ -238,7 +252,7 @@ class CompositionScaleGateTest {
             h.scene.setContent { EntityScene(model, h.onLeafSync) }
             assertTrue("the scene must actually be at scale", countSpatials(h.root) >= 50_000)
 
-            val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
+            val threads = allocationAccounting()
             val self = Thread.currentThread().id
             repeat(10_000) { h.frame() } // warmup, mirroring the small-scene gate
 

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleGateTest.kt
@@ -1,0 +1,259 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import com.ardor3d.scenegraph.Node
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.management.ManagementFactory
+
+/**
+ * Scale gates for the composed scene layer: the checkers board proved the paradigm at ~90 nodes,
+ * and these assert the properties that must survive at 10k-50k. The load-bearing one is that the
+ * cost of a change tracks the change, never the scene: one leaf write recomposes one leaf and
+ * allocates the same bytes in a 50k-node scene as in a 1k-node one, keyed churn produces the same
+ * applier traffic at any size, and an idle frame at 50k spatials is as silent and allocation-free
+ * as the two-piece scene in [SceneCompositionTest].
+ *
+ * Every assertion here is a deterministic count - recompositions through the leaf-sync hook,
+ * applier traffic through [CountingApplier], allocated bytes through thread-allocation accounting.
+ * Wall-clock curves are deliberately not asserted; the env-gated [CompositionScaleBench] reports
+ * those. Like the other measurement gates, a classic red->green is not constructible: a red here
+ * is the runtime failing a scaling property, not a code path we could deliberately break.
+ */
+class CompositionScaleGateTest {
+
+    /** A composition over a [CountingApplier] plus a leaf-recomposition counter. */
+    private class Harness : AutoCloseable {
+        val root = Node("root")
+        val applier = CountingApplier(root)
+        val scene = SceneComposition(applier)
+
+        var leafSyncs = 0
+            private set
+        val onLeafSync: () -> Unit = { leafSyncs++ }
+
+        private var t = 0L
+        fun frame() = scene.frame(++t)
+
+        fun resetCounts() {
+            leafSyncs = 0
+            applier.resetCounts()
+        }
+
+        override fun close() = scene.close()
+    }
+
+    private fun assertConfined(name: String, model: ScaleModel, pokeId: Int, compose: Harness.() -> Unit) {
+        Harness().use { h ->
+            h.compose()
+            h.resetCounts()
+            model.poke(pokeId, 1.0)
+            h.frame()
+            assertEquals("$name: one leaf write must recompose exactly one leaf", 1, h.leafSyncs)
+            assertEquals("$name: one leaf write must cause no structural traffic", 0, h.applier.structuralOps)
+        }
+    }
+
+    @Test
+    fun aSingleLeafWriteRecomposesOnlyThatLeafInEveryShape() {
+        val flat = ScaleModel(10_000)
+        assertConfined("flat", flat, 5_000) { scene.setContent { FlatScene(flat, onLeafSync) } }
+
+        val tree = ScaleModel(10_000) // branching 10, depth 4: 10^4 leaves
+        assertConfined("tree", tree, 5_000) { scene.setContent { TreeScene(tree, 10, 4, onLeafSync) } }
+
+        val entity = ScaleModel(3_333) // ~10k spatials at 3 per entity
+        assertConfined("entity", entity, 1_666) { scene.setContent { EntityScene(entity, onLeafSync) } }
+    }
+
+    @Test
+    fun scatteredWritesRecomposeExactlyThatManyLeaves() {
+        val model = ScaleModel(10_000)
+        Harness().use { h ->
+            h.scene.setContent { FlatScene(model, h.onLeafSync) }
+            h.resetCounts()
+
+            val ids = (0 until 10).map { it * 1_000 + 37 }
+            ids.forEach { model.poke(it, 2.0) }
+            h.frame()
+
+            assertEquals("K scattered writes must recompose exactly K leaves", ids.size, h.leafSyncs)
+            assertEquals(0, h.applier.structuralOps)
+        }
+    }
+
+    @Test
+    fun leafWriteCostIsIndependentOfSceneSize() {
+        val small = measureLeafWrite(1_000)
+        val big = measureLeafWrite(50_000)
+
+        assertEquals(
+            "applier traffic for one leaf write must not depend on scene size",
+            small.operations, big.operations
+        )
+        assertTrue(
+            "allocation for one leaf write must not scale with scene size: " +
+                "${small.medianBytes}B at 1k vs ${big.medianBytes}B at 50k leaves",
+            big.medianBytes <= small.medianBytes * 2 + 512
+        )
+    }
+
+    private class LeafWriteCost(val operations: Int, val medianBytes: Long)
+
+    private fun measureLeafWrite(leafCount: Int): LeafWriteCost {
+        val model = ScaleModel(leafCount)
+        Harness().use { h ->
+            h.scene.setContent { FlatScene(model) } // no sync hook: measure the bare path
+            val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
+            val self = Thread.currentThread().id
+            var value = 1.0
+
+            // Warm until JIT and the runtime's lazy caches are done allocating.
+            repeat(2_000) { i ->
+                model.poke(i % leafCount, value++)
+                h.frame()
+            }
+
+            h.resetCounts()
+            model.poke(leafCount / 2, value++)
+            h.frame()
+            val operations = h.applier.operations
+
+            val samples = LongArray(9)
+            for (i in samples.indices) {
+                val before = threads.getThreadAllocatedBytes(self)
+                model.poke((leafCount / 2 + i * 13) % leafCount, value++)
+                h.frame()
+                samples[i] = threads.getThreadAllocatedBytes(self) - before
+            }
+            samples.sort()
+            return LeafWriteCost(operations, samples[samples.size / 2])
+        }
+    }
+
+    @Test
+    fun keyedChurnTrafficIsIndependentOfSceneSize() {
+        val small = measureChurn(1_000)
+        val big = measureChurn(50_000)
+
+        assertEquals("traffic for removing one keyed leaf", small.remove, big.remove)
+        assertEquals("traffic for inserting one keyed leaf", small.insert, big.insert)
+        assertEquals("traffic for moving one keyed leaf", small.move, big.move)
+    }
+
+    private class ChurnTraffic(val remove: Int, val insert: Int, val move: Int)
+
+    private fun measureChurn(leafCount: Int): ChurnTraffic {
+        val model = ScaleModel(leafCount)
+        Harness().use { h ->
+            h.scene.setContent { FlatScene(model) }
+
+            fun trafficFor(mutate: (List<Int>) -> List<Int>): Int {
+                h.resetCounts()
+                model.ids.value = mutate(model.ids.value)
+                h.frame()
+                return h.applier.operations
+            }
+
+            val mid = leafCount / 2
+            val remove = trafficFor { it - mid }
+            val insert = trafficFor { it.toMutableList().apply { add(mid, mid) } }
+            val move = trafficFor { it.drop(1) + it.first() }
+            return ChurnTraffic(remove, insert, move)
+        }
+    }
+
+    @Test
+    fun cellMembershipChurnIsIndependentOfSceneSize() {
+        val small = measureCellChurn(1_000)
+        val big = measureCellChurn(50_000)
+
+        assertEquals("traffic for removing one leaf from a cell", small.removeOps, big.removeOps)
+        assertEquals("traffic for re-inserting it", small.insertOps, big.insertOps)
+        assertEquals("traffic for transferring one leaf between cells", small.transferOps, big.transferOps)
+
+        for (churn in listOf(small, big)) {
+            assertEquals("a cell remove must not rebuild any surviving leaf", 0, churn.removeRebuilds)
+            assertEquals("a cell insert rebuilds exactly the inserted leaf", 1, churn.insertRebuilds)
+            assertEquals(
+                "a cross-cell transfer rebuilds exactly the moved leaf (keyed content does not cross parents)",
+                1, churn.transferRebuilds
+            )
+        }
+    }
+
+    private class CellChurn(
+        val removeOps: Int, val insertOps: Int, val transferOps: Int,
+        val removeRebuilds: Int, val insertRebuilds: Int, val transferRebuilds: Int
+    )
+
+    private fun measureCellChurn(leafCount: Int): CellChurn {
+        val cellSize = Math.round(Math.sqrt(leafCount.toDouble())).toInt()
+        val model = CellModel(leafCount, cellSize)
+        Harness().use { h ->
+            h.scene.setContent { CellScene(model, h.onLeafSync) }
+
+            // A rebuilt leaf announces itself: its first applied update fires the leaf-sync hook.
+            fun opsAndRebuilds(mutate: () -> Unit): Pair<Int, Int> {
+                h.resetCounts()
+                mutate()
+                h.frame()
+                return h.applier.operations to h.leafSyncs
+            }
+
+            val c = model.cells.size / 2
+            var pulled = -1
+            val remove = opsAndRebuilds {
+                val cell = model.cells[c].value
+                pulled = cell[cell.size / 2]
+                model.cells[c].value = cell - pulled
+            }
+            val insert = opsAndRebuilds {
+                model.cells[c].value = model.cells[c].value.toMutableList().apply { add(size / 2, pulled) }
+            }
+            val transfer = opsAndRebuilds {
+                val from = model.cells[c].value
+                val id = from.first()
+                model.cells[c].value = from.drop(1)
+                model.cells[c + 1].value = model.cells[c + 1].value + id
+            }
+            return CellChurn(remove.first, insert.first, transfer.first, remove.second, insert.second, transfer.second)
+        }
+    }
+
+    @Test
+    fun idleFramesStaySilentAndAllocationFreeAt50kSpatials() {
+        val model = ScaleModel(16_667) // 3 spatials per entity: ~50k emitted
+        Harness().use { h ->
+            h.scene.setContent { EntityScene(model, h.onLeafSync) }
+            assertTrue("the scene must actually be at scale", countSpatials(h.root) >= 50_000)
+
+            val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
+            val self = Thread.currentThread().id
+            repeat(10_000) { h.frame() } // warmup, mirroring the small-scene gate
+
+            h.resetCounts()
+            val before = threads.getThreadAllocatedBytes(self)
+            repeat(10_000) { h.frame() }
+            val allocated = threads.getThreadAllocatedBytes(self) - before
+
+            assertEquals("an idle frame at 50k spatials must not allocate", 0L, allocated)
+            assertEquals("an idle frame at 50k spatials must not touch the applier", 0, h.applier.operations)
+
+            // And the quiet stretch must not have starved a real change.
+            model.poke(8_000, 1.0)
+            h.frame()
+            assertEquals(1, h.leafSyncs)
+        }
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CountingApplier.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CountingApplier.kt
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.Spatial
+
+/**
+ * Instruments every applier entry point, structural and navigational, so tests can assert not just
+ * what the composed tree looks like but how much traffic it took to get there - including the
+ * silence gates, which assert none at all, and the scale gates, which assert the traffic for a
+ * change is the same in a 50k-node scene as in a 1k-node one.
+ */
+internal class CountingApplier(root: Node) : SpatialApplier(root) {
+    var structuralOps = 0
+        private set
+    var navigations = 0
+        private set
+
+    val operations: Int get() = structuralOps + navigations
+
+    fun resetCounts() {
+        structuralOps = 0
+        navigations = 0
+    }
+
+    override fun insertTopDown(index: Int, instance: Spatial) {
+        structuralOps++
+        super.insertTopDown(index, instance)
+    }
+
+    override fun insertBottomUp(index: Int, instance: Spatial) {
+        structuralOps++
+        super.insertBottomUp(index, instance)
+    }
+
+    override fun remove(index: Int, count: Int) {
+        structuralOps++
+        super.remove(index, count)
+    }
+
+    override fun move(from: Int, to: Int, count: Int) {
+        structuralOps++
+        super.move(from, to, count)
+    }
+
+    override fun onClear() {
+        structuralOps++
+        super.onClear()
+    }
+
+    override fun down(node: Spatial) {
+        navigations++
+        super.down(node)
+    }
+
+    override fun up() {
+        navigations++
+        super.up()
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ScaleScenes.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ScaleScenes.kt
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import com.ardor3d.scenegraph.Node
+
+/**
+ * Scene shapes for measuring the composition layer at scale, each a pure function from a
+ * [ScaleModel] to the composed tree. Every leaf reads its own state inside its own scope, so
+ * writing one leaf's state invalidates exactly that leaf - the property the scale gates assert
+ * still holds at 50k nodes. Three shapes bracket how scenes stress the slot table differently:
+ *
+ * - [FlatScene]: every leaf a keyed sibling under one node - the sibling-list worst case.
+ * - [TreeScene]: fixed-depth branching interior - slot-table depth without list width.
+ * - [EntityScene]: many small keyed subtrees (a group node holding two leaves) - the shape real
+ *   scenes are actually made of.
+ */
+internal open class LeafStates(val leafCount: Int) {
+    private val states = ArrayList<MutableState<Double>>(leafCount)
+
+    /** One state per leaf, grown on demand so churn can introduce ids beyond [leafCount]. */
+    fun offset(id: Int): MutableState<Double> {
+        while (states.size <= id) states.add(mutableStateOf(0.0))
+        return states[id]
+    }
+
+    /** Writes a leaf's state with a value guaranteed to differ, so the write always invalidates. */
+    fun poke(id: Int, value: Double) {
+        offset(id).value = value
+    }
+}
+
+internal class ScaleModel(leafCount: Int) : LeafStates(leafCount) {
+    /** Keyed membership and order of the leaves/entities; the churn scenarios rewrite this. */
+    val ids: MutableState<List<Int>> = mutableStateOf(List(leafCount) { it })
+}
+
+/**
+ * Stable-partition model: each cell owns its membership list as its own state, so churn rewrites
+ * one cell and invalidates one cell's scope - the composition pattern the engine would actually
+ * use for a large dynamic collection, as opposed to [ScaleModel.ids]'s single global list.
+ */
+internal class CellModel(leafCount: Int, cellSize: Int) : LeafStates(leafCount) {
+    val cells: List<MutableState<List<Int>>> =
+        (0 until (leafCount + cellSize - 1) / cellSize).map { c ->
+            mutableStateOf(((c * cellSize) until minOf((c + 1) * cellSize, leafCount)).toList())
+        }
+}
+
+/**
+ * One leaf of a scale scene. The state read sits inside [SceneSpatial]'s update, so an [offset]
+ * write invalidates only that innermost scope - tighter even than this function's own scope, which
+ * is why [onLeafSync] hooks the `set` apply block rather than a SideEffect here: it fires exactly
+ * when this leaf's node has its translation rewritten, the precise "only the changed leaf was
+ * touched" signal the scale gates count.
+ */
+@Composable
+internal fun BenchLeaf(id: Int, offset: State<Double>, onLeafSync: (() -> Unit)? = null) {
+    SceneSpatial(
+        factory = { Node("leaf_$id") },
+        update = {
+            set(offset.value) {
+                setTranslation(it, 0.0, 0.0)
+                onLeafSync?.invoke()
+            }
+        }
+    )
+}
+
+/** All leaves as keyed siblings under a single node. */
+@Composable
+internal fun FlatScene(model: ScaleModel, onLeafSync: (() -> Unit)? = null) {
+    SceneNode("flat") {
+        for (id in model.ids.value) {
+            key(id) { BenchLeaf(id, model.offset(id), onLeafSync) }
+        }
+    }
+}
+
+/**
+ * A balanced tree of [SceneNode] interiors with [BenchLeaf] leaves: `branching^depth` leaves, ids
+ * assigned positionally so the same id always lands at the same spot.
+ */
+@Composable
+internal fun TreeScene(model: ScaleModel, branching: Int, depth: Int, onLeafSync: (() -> Unit)? = null) {
+    TreeLevel(0, model.leafCount, branching, depth, model, onLeafSync)
+}
+
+@Composable
+private fun TreeLevel(
+    base: Int,
+    span: Int,
+    branching: Int,
+    depth: Int,
+    model: ScaleModel,
+    onLeafSync: (() -> Unit)?
+) {
+    if (depth == 0) {
+        BenchLeaf(base, model.offset(base), onLeafSync)
+    } else {
+        SceneNode("n_$base") {
+            val childSpan = span / branching
+            repeat(branching) { i ->
+                TreeLevel(base + i * childSpan, childSpan, branching, depth - 1, model, onLeafSync)
+            }
+        }
+    }
+}
+
+/**
+ * Entity-style scene: each id is a small keyed subtree - a group node holding a state-reading body
+ * leaf and a static trim leaf - so a scene of E entities emits 3E+1 spatials.
+ */
+@Composable
+internal fun EntityScene(model: ScaleModel, onLeafSync: (() -> Unit)? = null) {
+    SceneNode("entities") {
+        for (id in model.ids.value) {
+            key(id) {
+                SceneNode("entity_$id") {
+                    BenchLeaf(id, model.offset(id), onLeafSync)
+                    SceneSpatial(factory = { Node("trim_$id") })
+                }
+            }
+        }
+    }
+}
+
+/**
+ * [FlatScene]'s leaves regrouped under fixed-size keyed chunk nodes, chunked *positionally* from
+ * the single global ids list. Measured verdict: this rescues little (~3x, not orders of
+ * magnitude) - a global edit shifts membership across chunk boundaries, and keyed content does
+ * not move between parents in Compose, so shifted leaves are disposed and recreated chunk after
+ * chunk. Kept as the negative control for [CellScene], the stable-partition pattern that
+ * actually works.
+ */
+@Composable
+internal fun ChunkedScene(model: ScaleModel, chunkSize: Int, onLeafSync: (() -> Unit)? = null) {
+    SceneNode("chunked") {
+        val chunks = model.ids.value.chunked(chunkSize)
+        for ((index, chunk) in chunks.withIndex()) {
+            key(index) {
+                SceneNode("chunk_$index") {
+                    for (id in chunk) {
+                        key(id) { BenchLeaf(id, model.offset(id), onLeafSync) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Stable-partition scene over a [CellModel]: leaves live under the cell whose membership list
+ * names them, and a membership edit invalidates exactly that cell's scope. One sharp edge is part
+ * of what this shape measures: a leaf transferred between cells crosses keyed parents, so Compose
+ * disposes and recreates it - membership churn is cheap, but a transfer costs one node rebuild.
+ */
+@Composable
+internal fun CellScene(model: CellModel, onLeafSync: (() -> Unit)? = null) {
+    SceneNode("cells") {
+        for ((index, cell) in model.cells.withIndex()) {
+            key(index) {
+                SceneNode("cell_$index") {
+                    for (id in cell.value) {
+                        key(id) { BenchLeaf(id, model.offset(id), onLeafSync) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Counts every spatial under (and including) [root] - the honest denominator for per-node costs. */
+internal fun countSpatials(root: Node): Int {
+    var count = 1
+    for (child in root.children) {
+        count += if (child is Node) countSpatials(child) else 1
+    }
+    return count
+}
+
+/** Imperative twin of [FlatScene], for the memory baseline: what the scene graph alone costs. */
+internal fun buildFlatImperative(leafCount: Int): Node {
+    val root = Node("flat")
+    repeat(leafCount) { i -> root.attachChild(Node("leaf_$i")) }
+    return root
+}
+
+/** Imperative twin of [TreeScene]. */
+internal fun buildTreeImperative(branching: Int, depth: Int): Node {
+    if (depth == 0) return Node("leaf")
+    val node = Node("n")
+    repeat(branching) { node.attachChild(buildTreeImperative(branching, depth - 1)) }
+    return node
+}
+
+/** Imperative twin of [ChunkedScene]. */
+internal fun buildChunkedImperative(leafCount: Int, chunkSize: Int): Node {
+    val root = Node("chunked")
+    var chunkIndex = 0
+    var i = 0
+    while (i < leafCount) {
+        val chunkNode = Node("chunk_$chunkIndex")
+        val end = minOf(i + chunkSize, leafCount)
+        while (i < end) {
+            chunkNode.attachChild(Node("leaf_$i"))
+            i++
+        }
+        root.attachChild(chunkNode)
+        chunkIndex++
+    }
+    return root
+}
+
+/** Imperative twin of [EntityScene]. */
+internal fun buildEntityImperative(entityCount: Int): Node {
+    val root = Node("entities")
+    repeat(entityCount) { i ->
+        val entity = Node("entity_$i")
+        entity.attachChild(Node("leaf_$i"))
+        entity.attachChild(Node("trim_$i"))
+        root.attachChild(entity)
+    }
+    return root
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ScaleScenes.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ScaleScenes.kt
@@ -96,6 +96,10 @@ internal fun FlatScene(model: ScaleModel, onLeafSync: (() -> Unit)? = null) {
  */
 @Composable
 internal fun TreeScene(model: ScaleModel, branching: Int, depth: Int, onLeafSync: (() -> Unit)? = null) {
+    val leaves = generateSequence(1) { it * branching }.elementAt(depth)
+    require(model.leafCount == leaves) {
+        "TreeScene emits exactly branching^depth leaves; model has ${model.leafCount}, shape yields $leaves"
+    }
     TreeLevel(0, model.leafCount, branching, depth, model, onLeafSync)
 }
 

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/SceneCompositionTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/SceneCompositionTest.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.ardor3d.scenegraph.Node
-import com.ardor3d.scenegraph.Spatial
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -31,56 +30,6 @@ import java.lang.management.ManagementFactory
  * idle frame produces zero applier traffic of any kind.
  */
 class SceneCompositionTest {
-
-    /** Instruments every applier entry point, structural and navigational, for the silence gate. */
-    private class CountingApplier(root: Node) : SpatialApplier(root) {
-        var structuralOps = 0
-            private set
-        var navigations = 0
-            private set
-
-        val operations: Int get() = structuralOps + navigations
-
-        fun resetCounts() {
-            structuralOps = 0
-            navigations = 0
-        }
-
-        override fun insertTopDown(index: Int, instance: Spatial) {
-            structuralOps++
-            super.insertTopDown(index, instance)
-        }
-
-        override fun insertBottomUp(index: Int, instance: Spatial) {
-            structuralOps++
-            super.insertBottomUp(index, instance)
-        }
-
-        override fun remove(index: Int, count: Int) {
-            structuralOps++
-            super.remove(index, count)
-        }
-
-        override fun move(from: Int, to: Int, count: Int) {
-            structuralOps++
-            super.move(from, to, count)
-        }
-
-        override fun onClear() {
-            structuralOps++
-            super.onClear()
-        }
-
-        override fun down(node: Spatial) {
-            navigations++
-            super.down(node)
-        }
-
-        override fun up() {
-            navigations++
-            super.up()
-        }
-    }
 
     @Test
     fun setContentEmitsTheTreeSynchronously() {


### PR DESCRIPTION
The checkers board exercises the composition host at ~90 nodes; this adds the tests that pin how the layer behaves at 10k-50k spatials.

**CompositionScaleGateTest** — deterministic scaling properties, asserted as counts (recompositions, applier ops, allocated bytes), never wall time:

- An idle frame at 50k spatials allocates 0 bytes and produces 0 applier operations (the small-scene silence gate, at scale).
- One leaf-state write updates exactly one leaf in every shape; K scattered writes update exactly K.
- Leaf-write cost is size-independent: identical applier traffic and flat allocation at 1k vs 50k.
- Keyed-list churn emits size-independent traffic, and cell-membership churn (each cell's member list its own state) is size-independent with exact rebuild counts: a within-cell edit rebuilds only the inserted leaf, and a cross-cell transfer rebuilds exactly the moved leaf — keyed content does not cross parents.

**CompositionScaleBench** — env-gated (`A3D_COMPOSE_BENCH=1`, optionally `A3D_BENCH_SHAPES=...`), prints memory and wall-clock curves over five scene shapes at 1k/10k/50k. Headline measurements: composition retains ~0.5-1.1 KB per spatial over an imperative twin of the same tree; a single global keyed list reconciles remove/move quadratically in sibling count (seconds per edit at 50k) while emitting constant applier ops; positional chunking rescues little (shifted content rebuilds across chunk parents); stable-membership cells restore event-rate cost (250-775x on the same edits). The shapes double as documentation: `FlatScene` is the trap, `CellScene` is the pattern.

`CountingApplier` moves out of `SceneCompositionTest` so all three test files can instrument traffic; the editor test heap rises to 2g so the 50k scenes measure without GC skewing the allocation accounting. Full editor suite is green with the gates included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added scaling gate tests for composed scenes that precisely verify recomposition counts, structural update traffic, and allocation/idle behavior across small to very large scene sizes.
  - Added an optional benchmark suite that outputs composition/invalidation, churn operation, and allocation metrics across multiple scene layouts.
- **Chores**
  - Increased the JVM heap available for test execution to better support larger scenarios.
- **Refactor**
  - Centralized scene instrumentation for counting structural vs navigation operations, and updated related tests to use the shared instrumentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->