### PR TITLE
Channel-driven motion for composed scenes: slides and glow run outside recomposition

### DIFF
--- a/ardor3d-editor/build.gradle.kts
+++ b/ardor3d-editor/build.gradle.kts
@@ -61,4 +61,10 @@ tasks.test {
     // The composition scale gates hold 50k-spatial scenes; the default 512m test heap is tight
     // enough there that GC would skew the allocation accounting the gates assert on.
     maxHeapSize = "2g"
+
+    // Force Mesa's software rasterizer for the GL smoke tests: WSLg's d3d12 passthrough
+    // segfaults natively when a second GL context comes up in the same process, and its
+    // framebuffer readback returns zeros anyway. llvmpipe renders these tests correctly and
+    // deterministically; on non-Mesa platforms the variable is ignored.
+    environment("LIBGL_ALWAYS_SOFTWARE", "1")
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/ChannelBindings.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/ChannelBindings.kt
@@ -43,7 +43,10 @@ class TransformChannel internal constructor(
     fun writeTranslation(x: Double, y: Double, z: Double) =
         channels.writeTranslation(handle, x, y, z)
 
-    override fun onRemembered() {}
+    override fun onRemembered() {
+        // Nothing to do: the slot was already allocated in the remember lambda (see [handle]).
+    }
+
     override fun onForgotten() = channels.releaseTransform(key, handle)
     override fun onAbandoned() = channels.releaseTransform(key, handle)
 }
@@ -65,7 +68,10 @@ class ParamChannel internal constructor(
     /** Queues re-delivery of the current value - for when an outside input the target combines changed. */
     fun touch() = channels.touchParam(handle)
 
-    override fun onRemembered() {}
+    override fun onRemembered() {
+        // Nothing to do: the slot was already allocated in the remember lambda (see [handle]).
+    }
+
     override fun onForgotten() = channels.releaseParam(key, handle)
     override fun onAbandoned() = channels.releaseParam(key, handle)
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/ChannelBindings.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/ChannelBindings.kt
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.remember
+import com.ardor3d.scenegraph.Spatial
+
+/**
+ * The composition side of a channel: a binding is *made* by composition and *outlives
+ * recomposition* - the slot is allocated when the binding enters the composition (inside the
+ * remember lambda, so it exists even if that composition later fails to apply) and released
+ * exactly once when it leaves, whether that is [onForgotten] (left the composition, or the
+ * composition was disposed) or [onAbandoned] (the composition threw before applying). A second
+ * release is a stale-handle error, deliberately loud: if lifecycle notifications ever double
+ * up, that is a bug to hear about, not absorb.
+ *
+ * Replacement under the same remember position (a key change) creates the new binding *before*
+ * the old one is forgotten - the two briefly hold different slots, so a channel capacity must
+ * cover that transient overlap. The generation tag keeps the order honest: however the indexes
+ * recycle, a straggler writing through the replaced binding throws instead of reaching the new
+ * tenant.
+ */
+class TransformChannel internal constructor(
+    private val channels: SceneChannels,
+    private val key: Any?,
+    target: Spatial
+) : RememberObserver {
+
+    /** The slot handle - allocated here, at composition time. */
+    val handle: Long = channels.bindTransform(key, target)
+
+    /** Per-frame writer for game code holding this binding. Throws once the binding is released. */
+    fun writeTranslation(x: Double, y: Double, z: Double) =
+        channels.writeTranslation(handle, x, y, z)
+
+    override fun onRemembered() {}
+    override fun onForgotten() = channels.releaseTransform(key, handle)
+    override fun onAbandoned() = channels.releaseTransform(key, handle)
+}
+
+/** A param channel's binding; same lifecycle contract as [TransformChannel]. */
+class ParamChannel internal constructor(
+    private val channels: SceneChannels,
+    private val key: Any?,
+    initial: Float,
+    target: SceneChannels.FloatTarget
+) : RememberObserver {
+
+    /** The slot handle - allocated here, at composition time. */
+    val handle: Long = channels.bindParam(key, initial, target)
+
+    /** Per-frame writer. Throws once the binding is released. */
+    fun write(value: Float) = channels.writeParam(handle, value)
+
+    /** Queues re-delivery of the current value - for when an outside input the target combines changed. */
+    fun touch() = channels.touchParam(handle)
+
+    override fun onRemembered() {}
+    override fun onForgotten() = channels.releaseParam(key, handle)
+    override fun onAbandoned() = channels.releaseParam(key, handle)
+}
+
+/**
+ * Binds a transform channel for [target], alive exactly as long as this call stays in the
+ * composition. Re-keyed by all three parameters: a new [key] or a new [target] instance is a
+ * new binding (old released, new seeded from the target's then-current transform). [key] also
+ * registers the binding for [SceneChannels.transformHandle] lookup by event-rate game code.
+ */
+@Composable
+fun rememberTransformChannel(channels: SceneChannels, key: Any?, target: Spatial): TransformChannel =
+    remember(channels, key, target) { TransformChannel(channels, key, target) }
+
+/**
+ * Binds a param channel delivering to [target], alive exactly as long as this call stays in
+ * the composition. [initial] is captured at bind time only - it seeds the slot and is not a
+ * remember key, so a changed initial alone does not re-bind.
+ */
+@Composable
+fun rememberParamChannel(
+    channels: SceneChannels,
+    key: Any?,
+    initial: Float,
+    target: SceneChannels.FloatTarget
+): ParamChannel =
+    remember(channels, key, target) { ParamChannel(channels, key, initial, target) }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/ChannelBlock.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/ChannelBlock.kt
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import com.ardor3d.buffer.BufferUtils
+import java.nio.FloatBuffer
+
+/**
+ * A fixed-stride SoA store for values that change every frame - translation tracks, per-node
+ * float params. Composed scenes own *structure* through recomposition, but frame-rate motion
+ * must never ride that path (a recomposition per animation frame is exactly the cost the
+ * composed layer exists to avoid). Instead, a scene node binds a **channel**: a slot in this
+ * block, allocated when the binding enters the composition, released when it leaves. Game code
+ * writes the slot imperatively every frame by handle; a sampler drains [forEachDirtyClearing]
+ * after recomposition and applies the committed values to the live spatials. Composition owns
+ * the binding, never the value.
+ *
+ * Values live off the Java heap in a direct [FloatBuffer] (the scene graph's native idiom),
+ * one tightly packed array per channel. The per-frame surface - [set], [get], [touch],
+ * [forEachDirtyClearing] - is primitives only: nothing here may allocate at frame rate, which
+ * is what lets a slide or a pulse run through a channel at exactly zero bytes per frame (the
+ * gate tests assert this).
+ *
+ * **Slot lifecycle, made loud:** [allocate] returns a long handle packing (generation, index);
+ * [free] bumps the slot's generation first, so any later write, read, or re-free through a
+ * stale handle throws instead of silently landing in recycled memory - a bare int index cannot
+ * fail loudly once its index is reused. Structure and motion meet exactly here: a node disposed
+ * mid-animation retires its slot once, and the animation's next write is an error with a name,
+ * not a corrupted stranger's transform. [free] also returns the slot for immediate reuse -
+ * there is no retired-but-unrecycled state, which is sound here because the single-threaded
+ * host has no reader mid-pass to protect.
+ *
+ * **The binding writer rule:** [allocate] does not clear the slot's floats - a recycled slot
+ * still holds whatever its previous tenant last wrote. Whoever binds a slot must write *every*
+ * channel with real initial values before the first drain. Clearing would not make skipping
+ * that safe: an all-zero rotation is degenerate, not neutral, so zeros are just a different
+ * flavor of quietly-wrong data. The no-fill behavior is pinned by test.
+ */
+class ChannelBlock(val channels: Int, val capacity: Int) {
+
+    companion object {
+        /** px py pz | qx qy qz qw - a node's local translation and rotation. */
+        const val TRANSFORM_CHANNELS = 7
+
+        /** One float param (applied as written - never interpolated). */
+        const val PARAM_CHANNELS = 1
+    }
+
+    init {
+        require(channels > 0 && capacity > 0)
+    }
+
+    /** The block's values: [channels] contiguous arrays of [capacity] floats. */
+    private val values: FloatBuffer = BufferUtils.createFloatBuffer(channels * capacity)
+
+    // Free-list allocation, primitives only (pops ascending); a live-bit set backs the
+    // double-free check and the dirty set below is the sampler's work queue.
+    private val free = IntArray(capacity) { capacity - 1 - it }
+    private var freeTop = capacity
+    private val live = LongArray((capacity + 63) / 64)
+    private val generation = IntArray(capacity)
+
+    @PublishedApi // for the inline [forEachDirtyClearing]; not API - treat as private
+    internal val dirty = LongArray((capacity + 63) / 64)
+
+    /** Slots currently bound. */
+    val liveCount: Int get() = capacity - freeTop
+
+    fun allocate(): Long {
+        check(freeTop > 0) { "channel block exhausted: all $capacity slots live" }
+        val index = free[--freeTop]
+        live[index ushr 6] = live[index ushr 6] or (1L shl (index and 63))
+        return (generation[index].toLong() shl 32) or index.toLong()
+    }
+
+    /**
+     * Releases [handle]'s slot. The generation bumps *first*, so the handle (and any copy of
+     * it an animation still holds) is stale from this call onward; the slot only re-enters the
+     * free list here, giving the next [allocate] a fresh generation over the same index.
+     */
+    fun free(handle: Long) {
+        val index = checkedIndex(handle)
+        generation[index]++
+        val mask = 1L shl (index and 63)
+        require(live[index ushr 6] and mask != 0L) { "double free of channel slot $index" }
+        live[index ushr 6] = live[index ushr 6] and mask.inv()
+        dirty[index ushr 6] = dirty[index ushr 6] and mask.inv()
+        free[freeTop++] = index
+    }
+
+    /** The raw slot index behind [handle] - how a sampler keys its target tables. Checks staleness. */
+    fun indexOf(handle: Long): Int = checkedIndex(handle)
+
+    /** Writes one channel of [handle]'s slot and queues the slot for the next sampler drain. */
+    fun set(channel: Int, handle: Long, value: Float) {
+        val index = checkedIndex(handle)
+        values.put(offset(channel, index), value)
+        dirty[index ushr 6] = dirty[index ushr 6] or (1L shl (index and 63))
+    }
+
+    fun get(channel: Int, handle: Long): Float = values.get(offset(channel, checkedIndex(handle)))
+
+    /**
+     * Queues [handle]'s slot for the next sampler drain without writing a value - for when an
+     * input the sampler combines with the channel value (held outside the block) changed.
+     */
+    fun touch(handle: Long) {
+        val index = checkedIndex(handle)
+        dirty[index ushr 6] = dirty[index ushr 6] or (1L shl (index and 63))
+    }
+
+    /** Reads one channel by raw slot index - the sampler's drain-path read (no handle in hand). */
+    internal fun getByIndex(channel: Int, index: Int): Float = values.get(offset(channel, index))
+
+    /**
+     * Visits every dirty slot index in ascending order and clears the set - the sampler's
+     * drain. Inline so the per-frame caller pays no lambda object; like the rest of the
+     * per-frame surface, this must add nothing to the Java heap.
+     *
+     * [action] must not mutate the block (no allocate/free/set/touch from inside the drain):
+     * each word is snapshotted before its slots are visited, so a mid-drain mutation would be
+     * half-seen. The drain reads values by raw index, deliberately without a staleness check -
+     * that is only sound while this contract holds.
+     */
+    inline fun forEachDirtyClearing(action: (Int) -> Unit) {
+        for (word in dirty.indices) {
+            var bits = dirty[word]
+            dirty[word] = 0L
+            while (bits != 0L) {
+                action((word shl 6) + bits.countTrailingZeroBits())
+                bits = bits and (bits - 1)
+            }
+        }
+    }
+
+    private fun offset(channel: Int, index: Int): Int {
+        require(channel in 0 until channels) { "channel $channel outside 0 until $channels" }
+        return channel * capacity + index
+    }
+
+    private fun checkedIndex(handle: Long): Int {
+        val index = handle.toInt()
+        val gen = (handle ushr 32).toInt()
+        require(index in 0 until capacity) { "handle index $index outside capacity $capacity" }
+        check(gen == generation[index]) {
+            "stale channel handle: slot $index generation $gen, current ${generation[index]}"
+        }
+        return index
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/SceneChannels.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/SceneChannels.kt
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import com.ardor3d.math.Quaternion
+import com.ardor3d.scenegraph.Spatial
+
+/**
+ * One composed scene's channels: the value blocks, the target tables that map slots back to
+ * live scene objects, and the sampler that applies committed values. This is how frame-rate
+ * motion coexists with a composed scene without riding recomposition:
+ *
+ *  - **Composition owns the binding.** A composable binds a channel when it enters the
+ *    composition and releases it when it leaves; the binding seeds every channel from the
+ *    target's current state ([ChannelBlock]'s binding writer rule), so the slot starts as the
+ *    status quo, never a recycled slot's leftovers.
+ *  - **Game code owns the value.** Per-frame writers ([writeTranslation], [writeParam]) go
+ *    straight to the block by handle - no recomposition, no applier traffic, no allocation.
+ *    Recomposition of the owning node must not write a channel-owned value; the block is the
+ *    single source of truth for it.
+ *  - **The sampler commits.** [sample] drains the dirty slots and applies them - translation
+ *    and rotation onto the bound [Spatial], params through their [FloatTarget] - once per
+ *    update, after the composition frame, so structural changes and motion land in a known
+ *    order.
+ *
+ * Exactly two channel types exist: a transform track (translation + rotation; scale stays
+ * composition-owned) and a single float param. Single-threaded by the same contract as
+ * [SceneComposition]: bind, write, [sample], and release all on the thread driving the update
+ * loop. The per-frame surface allocates nothing; registries and binding are event-rate.
+ */
+class SceneChannels(transformCapacity: Int = 64, paramCapacity: Int = 64) {
+
+    /** Where a param channel's committed value lands - implementations write render state. */
+    fun interface FloatTarget {
+        fun apply(value: Float)
+    }
+
+    private val transforms = ChannelBlock(ChannelBlock.TRANSFORM_CHANNELS, transformCapacity)
+    private val params = ChannelBlock(ChannelBlock.PARAM_CHANNELS, paramCapacity)
+
+    private val transformTargets = arrayOfNulls<Spatial>(transformCapacity)
+    private val paramTargets = arrayOfNulls<FloatTarget>(paramCapacity)
+
+    // Key -> handle, so event-rate game code (a move starting, a pulse attaching) can find a
+    // composed binding without walking the scene graph. Never touched at frame rate.
+    private val transformsByKey = HashMap<Any, Long>()
+    private val paramsByKey = HashMap<Any, Long>()
+
+    private val quat = Quaternion() // sampler scratch, reused every drain
+
+    /** Transform slots currently bound. */
+    val liveTransformCount: Int get() = transforms.liveCount
+
+    /** Param slots currently bound. */
+    val liveParamCount: Int get() = params.liveCount
+
+    // --- binding (event rate) ------------------------------------------------------------
+
+    /**
+     * Binds a transform channel to [target], seeding every channel from the target's current
+     * local translation and rotation, and registers it under [key] (if any) for
+     * [transformHandle] lookup. The first [sample] after this re-applies the status quo.
+     */
+    fun bindTransform(key: Any?, target: Spatial): Long {
+        val handle = transforms.allocate()
+        transformTargets[transforms.indexOf(handle)] = target
+        val t = target.translation
+        transforms.set(PX, handle, t.x.toFloat())
+        transforms.set(PY, handle, t.y.toFloat())
+        transforms.set(PZ, handle, t.z.toFloat())
+        quat.fromRotationMatrix(target.rotation)
+        transforms.set(QX, handle, quat.x.toFloat())
+        transforms.set(QY, handle, quat.y.toFloat())
+        transforms.set(QZ, handle, quat.z.toFloat())
+        transforms.set(QW, handle, quat.w.toFloat())
+        if (key != null) transformsByKey[key] = handle
+        return handle
+    }
+
+    /**
+     * Releases a transform binding. The registry entry for [key] is removed only if it still
+     * points at [handle]: when a binding is replaced under the same key, the replacement
+     * registers *before* the old binding is forgotten, and its entry must survive this call.
+     */
+    fun releaseTransform(key: Any?, handle: Long) {
+        transformTargets[transforms.indexOf(handle)] = null
+        if (key != null && transformsByKey[key] == handle) transformsByKey.remove(key)
+        transforms.free(handle)
+    }
+
+    /** Binds a param channel delivering to [target], seeded with [initial]. See [bindTransform]. */
+    fun bindParam(key: Any?, initial: Float, target: FloatTarget): Long {
+        val handle = params.allocate()
+        paramTargets[params.indexOf(handle)] = target
+        params.set(PARAM, handle, initial)
+        if (key != null) paramsByKey[key] = handle
+        return handle
+    }
+
+    /** Releases a param binding. Same registry rule as [releaseTransform]. */
+    fun releaseParam(key: Any?, handle: Long) {
+        paramTargets[params.indexOf(handle)] = null
+        if (key != null && paramsByKey[key] == handle) paramsByKey.remove(key)
+        params.free(handle)
+    }
+
+    /** The handle bound under [key] - how a starting animation finds its channel. Loud if absent. */
+    fun transformHandle(key: Any): Long =
+        transformsByKey[key] ?: error("no transform channel bound under key $key")
+
+    /** The param handle bound under [key]. Loud if absent. */
+    fun paramHandle(key: Any): Long =
+        paramsByKey[key] ?: error("no param channel bound under key $key")
+
+    /** Whether a transform channel is currently bound under [key]. */
+    fun hasTransform(key: Any): Boolean = transformsByKey.containsKey(key)
+
+    /** Whether a param channel is currently bound under [key]. */
+    fun hasParam(key: Any): Boolean = paramsByKey.containsKey(key)
+
+    // --- the per-frame surface (must not allocate) -----------------------------------------
+
+    /** Writes [handle]'s translation; the next [sample] applies it. Throws if [handle] is stale. */
+    fun writeTranslation(handle: Long, x: Double, y: Double, z: Double) {
+        transforms.set(PX, handle, x.toFloat())
+        transforms.set(PY, handle, y.toFloat())
+        transforms.set(PZ, handle, z.toFloat())
+    }
+
+    /** Writes [handle]'s param value; the next [sample] delivers it. Throws if [handle] is stale. */
+    fun writeParam(handle: Long, value: Float) {
+        params.set(PARAM, handle, value)
+    }
+
+    /**
+     * Queues [handle]'s param for re-delivery at the next [sample] without changing its value -
+     * for when an input the target combines with the value (held outside the block, e.g. a base
+     * color) has changed.
+     */
+    fun touchParam(handle: Long) {
+        params.touch(handle)
+    }
+
+    /**
+     * Applies every value written (or touched) since the last call: transforms onto their bound
+     * spatials, params through their targets. Nothing dirty, nothing done - an idle sample is a
+     * bitset walk. Allocation-free; call once per update, after the composition frame.
+     */
+    fun sample() {
+        transforms.forEachDirtyClearing { index ->
+            val target = checkNotNull(transformTargets[index]) { "dirty transform slot $index has no target" }
+            target.setTranslation(
+                transforms.getByIndex(PX, index).toDouble(),
+                transforms.getByIndex(PY, index).toDouble(),
+                transforms.getByIndex(PZ, index).toDouble()
+            )
+            quat.set(
+                transforms.getByIndex(QX, index).toDouble(),
+                transforms.getByIndex(QY, index).toDouble(),
+                transforms.getByIndex(QZ, index).toDouble(),
+                transforms.getByIndex(QW, index).toDouble()
+            )
+            target.setRotation(quat)
+        }
+        params.forEachDirtyClearing { index ->
+            val target = checkNotNull(paramTargets[index]) { "dirty param slot $index has no target" }
+            target.apply(params.getByIndex(PARAM, index))
+        }
+    }
+
+    // --- test access (same module only) ----------------------------------------------------
+
+    internal val transformsForTest: ChannelBlock get() = transforms
+    internal val paramsForTest: ChannelBlock get() = params
+
+    internal companion object {
+        // Transform block channel order.
+        internal const val PX = 0
+        internal const val PY = 1
+        internal const val PZ = 2
+        internal const val QX = 3
+        internal const val QY = 4
+        internal const val QZ = 5
+        internal const val QW = 6
+
+        // The param block's single channel.
+        internal const val PARAM = 0
+    }
+}

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/SceneComposition.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/compose/SceneComposition.kt
@@ -72,10 +72,19 @@ class SceneComposition(applier: SpatialApplier) : AutoCloseable {
     fun frame(frameTimeNanos: Long) {
         Snapshot.sendApplyNotifications()
         if (clock.hasAwaiters) {
+            framesSent++
             clock.sendFrame(frameTimeNanos)
         }
         failure?.let { throw IllegalStateException("Scene recomposition failed", it) }
     }
+
+    private var framesSent = 0
+
+    /** How many [frame] calls actually sent a clock frame - the silence gates count this. */
+    internal val framesSentForTest: Int get() = framesSent
+
+    /** Whether anything currently awaits a clock frame - a truly idle host has no awaiters. */
+    internal val hasFrameAwaitersForTest: Boolean get() = clock.hasAwaiters
 
     override fun close() {
         composition.dispose()

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/BoardScene.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/BoardScene.kt
@@ -14,10 +14,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import com.ardor3d.bounding.BoundingBox
+import com.ardor3d.compose.SceneChannels
 import com.ardor3d.compose.SceneNode
 import com.ardor3d.compose.SceneSpatial
 import com.ardor3d.compose.SpatialApplier
+import com.ardor3d.compose.rememberParamChannel
+import com.ardor3d.compose.rememberTransformChannel
 import com.ardor3d.light.PointLight
 import com.ardor3d.math.ColorRGBA
 import com.ardor3d.math.Quaternion
@@ -35,11 +39,23 @@ import com.ardor3d.scenegraph.shape.Cylinder
  * job here. It contains no game rules, only presentation and the click-target mapping the game
  * needs.
  *
- * Attribute ownership: composition owns structure, and owns an attribute only through a
- * `set(value)` keyed on the model value it derives from - such a setter re-runs only when that
- * value changes. That is what legitimizes the move slide's *imperative* translation writes: while
- * a piece's square is unchanged, composition never touches its translation, and when the square
- * does change, the snap it writes is the slide's own endpoint.
+ * Attribute ownership is structural, not conventional. Every attribute is one of:
+ *
+ *  - **Composition-owned:** set through a `set(value)` keyed on the model value it derives from
+ *    (a piece's pick metadata, its king flag). Such a setter re-runs only when that value
+ *    changes.
+ *  - **Channel-owned:** composition owns the *binding* - a [SceneChannels] slot allocated when
+ *    the node enters the composition, released when it leaves - and never the value. A piece's
+ *    translation and a highlight marker's glow intensity live here: game code writes them
+ *    imperatively every frame by handle, the sampler applies them after the composition frame,
+ *    and recomposition of the owning node must not (and structurally cannot - there is no
+ *    setter left) write them back. A marker's color is the worked example of the two meeting:
+ *    the *base* color is composition-owned input (it follows the highlight kind), the *glow*
+ *    is channel-owned, and only the sampler writes the derived `defaultColor = base x glow`.
+ *
+ * The move slide is no longer an exception politely tolerated - it is a channel writer like any
+ * other, and a test can violate the ownership split and be caught by the channel's staleness
+ * and the scene's silence gates.
  *
  * Picking model (unchanged from the imperative view): only playable board tiles are pickable and
  * carry their square (see [squareForTile]); pieces and highlights are non-pickable, so a click
@@ -51,6 +67,7 @@ import com.ardor3d.scenegraph.shape.Cylinder
  */
 @Composable
 fun BoardScene(
+    channels: SceneChannels,
     board: () -> Board,
     highlights: () -> Map<Square, HighlightKind>,
     materialize: (Spatial) -> Unit = {},
@@ -61,8 +78,8 @@ fun BoardScene(
     // nothing and are composed exactly once.
     BoardLight()
     BoardTiles(materialize)
-    BoardPieces(board, materialize, onSync)
-    BoardHighlights(highlights, materialize, onSync)
+    BoardPieces(channels, board, materialize, onSync)
+    BoardHighlights(channels, highlights, materialize, onSync)
 }
 
 /** Metadata property keys on composed spatials (same key strings the imperative view used). */
@@ -116,16 +133,16 @@ private fun BoardTiles(materialize: (Spatial) -> Unit) {
 }
 
 @Composable
-private fun BoardPieces(board: () -> Board, materialize: (Spatial) -> Unit, onSync: () -> Unit) {
+private fun BoardPieces(channels: SceneChannels, board: () -> Board, materialize: (Spatial) -> Unit, onSync: () -> Unit) {
     SceneNode("Pieces") {
         val current = board()
         // Keyed by the model's stable piece identity and kept in identity order: a piece that moves
-        // keeps its node *and* its place among siblings, so a plain move is zero structural traffic -
-        // just the translation snap in BoardPiece's update.
+        // keeps its node, its channel binding, *and* its place among siblings, so a plain move is
+        // zero structural traffic - the translation itself belongs to the channel.
         for (entry in current.occupied.entries.sortedBy { current.idAt(it.key) }) {
             val id = current.idAt(entry.key)
             key(id) {
-                BoardPiece(id, entry.value, entry.key, materialize)
+                BoardPiece(channels, id, entry.value, entry.key, materialize)
             }
         }
         SideEffect { onSync() }
@@ -133,20 +150,24 @@ private fun BoardPieces(board: () -> Board, materialize: (Spatial) -> Unit, onSy
 }
 
 @Composable
-private fun BoardPiece(id: Int, piece: Piece, square: Square, materialize: (Spatial) -> Unit) {
+private fun BoardPiece(channels: SceneChannels, id: Int, piece: Piece, square: Square, materialize: (Spatial) -> Unit) {
+    // Created here rather than in the ComposeNode factory so the channel can bind to the
+    // instance at composition time. Spawn placement happens once, at creation; from then on the
+    // translation is channel-owned - the slide writes it by handle, the sampler applies it, and
+    // recomposition never writes it (there is deliberately no translation snap in the update
+    // block below).
+    val node = remember {
+        Node("piece_$id").apply {
+            // Pieces are presentation only - never picked (clicks resolve through the tile beneath).
+            sceneHints.setPickingHint(PickingHint.Pickable, false)
+            setTranslation(worldPositionOf(square))
+        }
+    }
+    rememberTransformChannel(channels, id, node)
     ComposeNode<Node, SpatialApplier>(
-        factory = {
-            Node("piece_$id").apply {
-                // Pieces are presentation only - never picked (clicks resolve through the tile beneath).
-                sceneHints.setPickingHint(PickingHint.Pickable, false)
-            }
-        },
+        factory = { node },
         update = {
-            // Placement is owned through the square (see the file doc's ownership policy).
-            set(square) {
-                setTranslation(worldPositionOf(it))
-                setProperty(PROP_SQUARE, it.row * Board.SIZE + it.col)
-            }
+            set(square) { setProperty(PROP_SQUARE, it.row * Board.SIZE + it.col) }
             set(piece.color) { setProperty(PROP_COLOR, it.name) }
             set(piece.king) { setProperty(PROP_KING, it) }
         }
@@ -160,6 +181,7 @@ private fun BoardPiece(id: Int, piece: Piece, square: Square, materialize: (Spat
 
 @Composable
 private fun BoardHighlights(
+    channels: SceneChannels,
     highlights: () -> Map<Square, HighlightKind>,
     materialize: (Spatial) -> Unit,
     onSync: () -> Unit
@@ -167,18 +189,57 @@ private fun BoardHighlights(
     SceneNode("Highlights") {
         for ((square, kind) in highlights()) {
             key(square) {
-                SceneSpatial(
-                    factory = { buildHighlightMarker().also(materialize) },
-                    update = {
-                        set(square) { setTranslation(it.col - OFFSET, TILE_TOP + 0.02, it.row - OFFSET) }
-                        set(kind) { defaultColor = colorFor(it) }
-                    }
-                )
+                HighlightMarker(channels, square, kind, materialize)
             }
         }
         SideEffect { onSync() }
     }
 }
+
+@Composable
+private fun HighlightMarker(
+    channels: SceneChannels,
+    square: Square,
+    kind: HighlightKind,
+    materialize: (Spatial) -> Unit
+) {
+    // Like a piece: created at composition time so the glow channel can bind to it, and placed
+    // once - markers never move; a different square is a different marker under key(square).
+    val marker = remember {
+        buildHighlightMarker().apply {
+            setTranslation(square.col - OFFSET, TILE_TOP + 0.02, square.row - OFFSET)
+        }.also(materialize)
+    }
+    val glow = remember { GlowTarget(marker) }
+    val glowChannel = rememberParamChannel(channels, square, GLOW_REST, glow)
+    SceneSpatial(
+        factory = { marker },
+        update = {
+            // The base color is composition-owned input; the shown color is derived by the
+            // sampler (base x glow), so a kind change updates the base and re-queues delivery
+            // instead of writing the mesh - the glow value itself is never touched from here.
+            set(kind) {
+                glow.base.set(colorFor(it))
+                glowChannel.touch()
+            }
+        }
+    )
+}
+
+/**
+ * Combines the composition-owned base color with the channel-owned glow intensity; only the
+ * sampler calls [apply], so this is the single writer of the marker's shown color.
+ */
+private class GlowTarget(private val marker: Spatial) : SceneChannels.FloatTarget {
+    val base = ColorRGBA()
+
+    override fun apply(value: Float) {
+        marker.setDefaultColor(base.red * value, base.green * value, base.blue * value, base.alpha)
+    }
+}
+
+/** A glow channel's resting intensity: the marker shows exactly its base color. */
+internal const val GLOW_REST = 1f
 
 // --- construction --------------------------------------------------------------------------
 

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
@@ -13,6 +13,7 @@ package com.ardor3d.editor.checkers
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.ardor3d.compose.SceneChannels
 import com.ardor3d.compose.SceneComposition
 import com.ardor3d.editor.play.GameContext
 import com.ardor3d.editor.play.GameInput
@@ -31,15 +32,18 @@ import com.ardor3d.scenegraph.extension.CameraNode
  * hand-written here.
  *
  * Interaction: hovering a movable piece previews its legal moves; clicking one selects it (it
- * stays lit with its destinations), and the destination under the pointer highlights distinctly.
- * Clicking a destination moves (a jump plays its whole mandatory chain); clicking another of your
- * pieces reselects; clicking elsewhere clears. Moves animate with a short slide; input is ignored
- * mid-slide and once the game is over.
+ * stays lit with its destinations), and the destination under the pointer highlights distinctly
+ * and breathes (a gentle glow pulse). Clicking a destination moves (a jump plays its whole
+ * mandatory chain); clicking another of your pieces reselects; clicking elsewhere clears. Moves
+ * animate with a short slide; input is ignored mid-slide and once the game is over.
  *
- * The move slide is the deliberate exception to declarative sync: it writes the sliding piece's
- * translation imperatively every frame, with zero recomposition mid-slide. Composition tolerates
- * that because [BoardScene] only rewrites a translation when the piece's square changes - and the
- * post-move snap it then writes is the slide's own endpoint.
+ * Frame-rate motion - the move slide, the glow pulse - runs through [SceneChannels], not through
+ * recomposition: composition binds a channel per piece (and per highlight marker), this class
+ * writes the animated values by handle each frame, and one [SceneChannels.sample] after the
+ * composition frame applies them. The update loop's order is the contract: advance the model and
+ * write channels, [SceneComposition.frame] for structure, then sample - so structural changes
+ * (a capture, a crowning) and motion land in a known order every frame, and a slide runs with
+ * zero recomposition and zero applier traffic by construction, not by convention.
  */
 class CheckersGame : GameMode {
     private var context: GameContext? = null
@@ -53,17 +57,29 @@ class CheckersGame : GameMode {
     // The composed scene: built per session in onStart, closed on stop.
     private var boardRoot: Node? = null
     private var composition: SceneComposition? = null
+    private var channels: SceneChannels? = null
     private var frameNanos = 0L
     private var syncs = 0
 
     // Move animation: slide the moving piece from its old square to its new one before the board
-    // state flips to the applied position (imperative by design - see the class doc).
+    // state flips to the applied position. The slide is a channel writer (see the class doc):
+    // the handle is looked up once when the move starts, written every frame, and the t=1 write
+    // is the endpoint itself - recomposition never snaps a translation.
     private var animating = false
     private var animElapsed = 0.0
-    private var animNode: Node? = null
+    private var animHandle = 0L
     private val animFrom = Vector3()
     private val animTo = Vector3()
     private var pendingBoard: Board? = null
+
+    // The glow pulse on the destination under the pointer. The channel handle is re-looked-up
+    // only when the pulsing square changes (bindings are event-rate); the per-frame work is one
+    // writeParam. boundPulse/pulseLive track what the last lookup found.
+    private var pulseTime = 0.0
+    private var pulseSquare: Square? = null
+    private var boundPulse: Square? = null
+    private var pulseLive = false
+    private var pulseHandle = 0L
 
     override fun onStart(context: GameContext) {
         this.context = context
@@ -81,9 +97,14 @@ class CheckersGame : GameMode {
 
         val root = Node("Checkers")
         boardRoot = root
+        // Capacities cover the board plus binding-replacement overlap (a replaced binding holds
+        // its slot until the old one is forgotten, so peak occupancy briefly exceeds live count).
+        val sceneChannels = SceneChannels(transformCapacity = 32, paramCapacity = 48)
+        channels = sceneChannels
         composition = SceneComposition(root).apply {
             setContent {
                 BoardScene(
+                    channels = sceneChannels,
                     board = { board },
                     highlights = { highlights },
                     materialize = context::materialize,
@@ -98,28 +119,39 @@ class CheckersGame : GameMode {
     override fun update(timePerFrame: Double, input: GameInput) {
         val context = this.context ?: return
         frameNanos += (timePerFrame * 1_000_000_000).toLong()
+        pulseTime += timePerFrame
         if (animating) {
             advanceAnimation(timePerFrame)
         } else if (!board.isGameOver()) {
             // The square under the pointer this frame (null = off the board).
-            val hover = squareAt(context, input.mouseX, input.mouseY)
+            val hover = forcedHoverForTest ?: squareAt(context, input.mouseX, input.mouseY)
             val click = input.click
             if (click != null) {
                 // Resolve the click where it happened, not where the pointer is now - the pointer
                 // can move between the release and this frame's poll.
                 processClick(squareAt(context, click.x, click.y))
             }
-            // beginMove already cleared the highlights if a move just started.
-            if (!animating) highlights = computeHighlights(hover)
+            // beginMove already cleared the highlights (and the pulse) if a move just started.
+            if (!animating) {
+                highlights = computeHighlights(hover)
+                pulseSquare = if (hover != null && highlights[hover] == HighlightKind.MOVE_HOVER) hover else null
+            }
         }
         // One composition frame per game update: state written above (including by finalizeMove)
         // lands in the scene now, synchronously. An idle frame does nothing.
         composition?.frame(frameNanos)
+        // Then motion: the pulse writes its channel (bindings made by the frame above are
+        // visible here), and one sample applies everything written this update.
+        channels?.let { ch ->
+            refreshPulse(ch)
+            ch.sample()
+        }
     }
 
     override fun onStop() {
         composition?.close()
         composition = null
+        channels = null
         boardRoot = null
         context?.setStatus(null)
         context = null
@@ -187,13 +219,17 @@ class CheckersGame : GameMode {
     private fun beginMove(move: Move) {
         deselect()
         highlights = emptyMap() // clear highlights for the duration of the slide
+        pulseSquare = null
+        val ch = channels
+        val id = board.idAt(move.from)
         pendingBoard = board.apply(move)
-        val node = boardRoot?.let { pieceNodeAt(it, move.from) }
-        if (node == null) {
-            finalizeMove() // nothing to animate; just snap
+        if (ch == null || !ch.hasTransform(id)) {
+            finalizeMove() // nothing composed to animate
             return
         }
-        animNode = node
+        // The channel is looked up once, here, by the piece's stable identity - never by
+        // re-querying the scene graph - and written every frame until the slide lands.
+        animHandle = ch.transformHandle(id)
         animFrom.set(worldPositionOf(move.from))
         animTo.set(worldPositionOf(move.to))
         animElapsed = 0.0
@@ -203,11 +239,13 @@ class CheckersGame : GameMode {
     private fun advanceAnimation(timePerFrame: Double) {
         animElapsed += timePerFrame
         val t = (animElapsed / ANIM_DURATION).coerceIn(0.0, 1.0)
-        animNode?.setTranslation(
+        channels?.writeTranslation(
+            animHandle,
             animFrom.x + (animTo.x - animFrom.x) * t,
             animFrom.y + (animTo.y - animFrom.y) * t,
             animFrom.z + (animTo.z - animFrom.z) * t
         )
+        // The t=1 write above is the endpoint itself; the board flip below only restructures.
         if (t >= 1.0) finalizeMove()
     }
 
@@ -215,9 +253,32 @@ class CheckersGame : GameMode {
         board = pendingBoard ?: board // recomposition restructures the pieces from this write
         pendingBoard = null
         animating = false
-        animNode = null
         highlights = emptyMap()
         context?.setStatus(statusText())
+    }
+
+    // --- the glow pulse ----------------------------------------------------------------------
+
+    /**
+     * Drives the breathing glow on the destination marker under the pointer. Handle lookup and
+     * the leave-at-rest write happen only when the pulsing square changes; steady pulsing is one
+     * [SceneChannels.writeParam] per frame. Runs after the composition frame, so a marker bound
+     * (or disposed) by this frame's recomposition is already reflected in the registry.
+     */
+    private fun refreshPulse(ch: SceneChannels) {
+        if (pulseSquare != boundPulse) {
+            val old = boundPulse
+            if (old != null && pulseLive && ch.hasParam(old) && ch.paramHandle(old) == pulseHandle) {
+                ch.writeParam(pulseHandle, GLOW_REST) // the marker we leave returns to rest
+            }
+            boundPulse = pulseSquare
+            val square = pulseSquare
+            pulseLive = square != null && ch.hasParam(square)
+            if (pulseLive) pulseHandle = ch.paramHandle(square!!)
+        }
+        if (pulseLive) {
+            ch.writeParam(pulseHandle, (1.0 - PULSE_DEPTH * (0.5 - 0.5 * Math.cos(pulseTime * PULSE_RADIANS))).toFloat())
+        }
     }
 
     // --- test seams (same package/module only) -----------------------------------------------
@@ -251,6 +312,12 @@ class CheckersGame : GameMode {
         if (!animating) highlights = computeHighlights(square)
     }
 
+    /** Pins the hover for update()-driven tests, whose fake pick would otherwise see nothing. */
+    internal var forcedHoverForTest: Square? = null
+
+    /** The channel rig - for the gate tests. */
+    internal val channelsForTest: SceneChannels? get() = channels
+
     // --- helpers -----------------------------------------------------------------------------
 
     private fun squareAt(context: GameContext, x: Int, y: Int): Square? {
@@ -272,5 +339,9 @@ class CheckersGame : GameMode {
 
     companion object {
         private const val ANIM_DURATION = 0.22
+
+        // The glow pulse: a raised-cosine dip, GLOW_REST at the top, ~1.2 s period.
+        private const val PULSE_DEPTH = 0.35
+        private const val PULSE_RADIANS = 2.0 * Math.PI / 1.2
     }
 }

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
@@ -87,7 +87,7 @@ class CheckersGame(
 
     override fun onStart(context: GameContext) {
         this.context = context
-        board = Board.initial()
+        board = initialBoardForTest ?: Board.initial()
         highlights = emptyMap()
         selected = null
         animating = false
@@ -318,6 +318,9 @@ class CheckersGame(
 
     /** Pins the hover for update()-driven tests, whose fake pick would otherwise see nothing. */
     internal var forcedHoverForTest: Square? = null
+
+    /** Overrides the opening position for the next [onStart] - for the gate tests. */
+    internal var initialBoardForTest: Board? = null
 
     /** The channel rig - for the gate tests. */
     internal val channelsForTest: SceneChannels? get() = channels

--- a/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
+++ b/ardor3d-editor/src/main/kotlin/com/ardor3d/editor/checkers/CheckersGame.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.ardor3d.compose.SceneChannels
 import com.ardor3d.compose.SceneComposition
+import com.ardor3d.compose.SpatialApplier
 import com.ardor3d.editor.play.GameContext
 import com.ardor3d.editor.play.GameInput
 import com.ardor3d.editor.play.GameMode
@@ -45,7 +46,10 @@ import com.ardor3d.scenegraph.extension.CameraNode
  * (a capture, a crowning) and motion land in a known order every frame, and a slide runs with
  * zero recomposition and zero applier traffic by construction, not by convention.
  */
-class CheckersGame : GameMode {
+class CheckersGame(
+    /** How the composed scene gets its applier - tests inject a counting one to gate silence. */
+    private val applierFactory: (Node) -> SpatialApplier = { SpatialApplier(it) }
+) : GameMode {
     private var context: GameContext? = null
 
     // Snapshot state - everything the composed view reads. Writing these is the entire view sync.
@@ -101,7 +105,7 @@ class CheckersGame : GameMode {
         // its slot until the old one is forgotten, so peak occupancy briefly exceeds live count).
         val sceneChannels = SceneChannels(transformCapacity = 32, paramCapacity = 48)
         channels = sceneChannels
-        composition = SceneComposition(root).apply {
+        composition = SceneComposition(applierFactory(root)).apply {
             setContent {
                 BoardScene(
                     channels = sceneChannels,
@@ -317,6 +321,9 @@ class CheckersGame : GameMode {
 
     /** The channel rig - for the gate tests. */
     internal val channelsForTest: SceneChannels? get() = channels
+
+    /** The composed host - the silence gates read its frame-clock instruments. */
+    internal val compositionForTest: SceneComposition? get() = composition
 
     // --- helpers -----------------------------------------------------------------------------
 

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/AllocationAccounting.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/AllocationAccounting.kt
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import org.junit.Assert.assertTrue
+import java.lang.management.ManagementFactory
+
+/**
+ * The allocation gates are only meaningful if thread-allocation accounting is actually on:
+ * when it is unsupported or disabled, getThreadAllocatedBytes returns -1 for every call and
+ * a before/after delta is 0 - the gate would pass vacuously. Enable it when the JVM merely
+ * left it off; fail loudly only when the platform cannot support it at all.
+ */
+internal fun allocationAccounting(): com.sun.management.ThreadMXBean {
+    val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
+    assertTrue(
+        "thread allocation accounting must be supported for the allocation gates",
+        threads.isThreadAllocatedMemorySupported
+    )
+    if (!threads.isThreadAllocatedMemoryEnabled) {
+        threads.isThreadAllocatedMemoryEnabled = true
+    }
+    return threads
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ChannelBindingTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ChannelBindingTest.kt
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.ardor3d.scenegraph.Node
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The binding lifecycle against a real composition: a channel exists exactly as long as its
+ * binding is in the composition - entering binds, leaving releases, disposal releases, a
+ * failed composition releases through onAbandoned, and a keyed replacement hands over with no
+ * aliasing: the new binding allocates before the old releases, and the straggler handle dies
+ * loudly. This is the mechanism the scene ownership policy rests on, tested on its own before
+ * any board is composed over it.
+ */
+class ChannelBindingTest {
+
+    /** A minimal composed host: content under a root node, driven frame by frame. */
+    private class Harness : AutoCloseable {
+        val root = Node("root")
+        val channels = SceneChannels(transformCapacity = 4, paramCapacity = 4)
+        val scene = SceneComposition(root)
+        private var t = 0L
+        fun frame() = scene.frame(++t)
+        override fun close() = scene.close()
+    }
+
+    @Test
+    fun enteringTheCompositionBindsAndLeavingReleases() {
+        Harness().use { h ->
+            var show by mutableStateOf(true)
+            var bound: TransformChannel? = null
+            h.scene.setContent {
+                if (show) {
+                    val node = remember { Node("piece") }
+                    bound = rememberTransformChannel(h.channels, "piece", node)
+                    SceneSpatial(factory = { node })
+                }
+            }
+            assertEquals(1, h.channels.liveTransformCount)
+            assertEquals(bound!!.handle, h.channels.transformHandle("piece"))
+
+            show = false
+            h.frame()
+
+            assertEquals("leaving the composition releases the slot", 0, h.channels.liveTransformCount)
+            assertTrue(!h.channels.hasTransform("piece"))
+            assertThrows("the straggler handle is loud", IllegalStateException::class.java) {
+                bound!!.writeTranslation(1.0, 1.0, 1.0)
+            }
+        }
+    }
+
+    @Test
+    fun writesThroughTheBindingReachTheNodeAtSample() {
+        Harness().use { h ->
+            var channel: TransformChannel? = null
+            var node: Node? = null
+            h.scene.setContent {
+                val n = remember { Node("piece") }
+                node = n
+                channel = rememberTransformChannel(h.channels, null, n)
+                SceneSpatial(factory = { n })
+            }
+            h.channels.sample() // settle the seed
+
+            channel!!.writeTranslation(2.0, 0.5, -1.0)
+            h.channels.sample()
+
+            assertEquals(2.0, node!!.translation.x, 1e-6)
+            assertEquals(-1.0, node!!.translation.z, 1e-6)
+        }
+    }
+
+    @Test
+    fun keyedReplacementHandsOverWithoutAliasing() {
+        Harness().use { h ->
+            var which by mutableStateOf(1)
+            var current: TransformChannel? = null
+            h.scene.setContent {
+                key(which) {
+                    val node = remember { Node("piece_$which") }
+                    current = rememberTransformChannel(h.channels, "piece", node)
+                    SceneSpatial(factory = { node })
+                }
+            }
+            val old = current!!
+            val oldHandle = old.handle
+
+            which = 2
+            h.frame()
+            val replacement = current!!
+
+            assertNotSameBinding(old, replacement)
+            assertEquals("exactly one binding lives on", 1, h.channels.liveTransformCount)
+            assertEquals(
+                "the registry points at the replacement",
+                replacement.handle, h.channels.transformHandle("piece")
+            )
+            assertNotEquals("no handle aliasing across the replacement", oldHandle, replacement.handle)
+            assertThrows("the replaced binding's writer is dead", IllegalStateException::class.java) {
+                old.writeTranslation(9.0, 9.0, 9.0)
+            }
+            // And the survivor still works.
+            replacement.writeTranslation(1.0, 2.0, 3.0)
+            h.channels.sample()
+        }
+    }
+
+    private fun assertNotSameBinding(a: TransformChannel, b: TransformChannel) {
+        assertTrue("replacement must be a new binding", a !== b)
+    }
+
+    @Test
+    fun replacementOverlapNeedsCapacityHeadroom() {
+        // Pins the allocation ordering the no-aliasing claim rests on: the replacement binds
+        // BEFORE the old binding is forgotten, so a block sized exactly to the live count
+        // cannot host a keyed replacement - it exhausts, loudly. If this ever starts fitting
+        // in capacity 1, the runtime's replacement order changed: re-verify the aliasing
+        // analysis before loosening anything.
+        val channels = SceneChannels(transformCapacity = 1, paramCapacity = 1)
+        SceneComposition(Node("root")).use { scene ->
+            var which by mutableStateOf(1)
+            scene.setContent {
+                key(which) {
+                    val node = remember { Node("piece_$which") }
+                    rememberTransformChannel(channels, "piece", node)
+                    SceneSpatial(factory = { node })
+                }
+            }
+            assertEquals(1, channels.liveTransformCount)
+
+            which = 2
+            var t = 0L
+            val e = assertThrows(IllegalStateException::class.java) { scene.frame(++t) }
+            assertTrue(
+                "the failure names the exhaustion, not a downstream symptom",
+                generateSequence<Throwable>(e) { it.cause }.any { it.message?.contains("exhausted") == true }
+            )
+        }
+    }
+
+    @Test
+    fun aFailedCompositionReleasesItsBindingThroughOnAbandoned() {
+        Harness().use { h ->
+            assertThrows(RuntimeException::class.java) {
+                h.scene.setContent {
+                    val node = remember { Node("piece") }
+                    rememberTransformChannel(h.channels, "piece", node)
+                    error("composition fails after the binding was made")
+                }
+            }
+
+            assertEquals("onAbandoned released the slot", 0, h.channels.liveTransformCount)
+            assertTrue("and the registry entry", !h.channels.hasTransform("piece"))
+        }
+    }
+
+    @Test
+    fun disposalReleasesEveryBinding() {
+        val h = Harness()
+        var transform: TransformChannel? = null
+        var param: ParamChannel? = null
+        h.scene.setContent {
+            val a = remember { Node("a") }
+            val b = remember { Node("b") }
+            transform = rememberTransformChannel(h.channels, "a", a)
+            rememberTransformChannel(h.channels, "b", b)
+            param = rememberParamChannel(h.channels, "glow", 1f, { })
+            SceneNode("group") {
+                SceneSpatial(factory = { a })
+                SceneSpatial(factory = { b })
+            }
+        }
+        assertEquals(2, h.channels.liveTransformCount)
+        assertEquals(1, h.channels.liveParamCount)
+
+        h.close()
+
+        assertEquals("disposal releases every transform", 0, h.channels.liveTransformCount)
+        assertEquals("and every param", 0, h.channels.liveParamCount)
+        assertThrows(IllegalStateException::class.java) { transform!!.writeTranslation(1.0, 1.0, 1.0) }
+        assertThrows(IllegalStateException::class.java) { param!!.write(0.5f) }
+    }
+
+    @Test
+    fun paramBindingDeliversSeedAndWritesThroughItsTarget() {
+        Harness().use { h ->
+            var received = -1f
+            var channel: ParamChannel? = null
+            h.scene.setContent {
+                channel = rememberParamChannel(h.channels, "glow", 0.5f, { received = it })
+            }
+            h.channels.sample()
+            assertEquals("the seed arrives with the first sample", 0.5f, received, 0f)
+
+            channel!!.write(0.75f)
+            h.channels.sample()
+            assertEquals(0.75f, received, 0f)
+        }
+    }
+
+    @Test
+    fun bindingsSurviveRecompositionOfTheirOwnPosition() {
+        Harness().use { h ->
+            var label by mutableStateOf("first")
+            var channel: TransformChannel? = null
+            var node: Node? = null
+            h.scene.setContent {
+                val n = remember { Node("piece") }
+                node = n
+                channel = rememberTransformChannel(h.channels, "piece", n)
+                SceneSpatial(factory = { n }, update = { set(label) { setProperty("label", it) } })
+            }
+            val before = channel!!
+
+            label = "second"
+            h.frame()
+
+            assertSame("recomposition must not re-bind", before, channel)
+            assertEquals(1, h.channels.liveTransformCount)
+            assertNotNull(node!!.getProperty("label", null as String?))
+            // The channel value is untouched by the recomposition: the writer still owns it.
+            before.writeTranslation(5.0, 0.0, 0.0)
+            h.channels.sample()
+            assertEquals(5.0, node!!.translation.x, 1e-6)
+        }
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ChannelBindingTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ChannelBindingTest.kt
@@ -178,28 +178,32 @@ class ChannelBindingTest {
     @Test
     fun disposalReleasesEveryBinding() {
         val h = Harness()
-        var transform: TransformChannel? = null
-        var param: ParamChannel? = null
-        h.scene.setContent {
-            val a = remember { Node("a") }
-            val b = remember { Node("b") }
-            transform = rememberTransformChannel(h.channels, "a", a)
-            rememberTransformChannel(h.channels, "b", b)
-            param = rememberParamChannel(h.channels, "glow", 1f, { })
-            SceneNode("group") {
-                SceneSpatial(factory = { a })
-                SceneSpatial(factory = { b })
+        try {
+            var transform: TransformChannel? = null
+            var param: ParamChannel? = null
+            h.scene.setContent {
+                val a = remember { Node("a") }
+                val b = remember { Node("b") }
+                transform = rememberTransformChannel(h.channels, "a", a)
+                rememberTransformChannel(h.channels, "b", b)
+                param = rememberParamChannel(h.channels, "glow", 1f, { })
+                SceneNode("group") {
+                    SceneSpatial(factory = { a })
+                    SceneSpatial(factory = { b })
+                }
             }
+            assertEquals(2, h.channels.liveTransformCount)
+            assertEquals(1, h.channels.liveParamCount)
+
+            h.close() // the act under test; the finally re-close is an idempotent no-op
+
+            assertEquals("disposal releases every transform", 0, h.channels.liveTransformCount)
+            assertEquals("and every param", 0, h.channels.liveParamCount)
+            assertThrows(IllegalStateException::class.java) { transform!!.writeTranslation(1.0, 1.0, 1.0) }
+            assertThrows(IllegalStateException::class.java) { param!!.write(0.5f) }
+        } finally {
+            h.close()
         }
-        assertEquals(2, h.channels.liveTransformCount)
-        assertEquals(1, h.channels.liveParamCount)
-
-        h.close()
-
-        assertEquals("disposal releases every transform", 0, h.channels.liveTransformCount)
-        assertEquals("and every param", 0, h.channels.liveParamCount)
-        assertThrows(IllegalStateException::class.java) { transform!!.writeTranslation(1.0, 1.0, 1.0) }
-        assertThrows(IllegalStateException::class.java) { param!!.write(0.5f) }
     }
 
     @Test

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ChannelBlockTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/ChannelBlockTest.kt
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The channel store on its own: slots round-trip values per channel independently, the dirty
+ * drain visits exactly what was written and clears itself, and - the load-bearing part - every
+ * touch of a freed handle fails loudly, including after its slot index has been recycled to a
+ * new tenant. An animation holding a handle to a disposed node must get an exception with a
+ * name, never a silent write into someone else's slot.
+ */
+class ChannelBlockTest {
+
+    @Test
+    fun slotsRoundTripValuesPerChannelIndependently() {
+        val block = ChannelBlock(channels = 3, capacity = 4)
+        val a = block.allocate()
+        val b = block.allocate()
+
+        block.set(0, a, 1f)
+        block.set(2, a, 3f)
+        block.set(0, b, 10f)
+
+        assertEquals(1f, block.get(0, a), 0f)
+        assertEquals(0f, block.get(1, a), 0f)
+        assertEquals(3f, block.get(2, a), 0f)
+        assertEquals(10f, block.get(0, b), 0f)
+        // First tenancy only: a fresh buffer is born zeroed. A recycled slot is NOT - see
+        // recycledSlotRetainsThePreviousTenantsValuesUntilOverwritten.
+        assertEquals("b's other channels untouched (fresh buffer)", 0f, block.get(2, b), 0f)
+        assertEquals(2, block.liveCount)
+    }
+
+    @Test
+    fun staleHandleThrowsOnWriteReadAndReFree() {
+        val block = ChannelBlock(channels = 1, capacity = 2)
+        val handle = block.allocate()
+        block.set(0, handle, 5f)
+        block.free(handle)
+
+        assertThrows(IllegalStateException::class.java) { block.set(0, handle, 6f) }
+        assertThrows(IllegalStateException::class.java) { block.get(0, handle) }
+        assertThrows(IllegalStateException::class.java) { block.touch(handle) }
+        assertThrows("a double free is a stale handle too", IllegalStateException::class.java) {
+            block.free(handle)
+        }
+        assertEquals(0, block.liveCount)
+    }
+
+    @Test
+    fun recycledIndexGetsAFreshGenerationAndTheOldHandleStaysDead() {
+        val block = ChannelBlock(channels = 1, capacity = 1)
+        val old = block.allocate()
+        block.free(old)
+
+        val recycled = block.allocate()
+        assertEquals("one slot: the index must be reused", block.indexOf(recycled), old.toInt())
+        assertNotEquals("but under a new handle", old, recycled)
+
+        block.set(0, recycled, 42f)
+        assertThrows("the old tenant's handle must not reach the new tenant's value",
+            IllegalStateException::class.java) { block.get(0, old) }
+        assertEquals(42f, block.get(0, recycled), 0f)
+    }
+
+    @Test
+    fun recycledSlotRetainsThePreviousTenantsValuesUntilOverwritten() {
+        // Pins the binding writer rule's sharp edge: allocate() hands back the slot's floats
+        // exactly as the previous tenant left them - no clear, by design (zeroing would not
+        // make a partial bind safe: an all-zero rotation is degenerate, not neutral; the rule
+        // is that a binder writes every channel before the first drain). If a fill is ever
+        // added, this test goes stale on purpose - re-decide the writer rule before deleting it.
+        val block = ChannelBlock(channels = 2, capacity = 1)
+        val old = block.allocate()
+        block.set(0, old, 7f)
+        block.set(1, old, 9f)
+        block.free(old)
+
+        val recycled = block.allocate()
+        assertEquals("same slot index", 0, block.indexOf(recycled))
+        block.set(0, recycled, 1f) // the new tenant writes only channel 0...
+        assertEquals(1f, block.get(0, recycled), 0f)
+        assertEquals(
+            "...and an unwritten channel shows the dead tenant's value",
+            9f, block.get(1, recycled), 0f
+        )
+    }
+
+    @Test
+    fun exhaustionFailsLoudly() {
+        val block = ChannelBlock(channels = 1, capacity = 2)
+        block.allocate()
+        block.allocate()
+        val e = assertThrows(IllegalStateException::class.java) { block.allocate() }
+        assertTrue(e.message!!.contains("exhausted"))
+    }
+
+    @Test
+    fun dirtyDrainVisitsWritesOnceAscendingAndClears() {
+        val block = ChannelBlock(channels = 2, capacity = 70) // spans two bitset words
+        val handles = LongArray(70) { block.allocate() }
+
+        block.set(0, handles[65], 1f) // written out of order,
+        block.set(1, handles[3], 2f)
+        block.set(0, handles[3], 3f) // twice on one slot,
+        block.touch(handles[40]) // and one touch with no value write
+
+        val visited = mutableListOf<Int>()
+        block.forEachDirtyClearing { visited.add(it) }
+        assertEquals("each dirty slot once, in ascending order", listOf(3, 40, 65), visited)
+
+        visited.clear()
+        block.forEachDirtyClearing { visited.add(it) }
+        assertTrue("the drain cleared the set", visited.isEmpty())
+    }
+
+    @Test
+    fun freeingASlotRemovesItFromTheDirtySet() {
+        val block = ChannelBlock(channels = 1, capacity = 4)
+        val doomed = block.allocate()
+        val kept = block.allocate()
+        block.set(0, doomed, 1f)
+        block.set(0, kept, 2f)
+        block.free(doomed)
+
+        val visited = mutableListOf<Int>()
+        block.forEachDirtyClearing { visited.add(it) }
+        assertEquals("a freed slot must never reach the sampler", listOf(block.indexOf(kept)), visited)
+    }
+
+    @Test
+    fun forgedAndOutOfRangeHandlesAreRejected() {
+        val block = ChannelBlock(channels = 1, capacity = 2)
+        block.allocate()
+        assertThrows(IllegalArgumentException::class.java) { block.get(0, 5L) } // index out of range
+        assertThrows(IllegalArgumentException::class.java) { block.get(0, -1L) }
+        val e = assertThrows(IllegalStateException::class.java) {
+            block.get(0, (7L shl 32) or 0L) // right index, wrong generation
+        }
+        assertTrue(e.message!!.contains("stale"))
+    }
+
+    @Test
+    fun channelBoundsAreChecked() {
+        val block = ChannelBlock(channels = 2, capacity = 1)
+        val handle = block.allocate()
+        assertThrows(IllegalArgumentException::class.java) { block.set(2, handle, 1f) }
+        assertThrows(IllegalArgumentException::class.java) { block.get(-1, handle) }
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/CompositionScaleGateTest.kt
@@ -14,7 +14,6 @@ import com.ardor3d.scenegraph.Node
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.lang.management.ManagementFactory
 
 /**
  * Scale gates for the composed scene layer: the checkers board proved the paradigm at ~90 nodes,
@@ -51,24 +50,6 @@ class CompositionScaleGateTest {
         }
 
         override fun close() = scene.close()
-    }
-
-    /**
-     * The allocation gates are only meaningful if thread-allocation accounting is actually on:
-     * when it is unsupported or disabled, getThreadAllocatedBytes returns -1 for every call and
-     * a before/after delta is 0 - the gate would pass vacuously. Enable it when the JVM merely
-     * left it off; fail loudly only when the platform cannot support it at all.
-     */
-    private fun allocationAccounting(): com.sun.management.ThreadMXBean {
-        val threads = ManagementFactory.getThreadMXBean() as com.sun.management.ThreadMXBean
-        assertTrue(
-            "thread allocation accounting must be supported for the allocation gates",
-            threads.isThreadAllocatedMemorySupported
-        )
-        if (!threads.isThreadAllocatedMemoryEnabled) {
-            threads.isThreadAllocatedMemoryEnabled = true
-        }
-        return threads
     }
 
     private fun assertConfined(name: String, model: ScaleModel, pokeId: Int, compose: Harness.() -> Unit) {

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/SceneChannelsTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/compose/SceneChannelsTest.kt
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.compose
+
+import com.ardor3d.math.Quaternion
+import com.ardor3d.math.Vector3
+import com.ardor3d.scenegraph.Node
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The rig around the channel store: binding seeds the slot from where the target already
+ * stands (the binding writer rule, so a recycled slot never leaks its dead tenant into a new
+ * node), the sampler applies exactly what was written and nothing else, release makes every
+ * later touch loud, the key registry survives same-key replacement, and the whole
+ * write-then-sample frame path allocates nothing - measured, not assumed.
+ */
+class SceneChannelsTest {
+
+    private fun quarterTurnX() = Quaternion().fromAngleAxis(Math.PI / 2, Vector3.UNIT_X)
+
+    @Test
+    fun bindingSeedsTheSlotFromTheTargetsCurrentTransform() {
+        val channels = SceneChannels()
+        val node = Node("n")
+        node.setTranslation(1.0, 2.0, 3.0)
+        node.setRotation(quarterTurnX())
+
+        val handle = channels.bindTransform("n", node)
+
+        // Perturb the node behind the rig's back; the seeded values must win the next sample.
+        node.setTranslation(9.0, 9.0, 9.0)
+        node.setRotation(Quaternion.IDENTITY)
+        channels.sample()
+
+        assertEquals(1.0, node.translation.x, 1e-6)
+        assertEquals(2.0, node.translation.y, 1e-6)
+        assertEquals(3.0, node.translation.z, 1e-6)
+        // A quarter turn about X carries +Y to +Z.
+        val turned = node.rotation.applyPost(Vector3.UNIT_Y, Vector3())
+        assertEquals(0.0, turned.x, 1e-6)
+        assertEquals(0.0, turned.y, 1e-6)
+        assertEquals(1.0, turned.z, 1e-6)
+        assertEquals(1, channels.liveTransformCount)
+        assertEquals(handle, channels.transformHandle("n"))
+    }
+
+    @Test
+    fun writesLandOnTheTargetAtSampleAndUnwrittenChannelsKeepTheirSeed() {
+        val channels = SceneChannels()
+        val node = Node("n")
+        node.setRotation(quarterTurnX())
+        val handle = channels.bindTransform(null, node)
+        channels.sample() // settle the seed
+
+        channels.writeTranslation(handle, 4.0, 5.0, 6.0)
+        assertEquals("nothing moves before sample", 0.0, node.translation.x, 0.0)
+        channels.sample()
+
+        assertEquals(4.0, node.translation.x, 1e-6)
+        assertEquals(5.0, node.translation.y, 1e-6)
+        assertEquals(6.0, node.translation.z, 1e-6)
+        val turned = node.rotation.applyPost(Vector3.UNIT_Y, Vector3())
+        assertEquals("rotation channels keep their seeded value", 1.0, turned.z, 1e-6)
+    }
+
+    @Test
+    fun sampleAppliesOnlyWhatWasWritten() {
+        val channels = SceneChannels()
+        val moved = Node("moved")
+        val still = Node("still")
+        val handle = channels.bindTransform(null, moved)
+        channels.bindTransform(null, still)
+        channels.sample() // settle both seeds
+
+        // Perturb the unwritten node directly: if the sampler blindly re-applied every live
+        // slot, it would stomp this back to the seed.
+        still.setTranslation(7.0, 7.0, 7.0)
+        channels.writeTranslation(handle, 1.0, 0.0, 0.0)
+        channels.sample()
+
+        assertEquals(1.0, moved.translation.x, 1e-6)
+        assertEquals("an unwritten slot must not be touched", 7.0, still.translation.x, 0.0)
+    }
+
+    @Test
+    fun releaseMakesLaterWritesLoudAndUnbindsTheTarget() {
+        val channels = SceneChannels()
+        val node = Node("n")
+        val handle = channels.bindTransform("k", node)
+        channels.sample()
+
+        channels.releaseTransform("k", handle)
+
+        assertThrows(IllegalStateException::class.java) { channels.writeTranslation(handle, 1.0, 1.0, 1.0) }
+        assertThrows(IllegalStateException::class.java) { channels.transformHandle("k") }
+        assertEquals(0, channels.liveTransformCount)
+        node.setTranslation(5.0, 5.0, 5.0)
+        channels.sample() // nothing dirty, nothing applied
+        assertEquals(5.0, node.translation.x, 0.0)
+    }
+
+    @Test
+    fun aRecycledSlotServesItsNewTenantOnly() {
+        val channels = SceneChannels(transformCapacity = 1, paramCapacity = 1)
+        val first = Node("first")
+        first.setTranslation(1.0, 1.0, 1.0)
+        val old = channels.bindTransform(null, first)
+        channels.sample()
+        channels.releaseTransform(null, old)
+
+        val second = Node("second")
+        second.setTranslation(2.0, 2.0, 2.0)
+        val recycled = channels.bindTransform(null, second)
+        assertNotEquals("same slot, new generation", old, recycled)
+        channels.sample()
+
+        assertEquals("the seed is the new tenant's, not the corpse's", 2.0, second.translation.x, 1e-6)
+        assertEquals("the old tenant is not the new slot's target", 1.0, first.translation.x, 1e-6)
+        assertThrows(IllegalStateException::class.java) { channels.writeTranslation(old, 9.0, 9.0, 9.0) }
+    }
+
+    @Test
+    fun sameKeyReplacementRegistersBeforeTheOldBindingReleases() {
+        // The composition runtime's replacement order: the new binding is created (and
+        // registers) before the old one is forgotten. The old release must not evict the
+        // replacement's registry entry.
+        val channels = SceneChannels()
+        val oldNode = Node("old")
+        val newNode = Node("new")
+        val oldHandle = channels.bindTransform("piece", oldNode)
+        val newHandle = channels.bindTransform("piece", newNode)
+
+        channels.releaseTransform("piece", oldHandle)
+
+        assertEquals("the replacement's entry survives", newHandle, channels.transformHandle("piece"))
+        assertTrue(channels.hasTransform("piece"))
+        assertEquals(1, channels.liveTransformCount)
+    }
+
+    @Test
+    fun paramsDeliverSeedWritesAndTouchThroughTheirTarget() {
+        val channels = SceneChannels()
+        var received = -1f
+        var deliveries = 0
+        val handle = channels.bindParam("glow", 1f, { value -> received = value; deliveries++ })
+
+        channels.sample()
+        assertEquals("the seed is delivered by the first sample", 1f, received, 0f)
+        assertEquals(1, deliveries)
+
+        channels.sample()
+        assertEquals("an idle sample delivers nothing", 1, deliveries)
+
+        channels.writeParam(handle, 0.25f)
+        channels.sample()
+        assertEquals(0.25f, received, 0f)
+        assertEquals(2, deliveries)
+
+        // touch: same value, re-delivered - for when a combined outside input changed.
+        channels.touchParam(handle)
+        channels.sample()
+        assertEquals(0.25f, received, 0f)
+        assertEquals(3, deliveries)
+
+        channels.releaseParam("glow", handle)
+        assertThrows(IllegalStateException::class.java) { channels.writeParam(handle, 1f) }
+        assertThrows(IllegalStateException::class.java) { channels.paramHandle("glow") }
+    }
+
+    @Test
+    fun theWriteSampleFramePathAllocatesNothing() {
+        val channels = SceneChannels()
+        val parent = Node("parent") // a parent, so dirty propagation walks up as it will live
+        val node = Node("n")
+        parent.attachChild(node)
+        val transform = channels.bindTransform(null, node)
+        var sink = 0f
+        val param = channels.bindParam(null, 1f, { sink = it })
+
+        val threads = allocationAccounting()
+        val self = Thread.currentThread().id
+
+        var x = 0.0
+        repeat(10_000) { // warm until JIT is done allocating
+            channels.writeTranslation(transform, x, 0.5, -x)
+            channels.writeParam(param, (x % 1.0).toFloat())
+            channels.sample()
+            x += 0.01
+        }
+
+        val before = threads.getThreadAllocatedBytes(self)
+        repeat(5_000) {
+            channels.writeTranslation(transform, x, 0.5, -x)
+            channels.writeParam(param, (x % 1.0).toFloat())
+            channels.sample()
+            x += 0.01
+        }
+        val allocated = threads.getThreadAllocatedBytes(self) - before
+
+        assertEquals("write + sample must be allocation-free per frame", 0L, allocated)
+        assertTrue(sink >= 0f) // keep the param sink observably live
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/BoardSceneTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/BoardSceneTest.kt
@@ -13,6 +13,7 @@ package com.ardor3d.editor.checkers
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.ardor3d.compose.SceneChannels
 import com.ardor3d.compose.SceneComposition
 import com.ardor3d.compose.SpatialApplier
 import com.ardor3d.math.ColorRGBA
@@ -29,8 +30,9 @@ import org.junit.Test
  * The composed scene view of the board, tested headlessly - composing is pure scene-graph work (no
  * GL, no materials): the opening lays out 24 pieces on the right squares, a capture restructures on
  * the next frame, crowning adds the crown to the *same* piece node, a plain move is zero structural
- * traffic (the node survives; only its translation snaps), highlight markers recolor in place, and
- * pickable tiles map back to their squares.
+ * traffic (the node and its channel binding survive; the translation belongs to the channel's
+ * writer), highlight markers recolor in place through the sampler, and pickable tiles map back to
+ * their squares.
  */
 class BoardSceneTest {
 
@@ -69,10 +71,11 @@ class BoardSceneTest {
         }
     }
 
-    /** A composed board over mutable snapshot state, driven frame by frame. */
+    /** A composed board over mutable snapshot state, driven frame by frame like the game loop. */
     private class Harness(initial: Board = Board.initial()) : AutoCloseable {
         val root = Node("Checkers")
         val applier = CountingApplier(root)
+        val channels = SceneChannels(transformCapacity = 32, paramCapacity = 48)
         var board by mutableStateOf(initial)
         var highlights by mutableStateOf<Map<Square, HighlightKind>>(emptyMap())
 
@@ -84,11 +87,15 @@ class BoardSceneTest {
 
         init {
             composition.setContent {
-                BoardScene(board = { board }, highlights = { highlights }, onSync = { syncs++ })
+                BoardScene(channels, board = { board }, highlights = { highlights }, onSync = { syncs++ })
             }
         }
 
-        fun frame() = composition.frame(++frames)
+        /** One update-loop step: the composition frame, then the sampler - the game's order. */
+        fun frame() {
+            composition.frame(++frames)
+            channels.sample()
+        }
 
         override fun close() = composition.close()
     }
@@ -131,10 +138,11 @@ class BoardSceneTest {
     }
 
     @Test
-    fun plainMoveIsZeroStructuralTrafficAndKeepsTheNode() {
+    fun plainMoveIsZeroStructuralTrafficAndLeavesTheTranslationToItsChannel() {
         val board = Board.of(PieceColor.RED, mapOf(sq(2, 2) to Piece(PieceColor.RED), sq(7, 7) to Piece(PieceColor.BLACK)))
         Harness(board).use { h ->
             val node = pieceNodeAt(h.root, sq(2, 2))!!
+            val spawn = worldPositionOf(sq(2, 2))
 
             h.applier.reset()
             h.board = h.board.apply(h.board.legalMovesFrom(sq(2, 2)).first { it.to == sq(3, 3) })
@@ -142,9 +150,20 @@ class BoardSceneTest {
 
             assertEquals("a plain move must not restructure the scene", 0, h.applier.structural)
             assertSame("the piece keeps its node", node, pieceNodeAt(h.root, sq(3, 3)))
-            val dest = worldPositionOf(sq(3, 3))
-            assertEquals(dest.x, node.translation.x, 1e-9)
-            assertEquals(dest.z, node.translation.z, 1e-9)
+            // The translation is channel-owned: recomposition updates the pick metadata but must
+            // not move the node - that is the writer's job (the game's slide does it; this
+            // harness has no writer, so the node stands exactly where it spawned).
+            assertEquals(spawn.x, node.translation.x, 1e-9)
+            assertEquals(spawn.z, node.translation.z, 1e-9)
+
+            // And the writer moves it through the channel, not the scene graph.
+            h.channels.writeTranslation(
+                h.channels.transformHandle(h.board.idAt(sq(3, 3))),
+                worldPositionOf(sq(3, 3)).x, spawn.y, worldPositionOf(sq(3, 3)).z
+            )
+            h.frame()
+            assertEquals(worldPositionOf(sq(3, 3)).x, node.translation.x, 1e-6)
+            assertEquals(worldPositionOf(sq(3, 3)).z, node.translation.z, 1e-6)
         }
     }
 

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersInteractionTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/CheckersInteractionTest.kt
@@ -10,12 +10,7 @@
 
 package com.ardor3d.editor.checkers
 
-import com.ardor3d.editor.play.GameContext
 import com.ardor3d.editor.play.GameInput
-import com.ardor3d.intersection.PrimitivePickResults
-import com.ardor3d.renderer.Camera
-import com.ardor3d.scenegraph.Node
-import com.ardor3d.scenegraph.Spatial
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -31,15 +26,6 @@ import org.junit.Test
  * it distinctly; clicking a destination moves and switches turns; clicking elsewhere clears.
  */
 class CheckersInteractionTest {
-
-    private class FakeGameContext : GameContext {
-        override val sceneRoot: Node = Node("scene")
-        override val camera: Camera = Camera(1, 1)
-        var lastStatus: String? = null
-        override fun pick(x: Int, y: Int): PrimitivePickResults = PrimitivePickResults()
-        override fun setStatus(text: String?) { lastStatus = text }
-        override fun materialize(spatial: Spatial) { /* no material system in this test */ }
-    }
 
     private fun sq(row: Int, col: Int) = Square(row, col)
 

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/FakeGameContext.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/FakeGameContext.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.editor.play.GameContext
+import com.ardor3d.intersection.PrimitivePickResults
+import com.ardor3d.renderer.Camera
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.Spatial
+
+/**
+ * A headless [GameContext] for driving [CheckersGame] in tests: picking sees nothing (tests
+ * steer by square through the game's test seams), materialization is a no-op, and the last
+ * status line is captured for assertion.
+ */
+internal class FakeGameContext : GameContext {
+    override val sceneRoot: Node = Node("scene")
+    override val camera: Camera = Camera(1, 1)
+    var lastStatus: String? = null
+    override fun pick(x: Int, y: Int): PrimitivePickResults = PrimitivePickResults()
+    override fun setStatus(text: String?) {
+        lastStatus = text
+    }
+
+    override fun materialize(spatial: Spatial) { /* no material system in tests */ }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/GlowChannelGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/GlowChannelGateTest.kt
@@ -136,6 +136,14 @@ class GlowChannelGateTest {
         game.onStart(FakeGameContext())
         val context = game.channelsForTest!!
 
+        try {
+            breatheThenRest(game, context)
+        } finally {
+            game.onStop() // idempotent - cleans up when an assertion fails mid-gate
+        }
+    }
+
+    private fun breatheThenRest(game: CheckersGame, context: SceneChannels) {
         // Select the opening piece and park the pointer on its destination.
         game.clickSquareForTest(sq(2, 0))
         game.forcedHoverForTest = sq(3, 1)
@@ -165,7 +173,6 @@ class GlowChannelGateTest {
         game.update(0.1, GameInput.EMPTY)
         game.update(0.1, GameInput.EMPTY)
         assertEquals("and it stays at rest", atRest, ColorRGBA(markerAt(game, sq(3, 1)).getDefaultColor()))
-        game.onStop()
     }
 
     /** The highlight marker shown on [square], found by its placement. */

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/GlowChannelGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/GlowChannelGateTest.kt
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.ardor3d.compose.SceneChannels
+import com.ardor3d.compose.SceneComposition
+import com.ardor3d.editor.play.GameInput
+import com.ardor3d.math.ColorRGBA
+import com.ardor3d.math.type.ReadOnlyColorRGBA
+import com.ardor3d.scenegraph.Node
+import com.ardor3d.scenegraph.Spatial
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The param-channel gate: a non-transform value (highlight glow) meets composition under the
+ * same ordering discipline as the transform track. The marker's shown color is derived by the
+ * sampler from a composition-owned base times a channel-owned intensity, so the adversarial
+ * ordering is: recompose the owning marker (a kind change rewrites the base) while a pulse is
+ * mid-flight - the binding must survive and the in-flight intensity must not be stomped; the
+ * new base simply meets the old intensity. Disposal mid-pulse retires the param slot and kills
+ * the writer by name, and the real game's hover pulse breathes through exactly this mechanism.
+ */
+class GlowChannelGateTest {
+
+    private fun sq(row: Int, col: Int) = Square(row, col)
+
+    private class Harness(initial: Board) : AutoCloseable {
+        val root = Node("Checkers")
+        val channels = SceneChannels(transformCapacity = 32, paramCapacity = 48)
+        var board by mutableStateOf(initial)
+        var highlights by mutableStateOf<Map<Square, HighlightKind>>(emptyMap())
+
+        private val composition = SceneComposition(root)
+        private var frames = 0L
+
+        init {
+            composition.setContent {
+                BoardScene(channels, board = { board }, highlights = { highlights })
+            }
+        }
+
+        fun frame() {
+            composition.frame(++frames)
+            channels.sample()
+        }
+
+        fun marker(): Spatial = (root.getChild("Highlights") as Node).getChild(0)
+
+        override fun close() = composition.close()
+    }
+
+    private fun scaled(base: ReadOnlyColorRGBA, intensity: Float) =
+        ColorRGBA(base.red * intensity, base.green * intensity, base.blue * intensity, base.alpha)
+
+    @Test
+    fun kindRecompositionMidPulseKeepsTheBindingAndTheIntensity() {
+        Harness(Board.initial()).use { h ->
+            val square = sq(3, 3)
+            h.highlights = mapOf(square to HighlightKind.MOVE)
+            h.frame()
+            val marker = h.marker()
+            val handle = h.channels.paramHandle(square)
+            val moveBase = ColorRGBA(marker.getDefaultColor()) // intensity is at rest = the base
+
+            // A pulse is mid-flight: intensity 0.7 has landed.
+            h.channels.writeParam(handle, 0.7f)
+            h.frame()
+            assertEquals(scaled(moveBase, 0.7f), ColorRGBA(marker.getDefaultColor()))
+
+            // Adversarial ordering: the owning marker recomposes mid-pulse (its kind changes,
+            // rewriting the composition-owned base).
+            h.highlights = mapOf(square to HighlightKind.MOVE_HOVER)
+            h.frame()
+
+            assertSame("the marker survived its recomposition", marker, h.marker())
+            assertEquals("the binding survived", handle, h.channels.paramHandle(square))
+            assertEquals("still exactly one param bound", 1, h.channels.liveParamCount)
+            val shown = ColorRGBA(marker.getDefaultColor())
+            assertNotEquals("the base did change", scaled(moveBase, 0.7f), shown)
+            // Pin the unstomped intensity exactly: raising it to rest reveals the pure new
+            // base, and the mid-pulse color must have been that base times the old 0.7.
+            h.channels.writeParam(handle, GLOW_REST)
+            h.frame()
+            val hoverBase = ColorRGBA(marker.getDefaultColor())
+            assertEquals(scaled(hoverBase, 0.7f), shown)
+
+            // The writer is still live through it all.
+            h.channels.writeParam(handle, 0.5f)
+            h.frame()
+            assertEquals(scaled(hoverBase, 0.5f), ColorRGBA(marker.getDefaultColor()))
+        }
+    }
+
+    @Test
+    fun markerDisposalMidPulseRetiresTheParamAndKillsTheWriter() {
+        Harness(Board.initial()).use { h ->
+            val square = sq(3, 3)
+            h.highlights = mapOf(square to HighlightKind.MOVE)
+            h.frame()
+            val handle = h.channels.paramHandle(square)
+            h.channels.writeParam(handle, 0.8f) // mid-pulse
+            h.frame()
+            assertEquals(1, h.channels.liveParamCount)
+
+            h.highlights = emptyMap() // the marker leaves the composition mid-pulse
+            h.frame()
+
+            assertEquals("the param slot retired exactly once", 0, h.channels.liveParamCount)
+            assertTrue(!h.channels.hasParam(square))
+            val e = assertThrows(IllegalStateException::class.java) {
+                h.channels.writeParam(handle, 1f)
+            }
+            assertTrue("the writer died by name: ${e.message}", e.message!!.contains("stale"))
+        }
+    }
+
+    @Test
+    fun theDestinationUnderThePointerBreathesAndComesToRestWhenLeft() {
+        val game = CheckersGame()
+        game.onStart(FakeGameContext())
+        val context = game.channelsForTest!!
+
+        // Select the opening piece and park the pointer on its destination.
+        game.clickSquareForTest(sq(2, 0))
+        game.forcedHoverForTest = sq(3, 1)
+        game.update(0.1, GameInput.EMPTY)
+        assertEquals(HighlightKind.MOVE_HOVER, game.highlightForTest(sq(3, 1)))
+        assertTrue("the pulse bound its marker", context.hasParam(sq(3, 1)))
+
+        // The marker breathes: its shown color changes from frame to frame.
+        val marker = markerAt(game, sq(3, 1))
+        val first = ColorRGBA(marker.getDefaultColor())
+        game.update(0.1, GameInput.EMPTY)
+        val second = ColorRGBA(marker.getDefaultColor())
+        game.update(0.1, GameInput.EMPTY)
+        val third = ColorRGBA(marker.getDefaultColor())
+        assertNotEquals("the glow is alive", first, second)
+        assertNotEquals(second, third)
+        assertTrue("the pulse dims, never brightens past the base", third.red <= first.red + 1e-6f)
+
+        // Leaving the destination returns the marker to rest and stops the pulse.
+        game.forcedHoverForTest = null
+        game.update(0.1, GameInput.EMPTY)
+        assertEquals(
+            "the marker downgraded to a plain destination",
+            HighlightKind.MOVE, game.highlightForTest(sq(3, 1))
+        )
+        val atRest = ColorRGBA(markerAt(game, sq(3, 1)).getDefaultColor())
+        game.update(0.1, GameInput.EMPTY)
+        game.update(0.1, GameInput.EMPTY)
+        assertEquals("and it stays at rest", atRest, ColorRGBA(markerAt(game, sq(3, 1)).getDefaultColor()))
+        game.onStop()
+    }
+
+    /** The highlight marker shown on [square], found by its placement. */
+    private fun markerAt(game: CheckersGame, square: Square): Spatial {
+        val root = game.pieceNodeForTest(sq(2, 0))?.parent?.parent
+            ?: game.pieceNodeForTest(sq(3, 1))?.parent?.parent
+            ?: error("no board root reachable")
+        val markers = (root as Node).getChild("Highlights") as Node
+        return markers.children.first {
+            Math.abs(it.translation.x - (square.col - 3.5)) < 1e-6 &&
+                Math.abs(it.translation.z - (square.row - 3.5)) < 1e-6
+        }
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionAllocationGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionAllocationGateTest.kt
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import com.ardor3d.compose.allocationAccounting
+import com.ardor3d.editor.play.GameInput
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The allocation gate for continuous motion: a steady-state slide frame - channel write,
+ * composition frame, sampler apply, through the real game loop on the thread that drives it -
+ * allocates exactly nothing on the Java heap. Not "little": zero bytes, summed over hundreds
+ * of measured frames.
+ *
+ * Two kings shuttle between corners so slides repeat indefinitely without captures (and
+ * without ever creating a mandatory jump). Event-rate frames are excluded by design: the
+ * update that lands beginMove's state writes and the update that finalizes the move both
+ * recompose, and that traffic is priced elsewhere - this gate is the price of *motion*.
+ *
+ * The shuttle runs as two game sessions, each within the 80-ply draw counter (19 cycles x 4
+ * plies = 76): the first exists purely to warm - measured empirically, the JIT's one-time
+ * tier-transition artifacts land around cycle 11-12 and are quiet afterwards - and the second
+ * re-warms its fresh per-session objects briefly, then measures.
+ */
+class MotionAllocationGateTest {
+
+    private fun sq(row: Int, col: Int) = Square(row, col)
+
+    @Test
+    fun aSteadyStateMotionFrameAllocatesExactlyNothing() {
+        val threads = allocationAccounting()
+        val self = Thread.currentThread().id
+
+        // One slide; returns the bytes allocated across its strictly-interior frames.
+        // Timing: ANIM_DURATION 0.22s at 0.02s frames = the event frame, nine interior
+        // frames (elapsed 0.04..0.20), then the finalize frame(s).
+        fun slide(game: CheckersGame, from: Square, to: Square): Long {
+            game.clickSquareForTest(from)
+            game.clickSquareForTest(to)
+            check(game.isAnimatingForTest) { "no slide began for $from -> $to" }
+            game.update(FRAME, GameInput.EMPTY) // event frame: beginMove's writes land
+
+            val before = threads.getThreadAllocatedBytes(self)
+            repeat(INTERIOR_FRAMES) { game.update(FRAME, GameInput.EMPTY) }
+            val delta = threads.getThreadAllocatedBytes(self) - before
+
+            check(game.isAnimatingForTest) { "measured frames must all be mid-slide" }
+            while (game.isAnimatingForTest) game.update(FRAME, GameInput.EMPTY) // land (event)
+            return delta
+        }
+
+        fun cycle(game: CheckersGame): Long {
+            var bytes = 0L
+            bytes += slide(game, sq(0, 0), sq(1, 1))
+            bytes += slide(game, sq(7, 7), sq(6, 6))
+            bytes += slide(game, sq(1, 1), sq(0, 0))
+            bytes += slide(game, sq(6, 6), sq(7, 7))
+            return bytes
+        }
+
+        fun startSession(): CheckersGame {
+            val game = CheckersGame()
+            game.initialBoardForTest = Board.of(
+                PieceColor.RED,
+                mapOf(
+                    sq(0, 0) to Piece(PieceColor.RED, king = true),
+                    sq(7, 7) to Piece(PieceColor.BLACK, king = true)
+                )
+            )
+            game.onStart(FakeGameContext())
+            return game
+        }
+
+        // Session one: pure warmup, discarded.
+        val warmup = startSession()
+        repeat(SESSION_CYCLES) { cycle(warmup) }
+        warmup.onStop()
+
+        // Session two: fresh per-session objects settle over a short re-warm, then the gate.
+        val game = startSession()
+        repeat(REWARM_CYCLES) { cycle(game) }
+        var total = 0L
+        repeat(MEASURED_CYCLES) { total += cycle(game) }
+
+        assertEquals(
+            "a motion frame must allocate exactly nothing " +
+                "(${MEASURED_CYCLES * 4 * INTERIOR_FRAMES} frames measured)",
+            0L, total
+        )
+        assertTrue("the shuttle actually played", game.boardForTest.pieceAt(sq(0, 0)) != null)
+        game.onStop()
+    }
+
+    private companion object {
+        const val FRAME = 0.02
+        const val INTERIOR_FRAMES = 9
+        const val SESSION_CYCLES = 19
+        const val REWARM_CYCLES = 4
+        const val MEASURED_CYCLES = 6
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionAllocationGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionAllocationGateTest.kt
@@ -83,22 +83,28 @@ class MotionAllocationGateTest {
 
         // Session one: pure warmup, discarded.
         val warmup = startSession()
-        repeat(SESSION_CYCLES) { cycle(warmup) }
-        warmup.onStop()
+        try {
+            repeat(SESSION_CYCLES) { cycle(warmup) }
+        } finally {
+            warmup.onStop()
+        }
 
         // Session two: fresh per-session objects settle over a short re-warm, then the gate.
         val game = startSession()
-        repeat(REWARM_CYCLES) { cycle(game) }
-        var total = 0L
-        repeat(MEASURED_CYCLES) { total += cycle(game) }
+        try {
+            repeat(REWARM_CYCLES) { cycle(game) }
+            var total = 0L
+            repeat(MEASURED_CYCLES) { total += cycle(game) }
 
-        assertEquals(
-            "a motion frame must allocate exactly nothing " +
-                "(${MEASURED_CYCLES * 4 * INTERIOR_FRAMES} frames measured)",
-            0L, total
-        )
-        assertTrue("the shuttle actually played", game.boardForTest.pieceAt(sq(0, 0)) != null)
-        game.onStop()
+            assertEquals(
+                "a motion frame must allocate exactly nothing " +
+                    "(${MEASURED_CYCLES * 4 * INTERIOR_FRAMES} frames measured)",
+                0L, total
+            )
+            assertTrue("the shuttle actually played", game.boardForTest.pieceAt(sq(0, 0)) != null)
+        } finally {
+            game.onStop()
+        }
     }
 
     private companion object {

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionEscapeCanaryTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionEscapeCanaryTest.kt
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import androidx.compose.runtime.ComposeNode
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
+import com.ardor3d.compose.CountingApplier
+import com.ardor3d.compose.SceneChannels
+import com.ardor3d.compose.SceneComposition
+import com.ardor3d.compose.SpatialApplier
+import com.ardor3d.compose.rememberTransformChannel
+import com.ardor3d.scenegraph.Node
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The instrument canary for [SlideSilenceGateTest]: motion wired the forbidden way - a
+ * continuous value read by composition and re-fed every frame, the animateFloatAsState shape -
+ * must turn every silence instrument red. The piece even has a proper channel binding; the
+ * writer just ignores it and pushes the value through snapshot state instead.
+ *
+ * This test is permanent. It proves the gate's green means "the instruments watched and saw
+ * nothing," not "the instruments cannot see" - delete it and the silence gate becomes theater.
+ */
+class MotionEscapeCanaryTest {
+
+    @Test
+    fun perFrameSnapshotMotionTurnsEveryInstrumentRed() {
+        val channels = SceneChannels(transformCapacity = 4, paramCapacity = 4)
+        val root = Node("root")
+        val applier = CountingApplier(root)
+        SceneComposition(applier).use { scene ->
+            var t by mutableStateOf(0.0)
+            var syncs = 0
+            scene.setContent {
+                val node = remember { Node("piece") }
+                rememberTransformChannel(channels, "piece", node) // bound - and bypassed
+                ComposeNode<Node, SpatialApplier>(
+                    factory = { node },
+                    update = {
+                        // Forbidden: the continuous value flows through composition.
+                        set(t) { setTranslation(it, 0.11, 0.0) }
+                    }
+                )
+                SideEffect { syncs++ }
+            }
+            val node = root.getChild(0) as Node
+            var clock = 0L
+            scene.frame(++clock) // settle the initial composition
+            val syncsBefore = syncs
+            val framesSentBefore = scene.framesSentForTest
+            applier.resetCounts()
+
+            val frames = 5
+            repeat(frames) { i ->
+                t = (i + 1) * 0.1
+                // The write becomes an invalidation and the runtime queues for the next frame:
+                // the clock has an awaiter before the frame is even sent.
+                Snapshot.sendApplyNotifications()
+                assertTrue("the frame clock gained an awaiter", scene.hasFrameAwaitersForTest)
+                scene.frame(++clock)
+            }
+
+            assertEquals("one recomposition per motion frame", syncsBefore + frames, syncs)
+            assertEquals("every frame was sent through the clock", framesSentBefore + frames, scene.framesSentForTest)
+            assertTrue("the applier was dragged into the loop", applier.operations > 0)
+            assertEquals("the forbidden wiring does move the piece", 0.5, node.translation.x, 1e-9)
+
+            // And the runtime observes the continuous value - both the write and the read.
+            var reads = 0
+            var writes = 0
+            Snapshot.observe(readObserver = { reads++ }, writeObserver = { writes++ }) {
+                t = 0.6
+                scene.frame(++clock)
+            }
+            assertTrue("the runtime observed snapshot writes", writes > 0)
+            assertTrue("the runtime observed snapshot reads", reads > 0)
+        }
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionStructureOrderingGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionStructureOrderingGateTest.kt
@@ -277,21 +277,25 @@ class MotionStructureOrderingGateTest {
     @Test
     fun disposingTheCompositionWithALiveWriterRetiresEverythingOnceAndKillsTheWriter() {
         val h = Harness(twoPieceBoard())
-        h.highlights = mapOf(sq(3, 3) to HighlightKind.MOVE)
-        h.frame()
-        val handle = h.channels.transformHandle(0)
-        h.channels.writeTranslation(handle, -1.25, 0.11, -1.25) // slide in flight
-        assertEquals(2, h.channels.liveTransformCount)
-        assertEquals(1, h.channels.liveParamCount)
+        try {
+            h.highlights = mapOf(sq(3, 3) to HighlightKind.MOVE)
+            h.frame()
+            val handle = h.channels.transformHandle(0)
+            h.channels.writeTranslation(handle, -1.25, 0.11, -1.25) // slide in flight
+            assertEquals(2, h.channels.liveTransformCount)
+            assertEquals(1, h.channels.liveParamCount)
 
-        h.close() // the onStop-mid-slide shape
+            h.close() // the onStop-mid-slide shape
 
-        assertEquals("every transform retired", 0, h.channels.liveTransformCount)
-        assertEquals("every param retired", 0, h.channels.liveParamCount)
-        val e = assertThrows(IllegalStateException::class.java) {
-            h.channels.writeTranslation(handle, 9.0, 9.0, 9.0)
+            assertEquals("every transform retired", 0, h.channels.liveTransformCount)
+            assertEquals("every param retired", 0, h.channels.liveParamCount)
+            val e = assertThrows(IllegalStateException::class.java) {
+                h.channels.writeTranslation(handle, 9.0, 9.0, 9.0)
+            }
+            assertTrue("the writer died by name: ${e.message}", e.message!!.contains("stale"))
+        } finally {
+            h.close() // idempotent - cleans up if an assertion failed before the act above
         }
-        assertTrue("the writer died by name: ${e.message}", e.message!!.contains("stale"))
     }
 
     @Test
@@ -299,34 +303,36 @@ class MotionStructureOrderingGateTest {
         val channels = SceneChannels(transformCapacity = 32, paramCapacity = 48)
         val root = Node("Checkers")
         val composition = SceneComposition(root)
-        var board by mutableStateOf(twoPieceBoard())
-        var explode by mutableStateOf(false)
-        composition.setContent {
-            BoardScene(channels, board = { board }, highlights = { emptyMap() })
-            if (explode) error("recomposition fails after the new piece bound")
-        }
-        val before = channels.liveTransformCount
-        assertEquals(2, before)
-        val pieces = root.getChild("Pieces") as Node
+        try {
+            var board by mutableStateOf(twoPieceBoard())
+            var explode by mutableStateOf(false)
+            composition.setContent {
+                BoardScene(channels, board = { board }, highlights = { emptyMap() })
+                if (explode) error("recomposition fails after the new piece bound")
+            }
+            val before = channels.liveTransformCount
+            assertEquals(2, before)
+            val pieces = root.getChild("Pieces") as Node
 
-        // One frame both adds a piece (a new binding is created during recomposition) and
-        // fails the composition: the new binding must be released through onAbandoned.
-        board = Board.of(
-            PieceColor.RED,
-            mapOf(
-                sq(2, 2) to Piece(PieceColor.RED),
-                sq(5, 5) to Piece(PieceColor.BLACK),
-                sq(1, 1) to Piece(PieceColor.RED)
+            // One frame both adds a piece (a new binding is created during recomposition) and
+            // fails the composition: the new binding must be released through onAbandoned.
+            board = Board.of(
+                PieceColor.RED,
+                mapOf(
+                    sq(2, 2) to Piece(PieceColor.RED),
+                    sq(5, 5) to Piece(PieceColor.BLACK),
+                    sq(1, 1) to Piece(PieceColor.RED)
+                )
             )
-        )
-        explode = true
-        assertThrows(IllegalStateException::class.java) { composition.frame(1L) }
+            explode = true
+            assertThrows(IllegalStateException::class.java) { composition.frame(1L) }
 
-        assertEquals("the abandoned binding leaked nothing", before, channels.liveTransformCount)
-        assertEquals("no structural change from the failed frame", 2, pieces.numberOfChildren)
-
+            assertEquals("the abandoned binding leaked nothing", before, channels.liveTransformCount)
+            assertEquals("no structural change from the failed frame", 2, pieces.numberOfChildren)
+        } finally {
+            composition.close()
+        }
         // Disposal after the failure still releases the survivors exactly once.
-        composition.close()
         assertEquals(0, channels.liveTransformCount)
     }
 }

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionStructureOrderingGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/MotionStructureOrderingGateTest.kt
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.ardor3d.compose.CountingApplier
+import com.ardor3d.compose.SceneChannels
+import com.ardor3d.compose.SceneComposition
+import com.ardor3d.compose.SceneSpatial
+import com.ardor3d.compose.TransformChannel
+import com.ardor3d.compose.rememberTransformChannel
+import com.ardor3d.scenegraph.Node
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The ordering gate: structure and motion must not stomp each other, proven under adversarial
+ * interleavings the real game never produces on purpose. A slide is in flight - its writer
+ * holding a channel handle, values landing every frame - while recomposition restructures
+ * around it, over it, and out from under it:
+ *
+ *  1. an unrelated subtree recomposes: nothing of the mover is touched;
+ *  2. the mover's *own* subtree recomposes: the binding survives and the in-flight value is
+ *     not snapped to the model square (there is no snap left to fire);
+ *  3. the mover is disposed mid-slide (a capture): its slot retires exactly once and every
+ *     later write through the straggler handle throws by name;
+ *  4. kinging at landing: a composition-owned change (the crown) lands adjacent to the
+ *     channel-owned transform, cleanly;
+ *  5. keyed replacement mid-slide: the old binding is forgotten and the new one remembered
+ *     within one recomposition, with no index aliasing - driven through the scene idiom
+ *     directly, because board piece ids are positional and stable by design: the real game
+ *     structurally cannot re-key a live piece, and this gate exists to hold the *mechanism*
+ *     to a rule the game never tests;
+ *  6. the whole composition is disposed with the writer live: everything retires exactly
+ *     once, the writer dies loudly;
+ *  7. composition fails *after* a binding was made in that same composition: onAbandoned
+ *     releases it - no leak.
+ */
+class MotionStructureOrderingGateTest {
+
+    private fun sq(row: Int, col: Int) = Square(row, col)
+
+    /** Two-piece board: RED man at (2,2) is id 0, BLACK man at (5,5) is id 1 (board order). */
+    private fun twoPieceBoard() = Board.of(
+        PieceColor.RED,
+        mapOf(sq(2, 2) to Piece(PieceColor.RED), sq(5, 5) to Piece(PieceColor.BLACK))
+    )
+
+    private class Harness(initial: Board) : AutoCloseable {
+        val root = Node("Checkers")
+        val applier = CountingApplier(root)
+        val channels = SceneChannels(transformCapacity = 32, paramCapacity = 48)
+        var board by mutableStateOf(initial)
+        var highlights by mutableStateOf<Map<Square, HighlightKind>>(emptyMap())
+
+        var syncs = 0
+            private set
+
+        val composition = SceneComposition(applier)
+        private var frames = 0L
+
+        init {
+            composition.setContent {
+                BoardScene(channels, board = { board }, highlights = { highlights }, onSync = { syncs++ })
+            }
+        }
+
+        fun frame() {
+            composition.frame(++frames)
+            channels.sample()
+        }
+
+        override fun close() = composition.close()
+    }
+
+    @Test
+    fun unrelatedSubtreeRecompositionTouchesNothingOfTheMover() {
+        Harness(twoPieceBoard()).use { h ->
+            val mover = pieceNodeAt(h.root, sq(2, 2))!!
+            val handle = h.channels.transformHandle(0)
+
+            // Slide in flight: a mid-slide value has landed.
+            h.channels.writeTranslation(handle, -1.25, 0.11, -1.25)
+            h.frame()
+            val syncsBefore = h.syncs
+            h.applier.resetCounts()
+
+            // An unrelated subtree recomposes: a highlight marker appears.
+            h.highlights = mapOf(sq(4, 0) to HighlightKind.MOVE)
+            h.frame()
+
+            assertEquals("only the highlights subtree recomposed", syncsBefore + 1, h.syncs)
+            // One insertion arrives through both insert hooks (top-down and bottom-up), so a
+            // single new marker is exactly two structural ops - anything more touched the mover.
+            assertEquals("structural traffic is the marker alone", 2, h.applier.structuralOps)
+            assertSame("the mover keeps its node", mover, pieceNodeAt(h.root, sq(2, 2)))
+            assertEquals("the in-flight value is untouched", -1.25, mover.translation.x, 1e-6)
+            val channelValue = h.channels.transformsForTest.get(0, handle).toDouble()
+            assertEquals("the channel still holds the written value", -1.25, channelValue, 1e-6)
+
+            // And the writer is still live.
+            h.channels.writeTranslation(handle, -1.0, 0.11, -1.0)
+            h.frame()
+            assertEquals(-1.0, mover.translation.x, 1e-6)
+        }
+    }
+
+    @Test
+    fun ownSubtreeRecompositionMidSlideKeepsTheBindingAndTheValue() {
+        Harness(twoPieceBoard()).use { h ->
+            val mover = pieceNodeAt(h.root, sq(2, 2))!!
+            val handle = h.channels.transformHandle(0)
+            val midSlide = worldPositionOf(sq(2, 2)).lerpLocal(worldPositionOf(sq(3, 3)), 0.4)
+
+            h.channels.writeTranslation(handle, midSlide.x, midSlide.y, midSlide.z)
+            h.frame()
+
+            // Adversarial ordering: the model applies the move while the slide is mid-flight,
+            // recomposing the mover's own subtree (its square-keyed metadata changes).
+            h.board = h.board.apply(h.board.legalMovesFrom(sq(2, 2)).first { it.to == sq(3, 3) })
+            h.frame()
+
+            assertSame("the node survived its own recomposition", mover, pieceNodeAt(h.root, sq(3, 3)))
+            assertEquals("the binding survived", handle, h.channels.transformHandle(0))
+            assertEquals(
+                "the in-flight value was not snapped to the destination",
+                midSlide.x, mover.translation.x, 1e-6
+            )
+
+            // The slide lands afterwards, through the same binding.
+            val end = worldPositionOf(sq(3, 3))
+            h.channels.writeTranslation(handle, end.x, end.y, end.z)
+            h.frame()
+            assertEquals(end.x, mover.translation.x, 1e-6)
+            assertEquals(end.z, mover.translation.z, 1e-6)
+        }
+    }
+
+    @Test
+    fun captureDisposingTheMoverMidSlideRetiresOnceAndLaterWritesFailLoudly() {
+        Harness(twoPieceBoard()).use { h ->
+            val mover = pieceNodeAt(h.root, sq(5, 5))!!
+            val handle = h.channels.transformHandle(1)
+            assertEquals(2, h.channels.liveTransformCount)
+
+            // Slide in flight for the black piece...
+            h.channels.writeTranslation(handle, 1.2, 0.11, 1.2)
+            h.frame()
+
+            // ...when a capture removes it from the board. Its subtree leaves the composition.
+            h.board = Board.of(PieceColor.RED, mapOf(sq(2, 2) to Piece(PieceColor.RED)))
+            h.frame()
+
+            assertEquals("the slot retired exactly once", 1, h.channels.liveTransformCount)
+            assertNull("the node left the scene", mover.parent)
+            assertTrue("its registry entry is gone", !h.channels.hasTransform(1))
+
+            val first = assertThrows(IllegalStateException::class.java) {
+                h.channels.writeTranslation(handle, 9.0, 9.0, 9.0)
+            }
+            assertTrue("the failure names staleness: ${first.message}", first.message!!.contains("stale"))
+            // Exactly once: the second write dies the same way, not by corrupting a free list.
+            assertThrows(IllegalStateException::class.java) {
+                h.channels.writeTranslation(handle, 9.0, 9.0, 9.0)
+            }
+            assertEquals(1, h.channels.liveTransformCount)
+        }
+    }
+
+    @Test
+    fun kingingAtLandingAppliesTheCrownWithoutTouchingTheLandedTransform() {
+        // RED man one step from crowning; the far BLACK man keeps the game legal.
+        val board = Board.of(
+            PieceColor.RED,
+            mapOf(sq(6, 2) to Piece(PieceColor.RED), sq(0, 0) to Piece(PieceColor.BLACK))
+        )
+        Harness(board).use { h ->
+            val moverId = h.board.idAt(sq(6, 2))
+            val mover = pieceNodeAt(h.root, sq(6, 2))!!
+            val handle = h.channels.transformHandle(moverId)
+            assertEquals("a man is just its disk", 1, mover.numberOfChildren)
+
+            // The slide runs to its endpoint...
+            val end = worldPositionOf(sq(7, 3))
+            h.channels.writeTranslation(handle, end.x, end.y, end.z)
+            h.frame()
+
+            // ...and the landing applies the model: the crown is composition-owned structure,
+            // adjacent to the channel-owned transform.
+            h.board = h.board.apply(h.board.legalMovesFrom(sq(6, 2)).first { it.to == sq(7, 3) })
+            h.frame()
+
+            assertSame("crowning keeps the node", mover, pieceNodeAt(h.root, sq(7, 3)))
+            assertEquals("and adds the crown", 2, mover.numberOfChildren)
+            assertEquals(true, mover.getProperty(PROP_KING, false))
+            assertEquals("the landed transform is exactly the slide's endpoint", end.x, mover.translation.x, 1e-6)
+            assertEquals(end.z, mover.translation.z, 1e-6)
+            assertEquals("the binding survived the crowning", handle, h.channels.transformHandle(moverId))
+        }
+    }
+
+    @Test
+    fun keyedReplacementMidSlideHandsOverInOneRecompositionWithoutAliasing() {
+        // Driven through the scene idiom directly (see the class doc for why the board can't
+        // express this): a BoardPiece-shaped composable under an explicit key, replaced while
+        // its writer is live.
+        val channels = SceneChannels(transformCapacity = 4, paramCapacity = 4)
+        val root = Node("root")
+        SceneComposition(root).use { scene ->
+            var which by mutableStateOf(1)
+            var current: TransformChannel? = null
+            var currentNode: Node? = null
+            scene.setContent {
+                key(which) {
+                    val node = remember {
+                        Node("piece_$which").apply { setTranslation(1.0 * which, 0.0, 0.0) }
+                    }
+                    currentNode = node
+                    current = rememberTransformChannel(channels, "piece", node)
+                    SceneSpatial(factory = { node })
+                }
+            }
+            val old = current!!
+            val oldNode = currentNode!!
+            var t = 0L
+
+            // Writer live: a mid-slide value is in the old binding's slot.
+            old.writeTranslation(0.4, 0.0, 0.0)
+            scene.frame(++t)
+            channels.sample()
+            assertEquals(0.4, oldNode.translation.x, 1e-6)
+
+            which = 2 // the replacement: forgotten and remembered within this one frame
+            scene.frame(++t)
+            channels.sample()
+            val replacement = current!!
+            val newNode = currentNode!!
+
+            assertTrue("a new binding", replacement !== old)
+            assertNotEquals("a new handle - no aliasing", old.handle, replacement.handle)
+            assertEquals("exactly one live binding", 1, channels.liveTransformCount)
+            assertEquals("the registry follows the replacement", replacement.handle, channels.transformHandle("piece"))
+            assertThrows("the straggler writer is dead", IllegalStateException::class.java) {
+                old.writeTranslation(0.6, 0.0, 0.0)
+            }
+            assertEquals(
+                "the new tenant's seed is its own spawn, not the old slide's leftovers",
+                2.0, newNode.translation.x, 1e-6
+            )
+
+            // And the new binding animates its own node.
+            replacement.writeTranslation(2.5, 0.0, 0.0)
+            scene.frame(++t)
+            channels.sample()
+            assertEquals(2.5, newNode.translation.x, 1e-6)
+            assertEquals("the old node is not written through the new slot", 0.4, oldNode.translation.x, 1e-6)
+        }
+    }
+
+    @Test
+    fun disposingTheCompositionWithALiveWriterRetiresEverythingOnceAndKillsTheWriter() {
+        val h = Harness(twoPieceBoard())
+        h.highlights = mapOf(sq(3, 3) to HighlightKind.MOVE)
+        h.frame()
+        val handle = h.channels.transformHandle(0)
+        h.channels.writeTranslation(handle, -1.25, 0.11, -1.25) // slide in flight
+        assertEquals(2, h.channels.liveTransformCount)
+        assertEquals(1, h.channels.liveParamCount)
+
+        h.close() // the onStop-mid-slide shape
+
+        assertEquals("every transform retired", 0, h.channels.liveTransformCount)
+        assertEquals("every param retired", 0, h.channels.liveParamCount)
+        val e = assertThrows(IllegalStateException::class.java) {
+            h.channels.writeTranslation(handle, 9.0, 9.0, 9.0)
+        }
+        assertTrue("the writer died by name: ${e.message}", e.message!!.contains("stale"))
+    }
+
+    @Test
+    fun compositionFailureAfterANewBindingReleasesItThroughOnAbandoned() {
+        val channels = SceneChannels(transformCapacity = 32, paramCapacity = 48)
+        val root = Node("Checkers")
+        val composition = SceneComposition(root)
+        var board by mutableStateOf(twoPieceBoard())
+        var explode by mutableStateOf(false)
+        composition.setContent {
+            BoardScene(channels, board = { board }, highlights = { emptyMap() })
+            if (explode) error("recomposition fails after the new piece bound")
+        }
+        val before = channels.liveTransformCount
+        assertEquals(2, before)
+        val pieces = root.getChild("Pieces") as Node
+
+        // One frame both adds a piece (a new binding is created during recomposition) and
+        // fails the composition: the new binding must be released through onAbandoned.
+        board = Board.of(
+            PieceColor.RED,
+            mapOf(
+                sq(2, 2) to Piece(PieceColor.RED),
+                sq(5, 5) to Piece(PieceColor.BLACK),
+                sq(1, 1) to Piece(PieceColor.RED)
+            )
+        )
+        explode = true
+        assertThrows(IllegalStateException::class.java) { composition.frame(1L) }
+
+        assertEquals("the abandoned binding leaked nothing", before, channels.liveTransformCount)
+        assertEquals("no structural change from the failed frame", 2, pieces.numberOfChildren)
+
+        // Disposal after the failure still releases the survivors exactly once.
+        composition.close()
+        assertEquals(0, channels.liveTransformCount)
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/SlideSilenceGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/SlideSilenceGateTest.kt
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2008-2026 Bird Dog Games, Inc.
+ *
+ * This file is part of Ardor3D.
+ *
+ * Ardor3D is free software: you can redistribute it and/or modify it
+ * under the terms of its license which may be found in the accompanying
+ * LICENSE file or at <https://git.io/fjRmv>.
+ */
+
+package com.ardor3d.editor.checkers
+
+import androidx.compose.runtime.snapshots.Snapshot
+import com.ardor3d.compose.CountingApplier
+import com.ardor3d.editor.play.GameInput
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The silence gate for continuous motion: while a piece slides, the composition runtime must
+ * not merely do little - it must be provably out of the loop, on every instrument at once:
+ *
+ *  - zero recompositions (the leaf-sync counter),
+ *  - zero applier traffic, structural *and* navigational,
+ *  - the frame clock gains no awaiters and [com.ardor3d.compose.SceneComposition.frame] sends
+ *    no frame - a global assertion over the host, not a per-subtree count,
+ *  - and a whole mid-slide update observed under [Snapshot.observe] records zero snapshot
+ *    reads and zero writes: the runtime never so much as *sees* a continuous value.
+ *
+ * The companion canary test drives the same scene with motion deliberately wired through
+ * snapshot state and asserts every one of these instruments fires - so a green here means the
+ * instruments watched and saw nothing, not that they cannot see.
+ */
+class SlideSilenceGateTest {
+
+    private fun sq(row: Int, col: Int) = Square(row, col)
+
+    @Test
+    fun theSlideIsInvisibleToTheCompositionRuntime() {
+        lateinit var applier: CountingApplier
+        val game = CheckersGame(applierFactory = { CountingApplier(it).also { a -> applier = a } })
+        game.onStart(FakeGameContext())
+
+        // Select and move: (2,0) has the single opening move to (3,1).
+        game.clickSquareForTest(sq(2, 0))
+        game.clickSquareForTest(sq(3, 1))
+        assertTrue(game.isAnimatingForTest)
+
+        // The first update applies the event-rate state beginMove wrote (the highlight clear);
+        // the slide's silence is gated strictly after it.
+        game.update(0.05, GameInput.EMPTY)
+        assertTrue(game.isAnimatingForTest)
+        val composition = game.compositionForTest!!
+        val syncsAtSlideStart = game.syncCountForTest
+        val framesSentAtSlideStart = composition.framesSentForTest
+        applier.resetCounts()
+
+        // Mid-slide frames. After every one: piece moving, nothing composed.
+        repeat(2) {
+            game.update(0.05, GameInput.EMPTY)
+            assertTrue("still sliding", game.isAnimatingForTest)
+            assertFalse("no awaiters on the frame clock", composition.hasFrameAwaitersForTest)
+        }
+        assertEquals("zero recompositions during the slide", syncsAtSlideStart, game.syncCountForTest)
+        assertEquals("zero applier operations (structural and navigation)", 0, applier.operations)
+        assertEquals("frame() sent no frame", framesSentAtSlideStart, composition.framesSentForTest)
+
+        // One whole mid-slide update under snapshot observation: the runtime never observes a
+        // continuous value - not as a read, not as a write.
+        var reads = 0
+        var writes = 0
+        Snapshot.observe(readObserver = { reads++ }, writeObserver = { writes++ }) {
+            game.update(0.05, GameInput.EMPTY)
+        }
+        assertTrue("the observed frame was still mid-slide", game.isAnimatingForTest)
+        assertEquals("zero snapshot reads in a motion frame", 0, reads)
+        assertEquals("zero snapshot writes in a motion frame", 0, writes)
+
+        // And the gate must not have starved the landing: finish the slide, the move applies.
+        while (game.isAnimatingForTest) game.update(0.05, GameInput.EMPTY)
+        assertTrue("the landing recomposed the board", game.syncCountForTest > syncsAtSlideStart)
+        assertEquals(Piece(PieceColor.RED), game.boardForTest.pieceAt(sq(3, 1)))
+        game.onStop()
+    }
+}

--- a/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/SlideSilenceGateTest.kt
+++ b/ardor3d-editor/src/test/kotlin/com/ardor3d/editor/checkers/SlideSilenceGateTest.kt
@@ -42,7 +42,14 @@ class SlideSilenceGateTest {
         lateinit var applier: CountingApplier
         val game = CheckersGame(applierFactory = { CountingApplier(it).also { a -> applier = a } })
         game.onStart(FakeGameContext())
+        try {
+            slideUnderInstruments(game, applier)
+        } finally {
+            game.onStop() // idempotent - cleans up when an assertion fails mid-gate
+        }
+    }
 
+    private fun slideUnderInstruments(game: CheckersGame, applier: CountingApplier) {
         // Select and move: (2,0) has the single opening move to (3,1).
         game.clickSquareForTest(sq(2, 0))
         game.clickSquareForTest(sq(3, 1))
@@ -82,6 +89,5 @@ class SlideSilenceGateTest {
         while (game.isAnimatingForTest) game.update(0.05, GameInput.EMPTY)
         assertTrue("the landing recomposed the board", game.syncCountForTest > syncsAtSlideStart)
         assertEquals(Piece(PieceColor.RED), game.boardForTest.pieceAt(sq(3, 1)))
-        game.onStop()
     }
 }


### PR DESCRIPTION
## What this does

The editor's composed scene layer gets a **channel mechanism** for frame-rate motion, and the checkers game mode graduates onto it. Composition owns *structure*; continuous values (a sliding piece's translation, a highlight's glow intensity) live in off-heap channel slots that game code writes by handle every frame and a sampler applies after the composition frame. Recomposition never sees a continuous value - and that is now a gated property, not a convention.

**The mechanism** (`com.ardor3d.compose`):
- `ChannelBlock` - fixed-stride SoA floats in a direct `FloatBuffer`, slots handed out as generation-tagged handles: any write/read/re-free through a freed handle throws by name, including after the slot index is recycled. A dirty bitset is the sampler's work queue; the whole per-frame surface is primitives only.
- `SceneChannels` - the per-scene rig: a transform block (translation + rotation) and a float-param block, target tables, a key→handle registry for event-rate lookup, and the sampler. Binding seeds every channel from the target's current state, so a recycled slot never leaks its previous tenant.
- `TransformChannel`/`ParamChannel` - `RememberObserver` bindings: the slot is allocated when the binding enters the composition and released exactly once when it leaves - through `onForgotten` *or* `onAbandoned` (a composition that throws after binding still releases). Keyed replacement hands over with no handle aliasing.

**The graduation** (checkers): `BoardScene` binds a channel per piece and per highlight marker. The move slide looks its handle up once by piece identity and writes the channel every frame - `beginMove` no longer re-queries the scene graph, and there is no translation snap left in recomposition to stomp a slide. A marker's shown color is derived by the sampler from a composition-owned base color times a channel-owned glow, and the destination under the pointer now breathes with a gentle pulse.

## How it's held to the rule

- **Silence gate:** a mid-slide frame runs with zero recompositions, zero applier operations (structural and navigational), a frame clock that gains no awaiters and sends no frame, and zero snapshot reads/writes under `Snapshot.observe`.
- **Canary (permanent):** the same motion wired the forbidden way - per-frame snapshot state - must turn every one of those instruments red, so a green gate can't mean blind instruments.
- **Allocation gate:** steady-state motion frames measure **exactly 0 bytes** on the driving thread (216 frames, king-shuttle harness, thread-allocation accounting; JIT warmup runs as a discarded first game session).
- **Ordering gate:** seven adversarial interleavings of structure vs. motion - unrelated recomposition mid-slide, the mover's own recomposition, capture-disposal mid-slide (slot retires once, stragglers die loudly), kinging at landing, keyed replacement with a live writer, disposal with a live writer, and composition failure after a fresh binding.
- **Glow gate:** the param channel under the same ordering discipline - a kind change mid-pulse rewrites the base but never the in-flight intensity.

Loud-failure paths were bite-verified red (generation-bump removal flips the staleness tests; the canary pins instrument sensitivity). 154 tests green in the editor module, 45 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a channel-driven scene update path for transforms and highlight/param effects.
  * Refactored checkers movement and glow pulsing to use persistent, lifecycle-safe channels.
* **Performance**
  * Reduced per-frame scene-graph work during animation and improved allocation behavior during continuous motion.
* **Tests**
  * Expanded automated coverage for channel binding lifecycles, recomposition ordering, disposal behavior, and allocation-free update sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->